### PR TITLE
feat(strings): add truncate and slugify utilities

### DIFF
--- a/.changeset/add-truncate-slugify.md
+++ b/.changeset/add-truncate-slugify.md
@@ -1,0 +1,8 @@
+---
+"1o1-utils": minor
+---
+
+Add truncate and slugify string utilities
+
+- `truncate`: truncate a string to a given length with configurable suffix (default `...`)
+- `slugify`: convert a string to a URL-friendly slug with accent support

--- a/package.json
+++ b/package.json
@@ -48,6 +48,14 @@
 		"./retry": {
 			"import": "./dist/async/retry/index.js",
 			"types": "./dist/async/retry/index.d.ts"
+		},
+		"./slugify": {
+			"import": "./dist/strings/slugify/index.js",
+			"types": "./dist/strings/slugify/index.d.ts"
+		},
+		"./truncate": {
+			"import": "./dist/strings/truncate/index.js",
+			"types": "./dist/strings/truncate/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,5 @@ export { sleep } from "./async/sleep/index.js";
 export { isEmpty } from "./objects/is-empty/index.js";
 export { omit } from "./objects/omit/index.js";
 export { pick } from "./objects/pick/index.js";
+export { slugify } from "./strings/slugify/index.js";
+export { truncate } from "./strings/truncate/index.js";

--- a/src/strings/slugify/index.bench.ts
+++ b/src/strings/slugify/index.bench.ts
@@ -1,0 +1,46 @@
+import { Bench } from "tinybench";
+import { slugify } from "./index.js";
+
+const simple = "Hello World!";
+const accented = "São Paulo é uma cidade incrível";
+const heavy =
+  "This is a REALLY long string with LOTS of Special!@#$%^&*() Characters and Açaí and Über and naïve words".repeat(
+    10,
+  );
+
+function nativeSlugify(str: string): string {
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+const bench = new Bench({ name: "slugify", time: 1000 });
+
+bench
+  .add("1o1-utils (simple)", () => {
+    slugify({ str: simple });
+  })
+  .add("native (simple)", () => {
+    nativeSlugify(simple);
+  });
+
+bench
+  .add("1o1-utils (accented)", () => {
+    slugify({ str: accented });
+  })
+  .add("native (accented)", () => {
+    nativeSlugify(accented);
+  });
+
+bench
+  .add("1o1-utils (heavy)", () => {
+    slugify({ str: heavy });
+  })
+  .add("native (heavy)", () => {
+    nativeSlugify(heavy);
+  });
+
+export { bench };

--- a/src/strings/slugify/index.spec.ts
+++ b/src/strings/slugify/index.spec.ts
@@ -1,0 +1,60 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { slugify } from "./index.js";
+
+describe("slugify", () => {
+  it("should convert a string to a URL-friendly slug", () => {
+    const result = slugify({ str: "Hello World!" });
+
+    expect(result).to.equal("hello-world");
+  });
+
+  it("should handle accented characters", () => {
+    const result = slugify({ str: "São Paulo" });
+
+    expect(result).to.equal("sao-paulo");
+  });
+
+  it("should collapse multiple spaces into a single hyphen", () => {
+    const result = slugify({ str: "  multiple   spaces  " });
+
+    expect(result).to.equal("multiple-spaces");
+  });
+
+  it("should return the same string if already a slug", () => {
+    const result = slugify({ str: "already-a-slug" });
+
+    expect(result).to.equal("already-a-slug");
+  });
+
+  it("should convert uppercase to lowercase", () => {
+    const result = slugify({ str: "UPPERCASE" });
+
+    expect(result).to.equal("uppercase");
+  });
+
+  it("should handle special characters", () => {
+    const result = slugify({ str: "special!@#chars" });
+
+    expect(result).to.equal("special-chars");
+  });
+
+  it("should return an empty string for an empty input", () => {
+    const result = slugify({ str: "" });
+
+    expect(result).to.equal("");
+  });
+
+  it("should handle strings with only special characters", () => {
+    const result = slugify({ str: "!@#$%^&*()" });
+
+    expect(result).to.equal("");
+  });
+
+  it("should throw an error if str is not a string", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => slugify({ str: 123 })).to.throw(
+      "The 'str' parameter must be a string",
+    );
+  });
+});

