### PR TITLE
ci: upgrade Node.js from 20.x to 22.x

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -13,7 +13,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version-file: .nvmrc
+          node-version: 22.x
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: pnpm
 
       - name: Install library dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: pnpm
           registry-url: https://registry.npmjs.org
 

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 22.x
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- Astro (docs site) requires Node.js >=22.12.0, causing `docs.yml` to fail on Node 20.x
- Upgraded `node-version` from `20.x` to `22.x` in all 5 workflow files (`ci.yml`, `docs.yml`, `release.yml`, `size.yml`, `bench.yml`)
- `bench.yml` was using `node-version-file: .nvmrc` which doesn't exist — switched to explicit `22.x` for consistency

## Test plan
- [ ] CI pipeline passes on this PR
- [ ] Docs build succeeds with Node 22