### PR TITLE
fix(ci): remove npm self-upgrade step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - run: pnpm install --frozen-lockfile
 
       - name: Biome check


### PR DESCRIPTION
## Summary
- Remove the `npm install -g npm@latest` step from the release workflow
- Node 22 already ships with npm that supports OIDC trusted publishing natively
- The self-upgrade was failing with `Cannot find module 'promise-retry'`, breaking all releases since the Node 22 upgrade

## Test plan
- [x] Full local pipeline passes: `pnpm check`, `tsc --noEmit`, `test`, `build`
- [ ] Merge and verify release workflow succeeds on GitHub Actions