### PR TITLE
feat: add isEmpty, sleep, and retry utilities

### DIFF
--- a/.changeset/add-isEmpty-sleep-retry.md
+++ b/.changeset/add-isEmpty-sleep-retry.md
@@ -1,0 +1,9 @@
+---
+"1o1-utils": minor
+---
+
+Add isEmpty, sleep, and retry utilities
+
+- `isEmpty`: check if a value is empty (null, undefined, empty string, array, object, Map, Set)
+- `sleep`: async delay function with input validation
+- `retry`: retry async functions with configurable attempts, delay, and backoff (fixed or exponential)

--- a/benchmarks/is-empty.md
+++ b/benchmarks/is-empty.md
@@ -1,0 +1,22 @@
+# isEmpty
+
+[← Back to benchmarks](./README.md)
+
+Checks if a value is empty (null, undefined, empty string, empty array, empty object, empty Map/Set). Compared against `lodash.isEmpty` and `radash.isEmpty`.
+
+---
+
+| Size | 1o1-utils | lodash | radash | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| empty object | 41ns · 24.4M ops/s | 42ns · 23.8M ops/s | 83ns · 12.0M ops/s | 1o1-utils · on par vs lodash |
+| filled object | 41ns · 24.4M ops/s | 41ns · 24.4M ops/s | 83ns · 12.0M ops/s | lodash · on par vs lodash |
+| empty array | 41ns · 24.4M ops/s | 42ns · 23.8M ops/s | 83ns · 12.0M ops/s | 1o1-utils · on par vs lodash |
+| filled array | 41ns · 24.4M ops/s | 42ns · 23.8M ops/s | 958ns · 1.0M ops/s | 1o1-utils · on par vs lodash |
+| null | 41ns · 24.4M ops/s | 41ns · 24.4M ops/s | 41ns · 24.4M ops/s | radash · on par vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "isEmpty — ops/s at null items"
+  x-axis ["1o1-utils", "lodash", "radash"]
+  bar [24390249, 24390249, 24390249]
+```

--- a/benchmarks/retry.md
+++ b/benchmarks/retry.md
@@ -1,0 +1,20 @@
+# retry
+
+[← Back to benchmarks](./README.md)
+
+Retries an async function with configurable attempts, delay, and backoff strategy. Compared against `radash.retry` and a native retry loop.
+
+---
+
+| Size | 1o1-utils | radash | native | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| succeeds immediately | 167ns · 6.0M ops/s | 250ns · 4.0M ops/s | 125ns · 8.0M ops/s | native |
+| fails once, fixed | 4.7µs · 212.4K ops/s | — | — | 1o1-utils |
+| fails once | — | 5.3µs · 187.5K ops/s | 3.4µs · 292.7K ops/s | native |
+
+```mermaid
+xychart-beta horizontal
+  title "retry — ops/s at fails once items"
+  x-axis ["native", "radash"]
+  bar [292740, 187477]
+```

--- a/benchmarks/sleep.md
+++ b/benchmarks/sleep.md
@@ -1,0 +1,18 @@
+# sleep
+
+[← Back to benchmarks](./README.md)
+
+Async delay function. Compared against `radash.sleep` and native `setTimeout`.
+
+---
+
+| Size | 1o1-utils | radash | native setTimeout | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| 0ms | 1.17ms · 854 ops/s | 1.17ms · 856 ops/s | 1.16ms · 864 ops/s | native setTimeout |
+
+```mermaid
+xychart-beta horizontal
+  title "sleep — ops/s at 0ms items"
+  x-axis ["native setTimeout", "radash", "1o1-utils"]
+  bar [864, 856, 854]
+```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,18 @@
 		"./sort-by": {
 			"import": "./dist/arrays/sort-by/index.js",
 			"types": "./dist/arrays/sort-by/index.d.ts"
+		},
+		"./is-empty": {
+			"import": "./dist/objects/is-empty/index.js",
+			"types": "./dist/objects/is-empty/index.d.ts"
+		},
+		"./sleep": {
+			"import": "./dist/async/sleep/index.js",
+			"types": "./dist/async/sleep/index.d.ts"
+		},
+		"./retry": {
+			"import": "./dist/async/retry/index.js",
+			"types": "./dist/async/retry/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/async/retry/index.bench.ts
+++ b/src/async/retry/index.bench.ts
@@ -1,0 +1,53 @@
+import { retry as radashRetry } from "radash";
+import { Bench } from "tinybench";
+import { retry } from "./index.js";
+
+const bench = new Bench({ name: "retry", time: 1000 });
+
+const succeedFn = () => "ok";
+
+bench
+  .add("1o1-utils (succeeds immediately)", async () => {
+    await retry({ fn: succeedFn, delay: 0 });
+  })
+  .add("radash (succeeds immediately)", async () => {
+    await radashRetry({}, succeedFn);
+  })
+  .add("native (succeeds immediately)", async () => {
+    await succeedFn();
+  });
+
+bench
+  .add("1o1-utils (fails once, fixed)", async () => {
+    let calls = 0;
+    await retry({
+      fn: () => {
+        calls++;
+        if (calls === 1) throw new Error("fail");
+        return "ok";
+      },
+      delay: 0,
+    });
+  })
+  .add("radash (fails once)", async () => {
+    let calls = 0;
+    await radashRetry({ delay: 0 }, () => {
+      calls++;
+      if (calls === 1) throw new Error("fail");
+      return "ok";
+    });
+  })
+  .add("native (fails once)", async () => {
+    let calls = 0;
+    while (true) {
+      try {
+        calls++;
+        if (calls === 1) throw new Error("fail");
+        break;
+      } catch {
+        if (calls >= 3) throw new Error("fail");
+      }
+    }
+  });
+
+export { bench };

--- a/src/async/retry/index.spec.ts
+++ b/src/async/retry/index.spec.ts
@@ -1,0 +1,238 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { retry } from "./index.js";
+
+describe("retry", () => {
+  it("should return the result on first success", async () => {
+    const result = await retry({ fn: () => "ok" });
+    expect(result).to.equal("ok");
+  });
+
+  it("should return the result of an async function", async () => {
+    const result = await retry({ fn: async () => 42 });
+    expect(result).to.equal(42);
+  });
+
+  it("should retry and succeed on a later attempt", async () => {
+    let calls = 0;
+    const result = await retry({
+      fn: () => {
+        calls++;
+        if (calls < 3) throw new Error("fail");
+        return "success";
+      },
+      delay: 0,
+    });
+
+    expect(result).to.equal("success");
+    expect(calls).to.equal(3);
+  });
+
+  it("should throw the last error after all attempts fail", async () => {
+    try {
+      await retry({
+        fn: () => {
+          throw new Error("always fails");
+        },
+        attempts: 3,
+        delay: 0,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal("always fails");
+    }
+  });
+
+  it("should default to 3 attempts", async () => {
+    let calls = 0;
+    try {
+      await retry({
+        fn: () => {
+          calls++;
+          throw new Error("fail");
+        },
+        delay: 0,
+      });
+    } catch {
+      // expected
+    }
+    expect(calls).to.equal(3);
+  });
+
+  it("should respect custom attempts", async () => {
+    let calls = 0;
+    try {
+      await retry({
+        fn: () => {
+          calls++;
+          throw new Error("fail");
+        },
+        attempts: 5,
+        delay: 0,
+      });
+    } catch {
+      // expected
+    }
+    expect(calls).to.equal(5);
+  });
+
+  it("should call onRetry with error and attempt number", async () => {
+    const retries: { error: string; attempt: number }[] = [];
+
+    try {
+      await retry({
+        fn: () => {
+          throw new Error("boom");
+        },
+        attempts: 3,
+        delay: 0,
+        onRetry: (error, attempt) => {
+          retries.push({ error: (error as Error).message, attempt });
+        },
+      });
+    } catch {
+      // expected
+    }
+
+    expect(retries).to.deep.equal([
+      { error: "boom", attempt: 1 },
+      { error: "boom", attempt: 2 },
+    ]);
+  });
+
+  it("should use fixed delay between retries", async () => {
+    const timestamps: number[] = [];
+
+    try {
+      await retry({
+        fn: () => {
+          timestamps.push(Date.now());
+          throw new Error("fail");
+        },
+        attempts: 3,
+        delay: 50,
+        backoff: "fixed",
+      });
+    } catch {
+      // expected
+    }
+
+    const gap1 = timestamps[1] - timestamps[0];
+    const gap2 = timestamps[2] - timestamps[1];
+    expect(gap1).to.be.at.least(40);
+    expect(gap2).to.be.at.least(40);
+    expect(Math.abs(gap2 - gap1)).to.be.at.most(30);
+  });
+
+  it("should use exponential backoff", async () => {
+    const timestamps: number[] = [];
+
+    try {
+      await retry({
+        fn: () => {
+          timestamps.push(Date.now());
+          throw new Error("fail");
+        },
+        attempts: 3,
+        delay: 30,
+        backoff: "exponential",
+      });
+    } catch {
+      // expected
+    }
+
+    const gap1 = timestamps[1] - timestamps[0]; // delay * 2^0 = 30ms
+    const gap2 = timestamps[2] - timestamps[1]; // delay * 2^1 = 60ms
+    expect(gap1).to.be.at.least(20);
+    expect(gap2).to.be.at.least(50);
+    expect(gap2).to.be.greaterThan(gap1);
+  });
+
+  it("should work with delay: 0", async () => {
+    let calls = 0;
+    const result = await retry({
+      fn: () => {
+        calls++;
+        if (calls < 2) throw new Error("fail");
+        return "ok";
+      },
+      delay: 0,
+    });
+
+    expect(result).to.equal("ok");
+  });
+
+  it("should not retry with attempts: 1", async () => {
+    let calls = 0;
+    try {
+      await retry({
+        fn: () => {
+          calls++;
+          throw new Error("fail");
+        },
+        attempts: 1,
+        delay: 0,
+      });
+    } catch {
+      // expected
+    }
+    expect(calls).to.equal(1);
+  });
+
+  it("should reject if fn is not a function", async () => {
+    try {
+      // @ts-expect-error - testing invalid input
+      await retry({ fn: "not a function" });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'fn' parameter must be a function",
+      );
+    }
+  });
+
+  it("should reject if attempts is 0", async () => {
+    try {
+      await retry({ fn: () => "ok", attempts: 0 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'attempts' parameter must be a positive integer",
+      );
+    }
+  });
+
+  it("should reject if attempts is negative", async () => {
+    try {
+      await retry({ fn: () => "ok", attempts: -1 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'attempts' parameter must be a positive integer",
+      );
+    }
+  });
+
+  it("should reject if delay is negative", async () => {
+    try {
+      await retry({ fn: () => "ok", delay: -1 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'delay' parameter must be a non-negative number",
+      );
+    }
+  });
+
+  it("should reject if backoff is invalid", async () => {
+    try {
+      // @ts-expect-error - testing invalid input
+      await retry({ fn: () => "ok", backoff: "linear" });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'backoff' parameter must be 'fixed' or 'exponential'",
+      );
+    }
+  });
+});

--- a/src/async/retry/index.ts
+++ b/src/async/retry/index.ts
@@ -1,0 +1,52 @@
+import type { RetryParams } from "./types.js";
+
+async function retry<T>({
+  fn,
+  attempts = 3,
+  delay = 1000,
+  backoff = "fixed",
+  onRetry,
+}: RetryParams<T>): Promise<T> {
+  if (typeof fn !== "function") {
+    throw new Error("The 'fn' parameter must be a function");
+  }
+
+  if (
+    typeof attempts !== "number" ||
+    attempts < 1 ||
+    !Number.isInteger(attempts)
+  ) {
+    throw new Error("The 'attempts' parameter must be a positive integer");
+  }
+
+  if (typeof delay !== "number" || delay < 0 || Number.isNaN(delay)) {
+    throw new Error("The 'delay' parameter must be a non-negative number");
+  }
+
+  if (backoff !== "fixed" && backoff !== "exponential") {
+    throw new Error("The 'backoff' parameter must be 'fixed' or 'exponential'");
+  }
+
+  let lastError: unknown;
+
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      if (i < attempts - 1) {
+        if (onRetry) onRetry(error, i + 1);
+
+        const wait = backoff === "exponential" ? delay * 2 ** i : delay;
+        if (wait > 0) {
+          await new Promise((resolve) => setTimeout(resolve, wait));
+        }
+      }
+    }
+  }
+
+  throw lastError;
+}
+
+export { retry };

--- a/src/async/retry/types.ts
+++ b/src/async/retry/types.ts
@@ -1,0 +1,13 @@
+interface RetryParams<T> {
+  fn: () => Promise<T> | T;
+  attempts?: number;
+  delay?: number;
+  backoff?: "fixed" | "exponential";
+  onRetry?: (error: unknown, attempt: number) => void;
+}
+
+type RetryResult<T> = Promise<T>;
+
+type RetryFn = <T>(params: RetryParams<T>) => RetryResult<T>;
+
+export type { RetryFn, RetryParams, RetryResult };

--- a/src/async/sleep/index.bench.ts
+++ b/src/async/sleep/index.bench.ts
@@ -1,0 +1,18 @@
+import { sleep as radashSleep } from "radash";
+import { Bench } from "tinybench";
+import { sleep } from "./index.js";
+
+const bench = new Bench({ name: "sleep", time: 500 });
+
+bench
+  .add("1o1-utils (0ms)", async () => {
+    await sleep({ ms: 0 });
+  })
+  .add("radash (0ms)", async () => {
+    await radashSleep(0);
+  })
+  .add("native setTimeout (0ms)", async () => {
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  });
+
+export { bench };

--- a/src/async/sleep/index.spec.ts
+++ b/src/async/sleep/index.spec.ts
@@ -1,0 +1,42 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { sleep } from "./index.js";
+
+describe("sleep", () => {
+  it("should resolve after the specified duration", async () => {
+    const start = Date.now();
+    await sleep({ ms: 50 });
+    const elapsed = Date.now() - start;
+    expect(elapsed).to.be.at.least(40);
+  });
+
+  it("should resolve with ms: 0", async () => {
+    const result = sleep({ ms: 0 });
+    expect(result).to.be.instanceOf(Promise);
+    await result;
+  });
+
+  it("should return a Promise", () => {
+    const result = sleep({ ms: 0 });
+    expect(result).to.be.instanceOf(Promise);
+  });
+
+  it("should throw for a negative ms", () => {
+    expect(() => sleep({ ms: -1 })).to.throw(
+      "The 'ms' parameter must be a non-negative number",
+    );
+  });
+
+  it("should throw for a non-number ms", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => sleep({ ms: "100" })).to.throw(
+      "The 'ms' parameter must be a number",
+    );
+  });
+
+  it("should throw for NaN", () => {
+    expect(() => sleep({ ms: Number.NaN })).to.throw(
+      "The 'ms' parameter must be a number",
+    );
+  });
+});

--- a/src/async/sleep/index.ts
+++ b/src/async/sleep/index.ts
@@ -1,0 +1,15 @@
+import type { SleepParams } from "./types.js";
+
+function sleep({ ms }: SleepParams): Promise<void> {
+  if (typeof ms !== "number" || Number.isNaN(ms)) {
+    throw new Error("The 'ms' parameter must be a number");
+  }
+
+  if (ms < 0) {
+    throw new Error("The 'ms' parameter must be a non-negative number");
+  }
+
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export { sleep };

--- a/src/async/sleep/types.ts
+++ b/src/async/sleep/types.ts
@@ -1,0 +1,9 @@
+interface SleepParams {
+  ms: number;
+}
+
+type SleepResult = Promise<void>;
+
+type SleepFn = (params: SleepParams) => SleepResult;
+
+export type { SleepFn, SleepParams, SleepResult };

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -113,6 +113,21 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Converts an array into a hash/object keyed by a given property. Compared against `lodash.keyBy`, `radash.objectify`, and a native `for` loop.",
   },
+  isEmpty: {
+    slug: "is-empty",
+    description:
+      "Checks if a value is empty (null, undefined, empty string, empty array, empty object, empty Map/Set). Compared against `lodash.isEmpty` and `radash.isEmpty`.",
+  },
+  sleep: {
+    slug: "sleep",
+    description:
+      "Async delay function. Compared against `radash.sleep` and native `setTimeout`.",
+  },
+  retry: {
+    slug: "retry",
+    description:
+      "Retries an async function with configurable attempts, delay, and backoff strategy. Compared against `radash.retry` and a native retry loop.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,8 @@ export { chunk } from "./arrays/chunk/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
 export { unique } from "./arrays/unique/index.js";
+export { retry } from "./async/retry/index.js";
+export { sleep } from "./async/sleep/index.js";
+export { isEmpty } from "./objects/is-empty/index.js";
 export { omit } from "./objects/omit/index.js";
 export { pick } from "./objects/pick/index.js";

--- a/src/objects/is-empty/index.bench.ts
+++ b/src/objects/is-empty/index.bench.ts
@@ -1,0 +1,79 @@
+import lodashIsEmpty from "lodash/isEmpty.js";
+import { isEmpty as radashIsEmpty } from "radash";
+import { Bench } from "tinybench";
+import { isEmpty } from "./index.js";
+
+const emptyObj = {};
+const filledObj = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4,
+  e: 5,
+  f: 6,
+  g: 7,
+  h: 8,
+  i: 9,
+  j: 10,
+};
+const emptyArr: unknown[] = [];
+const filledArr = Array.from({ length: 100 }, (_, i) => i);
+
+const bench = new Bench({ name: "isEmpty", time: 1000 });
+
+bench
+  .add("1o1-utils (empty object)", () => {
+    isEmpty({ value: emptyObj });
+  })
+  .add("lodash (empty object)", () => {
+    lodashIsEmpty(emptyObj);
+  })
+  .add("radash (empty object)", () => {
+    radashIsEmpty(emptyObj);
+  });
+
+bench
+  .add("1o1-utils (filled object)", () => {
+    isEmpty({ value: filledObj });
+  })
+  .add("lodash (filled object)", () => {
+    lodashIsEmpty(filledObj);
+  })
+  .add("radash (filled object)", () => {
+    radashIsEmpty(filledObj);
+  });
+
+bench
+  .add("1o1-utils (empty array)", () => {
+    isEmpty({ value: emptyArr });
+  })
+  .add("lodash (empty array)", () => {
+    lodashIsEmpty(emptyArr);
+  })
+  .add("radash (empty array)", () => {
+    radashIsEmpty(emptyArr);
+  });
+
+bench
+  .add("1o1-utils (filled array)", () => {
+    isEmpty({ value: filledArr });
+  })
+  .add("lodash (filled array)", () => {
+    lodashIsEmpty(filledArr);
+  })
+  .add("radash (filled array)", () => {
+    radashIsEmpty(filledArr);
+  });
+
+bench
+  .add("1o1-utils (null)", () => {
+    isEmpty({ value: null });
+  })
+  .add("lodash (null)", () => {
+    lodashIsEmpty(null);
+  })
+  .add("radash (null)", () => {
+    radashIsEmpty(null);
+  });
+
+export { bench };

--- a/src/objects/is-empty/index.spec.ts
+++ b/src/objects/is-empty/index.spec.ts
@@ -1,0 +1,78 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { isEmpty } from "./index.js";
+
+describe("isEmpty", () => {
+  it("should return true for null", () => {
+    expect(isEmpty({ value: null })).to.equal(true);
+  });
+
+  it("should return true for undefined", () => {
+    expect(isEmpty({ value: undefined })).to.equal(true);
+  });
+
+  it("should return true for an empty string", () => {
+    expect(isEmpty({ value: "" })).to.equal(true);
+  });
+
+  it("should return false for a non-empty string", () => {
+    expect(isEmpty({ value: "hello" })).to.equal(false);
+  });
+
+  it("should return true for an empty array", () => {
+    expect(isEmpty({ value: [] })).to.equal(true);
+  });
+
+  it("should return false for a non-empty array", () => {
+    expect(isEmpty({ value: [1, 2] })).to.equal(false);
+  });
+
+  it("should return true for an empty object", () => {
+    expect(isEmpty({ value: {} })).to.equal(true);
+  });
+
+  it("should return false for a non-empty object", () => {
+    expect(isEmpty({ value: { a: 1 } })).to.equal(false);
+  });
+
+  it("should return true for an empty Map", () => {
+    expect(isEmpty({ value: new Map() })).to.equal(true);
+  });
+
+  it("should return false for a non-empty Map", () => {
+    expect(isEmpty({ value: new Map([["a", 1]]) })).to.equal(false);
+  });
+
+  it("should return true for an empty Set", () => {
+    expect(isEmpty({ value: new Set() })).to.equal(true);
+  });
+
+  it("should return false for a non-empty Set", () => {
+    expect(isEmpty({ value: new Set([1]) })).to.equal(false);
+  });
+
+  it("should return true for Object.create(null) with no properties", () => {
+    expect(isEmpty({ value: Object.create(null) })).to.equal(true);
+  });
+
+  it("should return false for a number", () => {
+    expect(isEmpty({ value: 0 })).to.equal(false);
+    expect(isEmpty({ value: 42 })).to.equal(false);
+  });
+
+  it("should return false for a boolean", () => {
+    expect(isEmpty({ value: false })).to.equal(false);
+    expect(isEmpty({ value: true })).to.equal(false);
+  });
+
+  it("should return false for a function", () => {
+    expect(isEmpty({ value: () => {} })).to.equal(false);
+  });
+
+  it("should return false for a class instance", () => {
+    class Foo {
+      x = 1;
+    }
+    expect(isEmpty({ value: new Foo() })).to.equal(false);
+  });
+});

--- a/src/objects/is-empty/index.ts
+++ b/src/objects/is-empty/index.ts
@@ -1,0 +1,20 @@
+import type { IsEmptyParams } from "./types.js";
+
+function isEmpty({ value }: IsEmptyParams): boolean {
+  if (value === null || value === undefined) return true;
+  if (typeof value === "string") return value.length === 0;
+  if (Array.isArray(value)) return value.length === 0;
+  if (value instanceof Map || value instanceof Set) return value.size === 0;
+
+  if (typeof value === "object") {
+    const proto = Object.getPrototypeOf(value);
+    if (proto === Object.prototype || proto === null) {
+      for (const _ in value) return false;
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export { isEmpty };

--- a/src/objects/is-empty/types.ts
+++ b/src/objects/is-empty/types.ts
@@ -1,0 +1,9 @@
+interface IsEmptyParams {
+  value: unknown;
+}
+
+type IsEmptyResult = boolean;
+
+type IsEmptyFn = (params: IsEmptyParams) => IsEmptyResult;
+
+export type { IsEmptyFn, IsEmptyParams, IsEmptyResult };


### PR DESCRIPTION
## Summary

- **`isEmpty`**: check if a value is empty (`null`, `undefined`, `""`, `[]`, `{}`, empty `Map`/`Set`). Uses `for...in` with early return for optimal performance on filled objects — on par with lodash, ~2x faster than radash.
- **`sleep`**: async delay function with input validation. On par with native `setTimeout`.
- **`retry`**: retry async functions with configurable `attempts`, `delay`, and `backoff` (`"fixed"` | `"exponential"`). Includes `onRetry` callback. ~1.5x faster than radash.

Closes #8, closes #12, closes #13.

## Test plan

- [x] 108 tests passing (`pnpm test`)
- [x] Lint clean (`pnpm check`)
- [x] Build clean (`pnpm build`)
- [x] Benchmarks run and markdown generated for all 3 utilities