### PR TITLE
docs: add discoverability keywords and prompt suggestions to all utilities

### DIFF
--- a/.changeset/add-discoverability-keywords.md
+++ b/.changeset/add-discoverability-keywords.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": patch
+---
+
+Add `@keywords` JSDoc tags to all 17 utilities for search discoverability, and add "Also known as" and "Prompt suggestion" sections to all utility doc pages

--- a/src/arrays/array-to-hash/index.ts
+++ b/src/arrays/array-to-hash/index.ts
@@ -14,6 +14,8 @@ import type { ArrayToHashParams, ArrayToHashResult } from "./types.js";
  * // => { a: { id: "a", name: "Alice" } }
  * ```
  *
+ * @keywords array to object, keyBy, objectify, index by, lookup table, dictionary
+ *
  * @throws Error if `array` is not an array
  * @throws Error if `key` is not a string
  */

--- a/src/arrays/chunk/index.ts
+++ b/src/arrays/chunk/index.ts
@@ -14,6 +14,8 @@ import type { ChunkParams, ChunkResult } from "./types.js";
  * // => [[1, 2], [3, 4], [5]]
  * ```
  *
+ * @keywords split array, batch, divide, paginate, group by size
+ *
  * @throws Error if `array` is not an array
  * @throws Error if `size` is not a positive integer
  */

--- a/src/arrays/group-by/index.ts
+++ b/src/arrays/group-by/index.ts
@@ -14,6 +14,8 @@ import type { GroupByParams, GroupByResult } from "./types.js";
  * // => { admin: [{ role: "admin", name: "Alice" }], user: [{ role: "user", name: "Bob" }] }
  * ```
  *
+ * @keywords categorize, bucket, cluster, group array
+ *
  * @throws Error if `array` is not an array
  * @throws Error if `key` is undefined or null
  */

--- a/src/arrays/sort-by/index.ts
+++ b/src/arrays/sort-by/index.ts
@@ -32,6 +32,8 @@ function getByPath(obj: unknown, path: string): unknown {
  * // => [{ age: 20 }, { age: 30 }]
  * ```
  *
+ * @keywords order by, sort array, arrange, rank
+ *
  * @throws Error if `array` is not an array
  * @throws Error if `key` is undefined or null
  */

--- a/src/arrays/unique/index.ts
+++ b/src/arrays/unique/index.ts
@@ -14,6 +14,8 @@ import type { UniqueParams, UniqueResult } from "./types.js";
  * // => [1, 2, 3]
  * ```
  *
+ * @keywords deduplicate, distinct, uniq, remove duplicates
+ *
  * @throws Error if `array` is not an array
  */
 function unique<T>({ array, key }: UniqueParams<T>): UniqueResult<T> {

--- a/src/async/debounce/index.ts
+++ b/src/async/debounce/index.ts
@@ -16,6 +16,8 @@ import type { Debounced, DebounceParams } from "./types.js";
  * debouncedFn.cancel(); // cancel pending call
  * ```
  *
+ * @keywords delay call, wait idle, input delay, search delay
+ *
  * @throws Error if `fn` is not a function
  * @throws Error if `ms` is not a number or is negative
  */

--- a/src/async/retry/index.ts
+++ b/src/async/retry/index.ts
@@ -16,6 +16,8 @@ import type { RetryParams } from "./types.js";
  * const data = await retry({ fn: () => fetch("/api"), attempts: 5, backoff: "exponential" });
  * ```
  *
+ * @keywords retry on failure, exponential backoff, resilient call, auto retry
+ *
  * @throws Error if `fn` is not a function
  * @throws The last error if all attempts fail
  */

--- a/src/async/sleep/index.ts
+++ b/src/async/sleep/index.ts
@@ -12,6 +12,8 @@ import type { SleepParams } from "./types.js";
  * await sleep({ ms: 1000 }); // waits 1 second
  * ```
  *
+ * @keywords wait, delay, pause, setTimeout promise
+ *
  * @throws Error if `ms` is not a number or is NaN
  * @throws Error if `ms` is negative
  */

--- a/src/async/throttle/index.ts
+++ b/src/async/throttle/index.ts
@@ -16,6 +16,8 @@ import type { Throttled, ThrottleParams } from "./types.js";
  * throttledFn.cancel(); // cancel pending trailing call
  * ```
  *
+ * @keywords rate limit, limit calls, scroll handler, resize handler
+ *
  * @throws Error if `fn` is not a function
  * @throws Error if `ms` is not a number or is negative
  */

--- a/src/objects/deep-merge/index.ts
+++ b/src/objects/deep-merge/index.ts
@@ -20,6 +20,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
  * // => { a: 1, b: { x: 10, y: 20 }, c: 3 }
  * ```
  *
