### PR TITLE
feat(sort-by): add sortBy utility

### DIFF
--- a/.changeset/add-sort-by-utility.md
+++ b/.changeset/add-sort-by-utility.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `sortBy` utility for arrays with dot notation key support and numeric fast path

--- a/benchmarks/sortby.md
+++ b/benchmarks/sortby.md
@@ -1,0 +1,20 @@
+# sortBy
+
+[← Back to benchmarks](./README.md)
+
+---
+
+| Size | 1o1-utils | lodash | radash | native slice+sort | Fastest |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| n=100 | 8.3µs · 120.0K ops/s | 14.7µs · 67.8K ops/s | 6.4µs · 155.8K ops/s | 8.1µs · 123.7K ops/s | radash · 2.3× faster vs lodash |
+| n=10k | 1.10ms · 911 ops/s | 1.84ms · 544 ops/s | 648.2µs · 1.5K ops/s | 1.06ms · 941 ops/s | radash · 2.8× faster vs lodash |
+| n=100k | 14.60ms · 69 ops/s | 25.26ms · 40 ops/s | 7.62ms · 131 ops/s | 14.17ms · 71 ops/s | radash · 3.3× faster vs lodash |
+| n=1M | 145.5ms · 7 ops/s | 340.4ms · 3 ops/s | 74.72ms · 13 ops/s | 145.9ms · 7 ops/s | radash · 4.6× faster vs lodash |
+| n=10M | 1585.1ms · 1 ops/s | 6993.8ms · 0 ops/s | 944.4ms · 1 ops/s | 1595.4ms · 1 ops/s | radash · 7.4× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "sortBy — ops/s at n=1M items"
+  x-axis ["radash", "1o1-utils", "native slice+sort", "lodash"]
+  bar [13, 7, 7, 3]
+```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
 		"./pick": {
 			"import": "./dist/objects/pick/index.js",
 			"types": "./dist/objects/pick/index.d.ts"
+		},
+		"./sort-by": {
+			"import": "./dist/arrays/sort-by/index.js",
+			"types": "./dist/arrays/sort-by/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/arrays/sort-by/index.bench.ts
+++ b/src/arrays/sort-by/index.bench.ts
@@ -1,0 +1,26 @@
+import lodashSortBy from "lodash/sortBy.js";
+import { sort } from "radash";
+import { Bench } from "tinybench";
+import { getDatasets } from "../../benchmarks/helpers.js";
+import { sortBy } from "./index.js";
+
+const bench = new Bench({ name: "sortBy", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      sortBy({ array: data, key: "age" });
+    })
+    .add(`lodash (${name})`, () => {
+      lodashSortBy(data, "age");
+    })
+    .add(`radash (${name})`, () => {
+      sort(data, (u) => u.age);
+    })
+    .add(`native slice+sort (${name})`, () => {
+      data.slice().sort((a, b) => a.age - b.age);
+    });
+}
+
+export { bench };

--- a/src/arrays/sort-by/index.spec.ts
+++ b/src/arrays/sort-by/index.spec.ts
@@ -1,0 +1,147 @@
+import { expect } from "chai";
+import { sortBy } from "./index.js";
+
+describe("sortBy", () => {
+  it("should sort by a string key in ascending order", () => {
+    const result = sortBy({
+      array: [{ name: "Bob" }, { name: "Ana" }, { name: "Carlos" }],
+      key: "name",
+    });
+
+    expect(result).to.deep.equal([
+      { name: "Ana" },
+      { name: "Bob" },
+      { name: "Carlos" },
+    ]);
+  });
+
+  it("should sort by a numeric key in ascending order", () => {
+    const result = sortBy({
+      array: [{ age: 30 }, { age: 20 }, { age: 25 }],
+      key: "age",
+    });
+
+    expect(result).to.deep.equal([{ age: 20 }, { age: 25 }, { age: 30 }]);
+  });
+
+  it("should sort in descending order", () => {
+    const result = sortBy({
+      array: [{ age: 30 }, { age: 20 }, { age: 25 }],
+      key: "age",
+      order: "desc",
+    });
+
+    expect(result).to.deep.equal([{ age: 30 }, { age: 25 }, { age: 20 }]);
+  });
+
+  it("should return an empty array for an empty array", () => {
+    const result = sortBy({ array: [] as { id: number }[], key: "id" });
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should return a single-element array as is", () => {
+    const result = sortBy({ array: [{ id: 1 }], key: "id" });
+    expect(result).to.deep.equal([{ id: 1 }]);
+  });
+
+  it("should not mutate the original array", () => {
+    const original = [{ age: 30 }, { age: 10 }, { age: 20 }];
+    const result = sortBy({ array: original, key: "age" });
+
+    expect(result).to.not.equal(original);
+    expect(original).to.deep.equal([{ age: 30 }, { age: 10 }, { age: 20 }]);
+  });
+
+  it("should handle equal values stably", () => {
+    const result = sortBy({
+      array: [
+        { name: "Bob", id: 1 },
+        { name: "Ana", id: 2 },
+        { name: "Bob", id: 3 },
+      ],
+      key: "name",
+    });
+
+    expect(result).to.deep.equal([
+      { name: "Ana", id: 2 },
+      { name: "Bob", id: 1 },
+      { name: "Bob", id: 3 },
+    ]);
+  });
+
+  it("should handle undefined values in the key", () => {
+    const result = sortBy({
+      array: [
+        { name: "Bob", team: "backend" },
+        { name: "Ana", team: undefined },
+        { name: "Carlos", team: "frontend" },
+      ],
+      key: "team",
+    });
+
+    expect(result).to.have.length(3);
+    expect(result.map((r) => r.name)).to.include("Ana");
+  });
+
+  it("should sort by a nested key using dot notation", () => {
+    const result = sortBy({
+      array: [
+        { name: "Bob", address: { city: "São Paulo" } },
+        { name: "Ana", address: { city: "Curitiba" } },
+        { name: "Carlos", address: { city: "Rio" } },
+      ],
+      key: "address.city",
+    });
+
+    expect(result).to.deep.equal([
+      { name: "Ana", address: { city: "Curitiba" } },
+      { name: "Carlos", address: { city: "Rio" } },
+      { name: "Bob", address: { city: "São Paulo" } },
+    ]);
+  });
+
+  it("should sort by a deeply nested key using dot notation", () => {
+    const result = sortBy({
+      array: [
+        { id: 1, meta: { score: { value: 90 } } },
+        { id: 2, meta: { score: { value: 50 } } },
+        { id: 3, meta: { score: { value: 70 } } },
+      ],
+      key: "meta.score.value",
+      order: "desc",
+    });
+
+    expect(result).to.deep.equal([
+      { id: 1, meta: { score: { value: 90 } } },
+      { id: 3, meta: { score: { value: 70 } } },
+      { id: 2, meta: { score: { value: 50 } } },
+    ]);
+  });
+
+  it("should handle missing nested paths gracefully", () => {
+    const result = sortBy({
+      array: [
+        { name: "Bob", address: { city: "São Paulo" } },
+        { name: "Ana" },
+        { name: "Carlos", address: { city: "Curitiba" } },
+      ],
+      key: "address.city",
+    });
+
+    expect(result).to.have.length(3);
+  });
+
+  it("should throw an error if array is not an array", () => {
+    // @ts-expect-error
+    expect(() => sortBy({ array: "not-an-array", key: "id" })).to.throw(
+      "The 'array' parameter is not an array",
+    );
+  });
+
+  it("should throw an error if key is not provided", () => {
+    // @ts-expect-error
+    expect(() => sortBy({ array: [{ id: 1 }] })).to.throw(
+      "The 'key' parameter is required",
+    );
+  });
+});

--- a/src/arrays/sort-by/index.ts
+++ b/src/arrays/sort-by/index.ts
@@ -1,0 +1,59 @@
+import type { SortByParams } from "./types.js";
+
+function getByPath(obj: unknown, path: string): unknown {
+  let current: unknown = obj;
+  let start = 0;
+  let dot = path.indexOf(".");
+
+  while (dot !== -1) {
+    if (typeof current !== "object" || current === null) return undefined;
+    const seg = path.substring(start, dot);
+    current = (current as Record<string, unknown>)[seg];
+    start = dot + 1;
+    dot = path.indexOf(".", start);
+  }
+
+  if (typeof current !== "object" || current === null) return undefined;
+  return (current as Record<string, unknown>)[path.substring(start)];
+}
+
+function sortBy<T>({ array, key, order = "asc" }: SortByParams<T>): T[] {
+  if (!Array.isArray(array)) {
+    throw new Error("The 'array' parameter is not an array");
+  }
+
+  if (key === undefined || key === null) {
+    throw new Error("The 'key' parameter is required");
+  }
+
+  const sorted = array.slice();
+  const isDotted = typeof key === "string" && key.indexOf(".") !== -1;
+
+  const sample = sorted.length > 0
+    ? (isDotted ? getByPath(sorted[0], key as string) : sorted[0][key as keyof T])
+    : undefined;
+  const isNumeric = typeof sample === "number";
+
+  if (isNumeric && !isDotted) {
+    const k = key as keyof T;
+    if (order === "desc") {
+      sorted.sort((a, b) => (b[k] as number) - (a[k] as number));
+    } else {
+      sorted.sort((a, b) => (a[k] as number) - (b[k] as number));
+    }
+  } else {
+    const direction = order === "desc" ? -1 : 1;
+    sorted.sort((a, b) => {
+      const valA = (isDotted ? getByPath(a, key as string) : a[key as keyof T]) as string | number;
+      const valB = (isDotted ? getByPath(b, key as string) : b[key as keyof T]) as string | number;
+
+      if (valA < valB) return -1 * direction;
+      if (valA > valB) return 1 * direction;
+      return 0;
+    });
+  }
+
+  return sorted;
+}
+
+export { sortBy };

--- a/src/arrays/sort-by/index.ts
+++ b/src/arrays/sort-by/index.ts
@@ -29,9 +29,12 @@ function sortBy<T>({ array, key, order = "asc" }: SortByParams<T>): T[] {
   const sorted = array.slice();
   const isDotted = typeof key === "string" && key.indexOf(".") !== -1;
 
-  const sample = sorted.length > 0
-    ? (isDotted ? getByPath(sorted[0], key as string) : sorted[0][key as keyof T])
-    : undefined;
+  const sample =
+    sorted.length > 0
+      ? isDotted
+        ? getByPath(sorted[0], key as string)
+        : sorted[0][key as keyof T]
+      : undefined;
   const isNumeric = typeof sample === "number";
 
   if (isNumeric && !isDotted) {
@@ -44,8 +47,12 @@ function sortBy<T>({ array, key, order = "asc" }: SortByParams<T>): T[] {
   } else {
     const direction = order === "desc" ? -1 : 1;
     sorted.sort((a, b) => {
-      const valA = (isDotted ? getByPath(a, key as string) : a[key as keyof T]) as string | number;
-      const valB = (isDotted ? getByPath(b, key as string) : b[key as keyof T]) as string | number;
+      const valA = (
+        isDotted ? getByPath(a, key as string) : a[key as keyof T]
+      ) as string | number;
+      const valB = (
+        isDotted ? getByPath(b, key as string) : b[key as keyof T]
+      ) as string | number;
 
       if (valA < valB) return -1 * direction;
       if (valA > valB) return 1 * direction;

--- a/src/arrays/sort-by/types.ts
+++ b/src/arrays/sort-by/types.ts
@@ -1,0 +1,9 @@
+type SortByOrder = "asc" | "desc";
+
+interface SortByParams<T> {
+  array: T[];
+  key: keyof T | (string & {});
+  order?: SortByOrder;
+}
+
+export type { SortByOrder, SortByParams };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { arrayToHash } from "./arrays/array-to-hash/index.js";
 export { chunk } from "./arrays/chunk/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
+export { sortBy } from "./arrays/sort-by/index.js";
 export { unique } from "./arrays/unique/index.js";
 export { pick } from "./objects/pick/index.js";


### PR DESCRIPTION
## Summary

- Add `sortBy` utility that sorts arrays of objects by a given key with optional `order` (`asc`/`desc`)
- Support dot notation for nested keys (e.g., `"address.city"`, `"meta.score.value"`)
- Numeric fast path using subtraction instead of branching comparator — on par with native `slice().sort()` and ~2x faster than lodash

## Test plan

- [x] 13 unit tests covering: string/numeric keys, asc/desc order, empty arrays, immutability, stable sort, undefined values, dot notation (nested + deeply nested), missing paths, error cases
- [x] Biome check passes
- [x] TypeScript build compiles cleanly
- [x] Benchmark suite included (vs lodash, radash, native)

Closes #4