### PR TITLE
fix: use absolute URL for npm logo and add license field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./website/public/logo.png" alt="1o1-utils logo" width="120">
+  <img src="https://raw.githubusercontent.com/pedrotroccoli/1o1-utils/main/website/public/logo.png" alt="1o1-utils logo" width="120">
   <h1 align="center">1o1-utils</h1>
   <p align="center">Lightweight, fastest, tree-shakeable TypeScript utilities. 2 kB gzipped.</p>
 </p>

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
 	"name": "1o1-utils",
 	"version": "1.4.0",
 	"description": "A collection of utility functions for TypeScript & Javascript",
+	"license": "MIT",
 	"type": "module",
 	"types": "dist/index.d.ts",
 	"sideEffects": false,


### PR DESCRIPTION
## Summary
- Use absolute GitHub raw URL for logo so it renders correctly on npmjs.com
- Add missing `license` field to `package.json` to fix the "missing" license badge

## Test plan
- [ ] Verify logo renders on npm after next publish
- [ ] Verify license badge shows "MIT" after next publish