+ * @keywords merge objects, recursive merge, combine objects, extend deep
+ *
  * @throws Error if `target` is not a plain object
  * @throws Error if `source` is not a plain object
  */

--- a/src/objects/is-empty/index.ts
+++ b/src/objects/is-empty/index.ts
@@ -17,6 +17,8 @@ import type { IsEmptyParams } from "./types.js";
  * isEmpty({ value: "" });   // => true
  * isEmpty({ value: [1] });  // => false
  * ```
+ *
+ * @keywords is empty, is blank, has value, null check, empty check
  */
 function isEmpty({ value }: IsEmptyParams): boolean {
   if (value === null || value === undefined) return true;

--- a/src/objects/omit/index.ts
+++ b/src/objects/omit/index.ts
@@ -47,6 +47,8 @@ function omitNested(target: Record<string, unknown>, key: string): void {
  * // => { a: 1 }
  * ```
  *
+ * @keywords exclude keys, remove properties, without keys, strip fields
+ *
  * @throws Error if `obj` is not an object
  * @throws Error if `keys` is not an array
  */

--- a/src/objects/pick/index.ts
+++ b/src/objects/pick/index.ts
@@ -56,6 +56,8 @@ function pickNested(
  * // => { a: 1, c: 3 }
  * ```
  *
+ * @keywords select keys, extract properties, subset object, pluck
+ *
  * @throws Error if `obj` is not an object
  * @throws Error if `keys` is not an array
  */

--- a/src/strings/capitalize/index.ts
+++ b/src/strings/capitalize/index.ts
@@ -14,6 +14,8 @@ import type { CapitalizeParams, CapitalizeResult } from "./types.js";
  * // => "Hello"
  * ```
  *
+ * @keywords uppercase first, first letter uppercase, initial cap
+ *
  * @throws Error if `str` is not a string
  */
 function capitalize({

--- a/src/strings/slugify/index.ts
+++ b/src/strings/slugify/index.ts
@@ -13,6 +13,8 @@ import type { SlugifyParams, SlugifyResult } from "./types.js";
  * // => "hello-world"
  * ```
  *
+ * @keywords url slug, url friendly, permalink, dash case url
+ *
  * @throws Error if `str` is not a string
  */
 function slugify({ str }: SlugifyParams): SlugifyResult {

--- a/src/strings/transform-case/index.ts
+++ b/src/strings/transform-case/index.ts
@@ -49,6 +49,8 @@ function joinWords(words: string[], to: CaseStyle): string {
  * // => "helloWorld"
  * ```
  *
+ * @keywords camelCase, snake_case, kebab-case, PascalCase, convert case
+ *
  * @throws Error if `str` is not a string
  * @throws Error if `to` is not a valid case style
  */

--- a/src/strings/truncate/index.ts
+++ b/src/strings/truncate/index.ts
@@ -15,6 +15,8 @@ import type { TruncateParams, TruncateResult } from "./types.js";
  * // => "Hello..."
  * ```
  *
+ * @keywords shorten text, ellipsis, cut string, text overflow
+ *
  * @throws Error if `str` is not a string
  * @throws Error if `length` is not a positive integer
  */

--- a/website/src/content/docs/arrays/array-to-hash.mdx
+++ b/website/src/content/docs/arrays/array-to-hash.mdx
@@ -49,3 +49,11 @@ arrayToHash({ array: users, key: "id" });
 - Throws if `array` is not an array.
 - Throws if `key` is not a string.
 - Skips items where the key value is falsy or not a string.
+
+## Also known as
+
+array to object, keyBy, objectify, index by, lookup table, dictionary
+
+## Prompt suggestion
+
+> `Show me how to use arrayToHash from 1o1-utils to create a lookup table from an API response array`

--- a/website/src/content/docs/arrays/chunk.mdx
+++ b/website/src/content/docs/arrays/chunk.mdx
@@ -47,3 +47,11 @@ chunk({ array: ["a", "b", "c", "d"], size: 3 });
 - Throws if `array` is not an array.
 - Throws if `size` is not a positive integer.
 - Returns `[]` for an empty array.
+
+## Also known as
+
+split array, batch, divide, paginate, group by size
+
+## Prompt suggestion
+
+> `Show me how to use chunk from 1o1-utils to paginate a list of items client-side`

--- a/website/src/content/docs/arrays/group-by.mdx
+++ b/website/src/content/docs/arrays/group-by.mdx
@@ -53,3 +53,11 @@ groupBy({ array: items, key: "role" });
 - Throws if `array` is not an array.
 - Throws if `key` is undefined or null.
 - Groups are keyed by `String(value[key])`.
+
+## Also known as
+
+categorize, bucket, cluster, group array
+
+## Prompt suggestion
+
+> `Show me how to use groupBy from 1o1-utils to group transactions by category`

--- a/website/src/content/docs/arrays/sort-by.mdx
+++ b/website/src/content/docs/arrays/sort-by.mdx
@@ -52,3 +52,11 @@ sortBy({ array: users, key: "address.city" });
 - Throws if `key` is undefined or null.
 - Supports both numeric and string comparisons.
 - Supports nested keys via dot notation (e.g., `"address.city"`).
+
+## Also known as
+
+order by, sort array, arrange, rank
+
+## Prompt suggestion
+
+> `Show me how to use sortBy from 1o1-utils to sort a table by nested user.name field`

--- a/website/src/content/docs/arrays/unique.mdx
+++ b/website/src/content/docs/arrays/unique.mdx
@@ -53,3 +53,11 @@ unique({ array: users, key: "id" });
 - Throws if `array` is not an array.
 - Without `key`, uses `Set` for primitive deduplication.
 - With `key`, keeps the first occurrence of each unique value.
+
+## Also known as
+
+deduplicate, distinct, uniq, remove duplicates
+
+## Prompt suggestion
+
+> `Show me how to use unique from 1o1-utils to deduplicate an array of objects by ID`

--- a/website/src/content/docs/async/debounce.mdx
+++ b/website/src/content/docs/async/debounce.mdx
@@ -55,3 +55,11 @@ debouncedSearch.cancel();
 - Throws if `ms` is negative.
 - Calling `.cancel()` clears any pending timeout.
 - Each call resets the delay timer.
+
+## Also known as
+
+delay call, wait idle, input delay, search delay
+
+## Prompt suggestion
+
+> `Show me how to use debounce from 1o1-utils to delay a search input API call`

--- a/website/src/content/docs/async/retry.mdx
+++ b/website/src/content/docs/async/retry.mdx
@@ -62,3 +62,11 @@ await retry({
 - Throws if `backoff` is not `"fixed"` or `"exponential"`.
 - With exponential backoff, delay is `delay * 2^i` for attempt `i`.
 - Throws the last error after all attempts are exhausted.
+
+## Also known as
+
+retry on failure, exponential backoff, resilient call, auto retry
+
+## Prompt suggestion
+
+> `Show me how to use retry from 1o1-utils with exponential backoff for a flaky API`

--- a/website/src/content/docs/async/sleep.mdx
+++ b/website/src/content/docs/async/sleep.mdx
@@ -42,3 +42,11 @@ await sleep({ ms: 1000 }); // waits 1 second
 - Throws if `ms` is not a number or is `NaN`.
 - Throws if `ms` is negative.
 - `sleep({ ms: 0 })` resolves on the next tick.
+
+## Also known as
+
+wait, delay, pause, setTimeout promise
+
+## Prompt suggestion
+
+> `Show me how to use sleep from 1o1-utils to add a delay between sequential API calls`

--- a/website/src/content/docs/async/throttle.mdx
+++ b/website/src/content/docs/async/throttle.mdx
@@ -54,3 +54,11 @@ throttledScroll.cancel();
 - First call executes immediately.
 - Subsequent calls within `ms` are queued; the last one fires after the interval.
 - `.cancel()` clears pending calls and resets state.
+
+## Also known as
+
+rate limit, limit calls, scroll handler, resize handler
+
+## Prompt suggestion
+
+> `Show me how to use throttle from 1o1-utils to limit a scroll event handler`

--- a/website/src/content/docs/objects/deep-merge.mdx
+++ b/website/src/content/docs/objects/deep-merge.mdx
@@ -48,3 +48,11 @@ deepMerge({
 - Throws if `source` is not a plain object.
 - Only merges plain objects recursively; arrays and other types are overwritten.
 - Uses a stack-based (non-recursive) algorithm to avoid stack overflow on deeply nested objects.
+
+## Also known as
+
+merge objects, recursive merge, combine objects, extend deep
+
+## Prompt suggestion
+
+> `Show me how to use deepMerge from 1o1-utils to merge user settings with defaults`

--- a/website/src/content/docs/objects/is-empty.mdx
+++ b/website/src/content/docs/objects/is-empty.mdx
@@ -59,3 +59,11 @@ isEmpty({ value: false });     // => false
 - Numbers (including `0`) and booleans are never empty.
 - Only plain objects (prototype is `Object.prototype` or `null`) are checked for emptiness.
 - Class instances and other non-plain objects return `false`.
+
+## Also known as
+
+is empty, is blank, has value, null check, empty check
+
+## Prompt suggestion
+
+> `Show me how to use isEmpty from 1o1-utils to validate form fields before submission`

--- a/website/src/content/docs/objects/omit.mdx
+++ b/website/src/content/docs/objects/omit.mdx
@@ -49,3 +49,11 @@ omit({ obj: { a: 1, b: { x: 10, y: 20 } }, keys: ["b.x"] });
 - Throws if `keys` is not an array.
 - Supports nested key removal via dot notation.
 - Does not mutate the original object.
+
+## Also known as
+
+exclude keys, remove properties, without keys, strip fields
+
+## Prompt suggestion
+
+> `Show me how to use omit from 1o1-utils to strip sensitive fields before logging`

--- a/website/src/content/docs/objects/pick.mdx
+++ b/website/src/content/docs/objects/pick.mdx
@@ -49,3 +49,11 @@ pick({ obj: { a: 1, b: { x: 10, y: 20 } }, keys: ["a", "b.x"] });
 - Throws if `keys` is not an array.
 - Supports nested key selection via dot notation.
 - Missing keys are silently skipped.
+
+## Also known as
+
+select keys, extract properties, subset object, pluck
+
+## Prompt suggestion
+
+> `Show me how to use pick from 1o1-utils to extract only needed fields from an API response`

--- a/website/src/content/docs/strings/capitalize.mdx
+++ b/website/src/content/docs/strings/capitalize.mdx
@@ -49,3 +49,11 @@ capitalize({ str: "hELLO" });
 
 - Throws if `str` is not a string.
 - Returns `""` for empty string.
+
+## Also known as
+
+uppercase first, first letter uppercase, initial cap
+
+## Prompt suggestion
+
+> `Show me how to use capitalize from 1o1-utils to format user display names`

--- a/website/src/content/docs/strings/slugify.mdx
+++ b/website/src/content/docs/strings/slugify.mdx
@@ -50,3 +50,11 @@ slugify({ str: "  --Multiple   Spaces--  " });
 - Handles Unicode normalization (NFD) to strip accents.
 - Removes leading/trailing hyphens.
 - Collapses multiple non-alphanumeric characters into a single hyphen.
+
+## Also known as
+
+url slug, url friendly, permalink, dash case url
+
+## Prompt suggestion
+
+> `Show me how to use slugify from 1o1-utils to generate URL slugs from article titles`

--- a/website/src/content/docs/strings/transform-case.mdx
+++ b/website/src/content/docs/strings/transform-case.mdx
@@ -57,3 +57,11 @@ transformCase({ str: "myVariableName", to: "kebab" });
 - Throws if `to` is not one of: `camel`, `kebab`, `snake`, `pascal`.
 - Returns `""` for empty string.
 - Splits on word boundaries (uppercase transitions, hyphens, underscores, spaces).
+
+## Also known as
+
+camelCase, snake_case, kebab-case, PascalCase, convert case
+
+## Prompt suggestion
+
+> `Show me how to use transformCase from 1o1-utils to convert API snake_case keys to camelCase`

--- a/website/src/content/docs/strings/truncate.mdx
+++ b/website/src/content/docs/strings/truncate.mdx
@@ -52,3 +52,11 @@ truncate({ str: "Hi", length: 10 });
 - Throws if `length` is not a positive integer.
 - Returns the original string if its length does not exceed `length`.
 - The suffix is appended beyond the `length` limit.
+
+## Also known as
+
+shorten text, ellipsis, cut string, text overflow
+
+## Prompt suggestion
+
+> `Show me how to use truncate from 1o1-utils to shorten long descriptions in a card component`


### PR DESCRIPTION
## Summary

Closes #90 (discoverability items)

- Add `@keywords` JSDoc tag to all 17 existing utility source files for tooling/search discoverability
- Add "Also known as" and "Prompt suggestion" sections to all 17 utility doc pages
- GitHub issue renames (8 issues) were already applied separately

## Test plan

- [x] `pnpm check` passes
- [x] `pnpm build` passes
- [ ] Spot-check doc pages render correctly with `pnpm docs:dev`