--- a/src/strings/slugify/index.ts
+++ b/src/strings/slugify/index.ts
@@ -1,0 +1,16 @@
+import type { SlugifyParams, SlugifyResult } from "./types.js";
+
+function slugify({ str }: SlugifyParams): SlugifyResult {
+  if (typeof str !== "string") {
+    throw new Error("The 'str' parameter must be a string");
+  }
+
+  return str
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+export { slugify };

--- a/src/strings/slugify/types.ts
+++ b/src/strings/slugify/types.ts
@@ -1,0 +1,9 @@
+interface SlugifyParams {
+  str: string;
+}
+
+type SlugifyResult = string;
+
+type Slugify = (params: SlugifyParams) => SlugifyResult;
+
+export type { Slugify, SlugifyParams, SlugifyResult };

--- a/src/strings/truncate/index.bench.ts
+++ b/src/strings/truncate/index.bench.ts
@@ -1,0 +1,49 @@
+import lodashTruncate from "lodash/truncate.js";
+import { Bench } from "tinybench";
+import { truncate } from "./index.js";
+
+const short = "Hello";
+const medium = "The quick brown fox jumps over the lazy dog";
+const long = "Lorem ipsum dolor sit amet. ".repeat(100);
+
+function nativeTruncate(str: string, length: number, suffix = "..."): string {
+  if (str.length <= length) return str;
+  return str.slice(0, length) + suffix;
+}
+
+const bench = new Bench({ name: "truncate", time: 1000 });
+
+bench
+  .add("1o1-utils (short, no-op)", () => {
+    truncate({ str: short, length: 10 });
+  })
+  .add("lodash (short, no-op)", () => {
+    lodashTruncate(short, { length: 10 });
+  })
+  .add("native (short, no-op)", () => {
+    nativeTruncate(short, 10);
+  });
+
+bench
+  .add("1o1-utils (medium)", () => {
+    truncate({ str: medium, length: 20 });
+  })
+  .add("lodash (medium)", () => {
+    lodashTruncate(medium, { length: 20 });
+  })
+  .add("native (medium)", () => {
+    nativeTruncate(medium, 20);
+  });
+
+bench
+  .add("1o1-utils (long)", () => {
+    truncate({ str: long, length: 50 });
+  })
+  .add("lodash (long)", () => {
+    lodashTruncate(long, { length: 50 });
+  })
+  .add("native (long)", () => {
+    nativeTruncate(long, 50);
+  });
+
+export { bench };

--- a/src/strings/truncate/index.spec.ts
+++ b/src/strings/truncate/index.spec.ts
@@ -1,0 +1,66 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { truncate } from "./index.js";
+
+describe("truncate", () => {
+  it("should truncate a string to the given length with default suffix", () => {
+    const result = truncate({ str: "Hello World", length: 5 });
+
+    expect(result).to.equal("Hello...");
+  });
+
+  it("should truncate a string with a custom suffix", () => {
+    const result = truncate({ str: "Hello World", length: 5, suffix: " →" });
+
+    expect(result).to.equal("Hello →");
+  });
+
+  it("should return the string as-is when shorter than length", () => {
+    const result = truncate({ str: "Hi", length: 10 });
+
+    expect(result).to.equal("Hi");
+  });
+
+  it("should return the string as-is when exactly at length", () => {
+    const result = truncate({ str: "Hello", length: 5 });
+
+    expect(result).to.equal("Hello");
+  });
+
+  it("should handle an empty string", () => {
+    const result = truncate({ str: "", length: 5 });
+
+    expect(result).to.equal("");
+  });
+
+  it("should allow an empty suffix", () => {
+    const result = truncate({ str: "Hello World", length: 5, suffix: "" });
+
+    expect(result).to.equal("Hello");
+  });
+
+  it("should throw an error if str is not a string", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => truncate({ str: 123, length: 5 })).to.throw(
+      "The 'str' parameter must be a string",
+    );
+  });
+
+  it("should throw an error if length is zero", () => {
+    expect(() => truncate({ str: "Hello", length: 0 })).to.throw(
+      "The 'length' parameter must be a positive integer",
+    );
+  });
+
+  it("should throw an error if length is negative", () => {
+    expect(() => truncate({ str: "Hello", length: -1 })).to.throw(
+      "The 'length' parameter must be a positive integer",
+    );
+  });
+
+  it("should throw an error if length is not an integer", () => {
+    expect(() => truncate({ str: "Hello", length: 2.5 })).to.throw(
+      "The 'length' parameter must be a positive integer",
+    );
+  });
+});

--- a/src/strings/truncate/index.ts
+++ b/src/strings/truncate/index.ts
@@ -1,0 +1,23 @@
+import type { TruncateParams, TruncateResult } from "./types.js";
+
+function truncate({
+  str,
+  length,
+  suffix = "...",
+}: TruncateParams): TruncateResult {
+  if (typeof str !== "string") {
+    throw new Error("The 'str' parameter must be a string");
+  }
+
+  if (typeof length !== "number" || length <= 0 || !Number.isInteger(length)) {
+    throw new Error("The 'length' parameter must be a positive integer");
+  }
+
+  if (str.length <= length) {
+    return str;
+  }
+
+  return str.slice(0, length) + suffix;
+}
+
+export { truncate };

--- a/src/strings/truncate/types.ts
+++ b/src/strings/truncate/types.ts
@@ -1,0 +1,11 @@
+interface TruncateParams {
+  str: string;
+  length: number;
+  suffix?: string;
+}
+
+type TruncateResult = string;
+
+type Truncate = (params: TruncateParams) => TruncateResult;
+
+export type { Truncate, TruncateParams, TruncateResult };


### PR DESCRIPTION
## Summary
- Add `truncate` utility: truncates a string to a given length with configurable suffix (default `...`)
- Add `slugify` utility: converts a string to a URL-friendly slug with accent support via NFD normalization
- First string utilities — creates `src/strings/` category

Closes #9, closes #10

## Test plan
- [x] Unit tests for truncate (10 cases: basic, custom suffix, no-op, empty, edge cases, errors)
- [x] Unit tests for slugify (9 cases: basic, accents, spaces, special chars, empty, errors)
- [x] Benchmarks: truncate ~1.4x faster than lodash; slugify on par with native
- [x] `pnpm build` compiles clean
- [x] `pnpm check` (biome) passes