### PR TITLE
fix(ci): pass NPM_TOKEN env to changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,9 +26,6 @@ jobs:
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
-
       - run: pnpm install --frozen-lockfile
 
       - name: Biome check

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,3 +49,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Add `NPM_TOKEN` env var to the changesets/action step
- The action checks for `NPM_TOKEN` to decide between token auth and OIDC — having only `NODE_AUTH_TOKEN` caused it to fall back to OIDC, which failed with `EOTP`

## Test plan
- [ ] Merge and verify release workflow publishes 1.4.0 to npm successfully