### PR TITLE
fix(release): add NPM_TOKEN to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,3 +51,4 @@ jobs:
           commit: "chore: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- The changesets publish step in `release.yml` was missing `NODE_AUTH_TOKEN`, so `pnpm changeset publish` couldn't authenticate with npm
- Added `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the env block

## Test plan
- [ ] Merge this PR, then merge PR #36 (version packages)
- [ ] Verify the Release workflow publishes 1.3.0 successfully
- [ ] Confirm with `npm view 1o1-utils version`