### PR TITLE
feat: add cloneDeep utility

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -31,6 +31,11 @@
     "limit": "1 kB"
   },
   {
+    "name": "clone-deep",
+    "path": "dist/objects/clone-deep/index.js",
+    "limit": "2 kB"
+  },
+  {
     "name": "deep-merge",
     "path": "dist/objects/deep-merge/index.js",
     "limit": "2 kB"

--- a/docs/benchmarks/clone-deep.md
+++ b/docs/benchmarks/clone-deep.md
@@ -1,0 +1,23 @@
+# cloneDeep
+
+[← Back to benchmarks](./README.md)
+
+Creates a deep clone of a value. Handles objects, arrays, dates, regexes, maps, sets, typed arrays, and circular references. Compared against `lodash.cloneDeep`, `radash.clone`, and native `structuredClone`.
+
+> **Note:** `radash.clone` is **not a true deep clone** — nested objects, arrays, Maps, and Sets keep their original references. Its numbers are shown for reference only and are not comparable to the others.
+
+---
+
+| Size | 1o1-utils | lodash | radash | structuredClone | Fastest |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| small | 125ns · 8.0M ops/s | 375ns · 2.7M ops/s | 83ns · 12.0M ops/s | 833ns · 1.2M ops/s | radash · 4.5× faster vs lodash |
+| deep | 875ns · 1.1M ops/s | 2.4µs · 421.1K ops/s | 42ns · 23.8M ops/s | 3.9µs · 255.3K ops/s | radash · 56.5× faster vs lodash |
+| mixed | 1.5µs · 648.5K ops/s | 6.3µs · 159.0K ops/s | — | 4.0µs · 247.4K ops/s | 1o1-utils · 4.1× faster vs lodash |
+| array-1k | 138.2µs · 7.2K ops/s | 431.4µs · 2.3K ops/s | 50.9µs · 19.6K ops/s | 490.5µs · 2.0K ops/s | radash · 8.5× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "cloneDeep — ops/s at array-1k items"
+  x-axis ["radash", "1o1-utils", "lodash", "structuredClone"]
+  bar [19640, 7238, 2318, 2039]
+```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -152,6 +152,30 @@ Without key, uses Set for primitive deduplication. With key, keeps the first occ
 
 ## Objects
 
+### cloneDeep
+
+Create a deep clone of any value. Handles plain objects, arrays, Date, RegExp, Map, Set, typed arrays, ArrayBuffer, Error, and circular references. Functions are copied by reference.
+
+Import: import { cloneDeep } from "1o1-utils/clone-deep";
+
+Signature:
+function cloneDeep<T>({ value }: CloneDeepParams<T>): T
+
+Parameters:
+- value (T, required): The value to clone
+
+Returns: T — A deep clone of the input. The return type matches the input type.
+
+Example:
+const original = { a: { b: [1, 2] }, date: new Date() };
+const cloned = cloneDeep({ value: original });
+cloned.a.b.push(3);
+original.a.b; // [1, 2] — unaffected
+
+Primitives are returned as-is. Functions are copied by reference. Map values are deep cloned but keys are kept by reference. Circular references are detected via a WeakMap. Uses an iterative, stack-based algorithm to avoid stack overflow on deeply nested structures. Custom class prototype chains are not preserved.
+
+---
+
 ### deepMerge
 
 Recursively merge two objects into a new object. Nested plain objects are merged deeply; arrays and other types are overwritten.

--- a/llms.txt
+++ b/llms.txt
@@ -20,6 +20,7 @@
 
 ## Objects
 
+- [cloneDeep](https://pedrotroccoli.github.io/1o1-utils/objects/clone-deep/): Deep clone any value — handles objects, arrays, Date, RegExp, Map, Set, typed arrays, and circular references
 - [deepMerge](https://pedrotroccoli.github.io/1o1-utils/objects/deep-merge/): Recursively merge two objects without mutation
 - [isEmpty](https://pedrotroccoli.github.io/1o1-utils/objects/is-empty/): Check if a value is empty (strings, arrays, objects, Maps, Sets)
 - [omit](https://pedrotroccoli.github.io/1o1-utils/objects/omit/): Create an object with specified keys removed (supports dot notation)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
 			"import": "./dist/arrays/group-by/index.js",
 			"types": "./dist/arrays/group-by/index.d.ts"
 		},
+		"./clone-deep": {
+			"import": "./dist/objects/clone-deep/index.js",
+			"types": "./dist/objects/clone-deep/index.d.ts"
+		},
 		"./deep-merge": {
 			"import": "./dist/objects/deep-merge/index.js",
 			"types": "./dist/objects/deep-merge/index.d.ts"

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -83,6 +83,11 @@ interface SuiteResult {
 }
 
 const SUITE_META: Record<string, { slug: string; description: string }> = {
+  cloneDeep: {
+    slug: "clone-deep",
+    description:
+      "Creates a deep clone of a value. Handles objects, arrays, dates, regexes, maps, sets, typed arrays, and circular references. Compared against `lodash.cloneDeep`, `radash.clone`, and native `structuredClone`.\n\n> **Note:** `radash.clone` is **not a true deep clone** — nested objects, arrays, Maps, and Sets keep their original references. Its numbers are shown for reference only and are not comparable to the others.",
+  },
   chunk: {
     slug: "chunk",
     description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { debounce } from "./async/debounce/index.js";
 export { retry } from "./async/retry/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
+export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
 export { isEmpty } from "./objects/is-empty/index.js";
 export { omit } from "./objects/omit/index.js";

--- a/src/objects/clone-deep/index.bench.ts
+++ b/src/objects/clone-deep/index.bench.ts
@@ -1,0 +1,93 @@
+import lodashCloneDeep from "lodash/cloneDeep.js";
+import { clone as radashClone } from "radash";
+import { Bench } from "tinybench";
+import { cloneDeep } from "./index.js";
+
+const small = { a: 1, b: "hello", c: true, d: null };
+
+const deep = {
+  user: {
+    name: "Alice",
+    settings: {
+      theme: "dark",
+      notifications: { email: true, sms: false, push: { enabled: true } },
+    },
+    metadata: { created: "2024-01-01", tags: ["vip", "beta"] },
+  },
+  config: { debug: false, version: "1.0", features: { a: true, b: false } },
+};
+
+const mixed = {
+  date: new Date("2024-06-01"),
+  pattern: /test/gi,
+  map: new Map<string, unknown>([
+    ["a", { nested: [1, 2] }],
+    ["b", new Set([3, 4, 5])],
+  ]),
+  set: new Set([{ x: 1 }, { y: 2 }]),
+  buffer: new Uint8Array([10, 20, 30]),
+  nested: { deep: { value: 42 } },
+};
+
+const array1k = Array.from({ length: 1000 }, (_, i) => ({
+  id: i,
+  name: `item-${i}`,
+  active: i % 2 === 0,
+}));
+
+const bench = new Bench({ name: "cloneDeep", time: 1000 });
+
+bench
+  .add("1o1-utils (small)", () => {
+    cloneDeep({ value: small });
+  })
+  .add("lodash (small)", () => {
+    lodashCloneDeep(small);
+  })
+  .add("radash (small)", () => {
+    radashClone(small);
+  })
+  .add("structuredClone (small)", () => {
+    structuredClone(small);
+  });
+
+bench
+  .add("1o1-utils (deep)", () => {
+    cloneDeep({ value: deep });
+  })
+  .add("lodash (deep)", () => {
+    lodashCloneDeep(deep);
+  })
+  .add("radash (deep)", () => {
+    radashClone(deep);
+  })
+  .add("structuredClone (deep)", () => {
+    structuredClone(deep);
+  });
+
+bench
+  .add("1o1-utils (mixed)", () => {
+    cloneDeep({ value: mixed });
+  })
+  .add("lodash (mixed)", () => {
+    lodashCloneDeep(mixed);
+  })
+  .add("structuredClone (mixed)", () => {
+    structuredClone(mixed);
+  });
+
+bench
+  .add("1o1-utils (array-1k)", () => {
+    cloneDeep({ value: array1k });
+  })
+  .add("lodash (array-1k)", () => {
+    lodashCloneDeep(array1k);
+  })
+  .add("radash (array-1k)", () => {
+    radashClone(array1k);
+  })
+  .add("structuredClone (array-1k)", () => {
+    structuredClone(array1k);
+  });
+
+export { bench };

--- a/src/objects/clone-deep/index.spec.ts
+++ b/src/objects/clone-deep/index.spec.ts
@@ -1,0 +1,397 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { cloneDeep } from "./index.js";
+
+describe("cloneDeep", () => {
+  // --- Primitives (pass-through) ---
+
+  it("should return numbers as-is", () => {
+    expect(cloneDeep({ value: 42 })).to.equal(42);
+    expect(cloneDeep({ value: 0 })).to.equal(0);
+    expect(cloneDeep({ value: -1 })).to.equal(-1);
+    expect(cloneDeep({ value: Number.POSITIVE_INFINITY })).to.equal(
+      Number.POSITIVE_INFINITY,
+    );
+  });
+
+  it("should return strings as-is", () => {
+    expect(cloneDeep({ value: "hello" })).to.equal("hello");
+    expect(cloneDeep({ value: "" })).to.equal("");
+  });
+
+  it("should return booleans as-is", () => {
+    expect(cloneDeep({ value: true })).to.equal(true);
+    expect(cloneDeep({ value: false })).to.equal(false);
+  });
+
+  it("should return null as-is", () => {
+    expect(cloneDeep({ value: null })).to.equal(null);
+  });
+
+  it("should return undefined as-is", () => {
+    expect(cloneDeep({ value: undefined })).to.equal(undefined);
+  });
+
+  it("should return symbols as-is", () => {
+    const sym = Symbol.for("test");
+    expect(cloneDeep({ value: sym })).to.equal(sym);
+  });
+
+  it("should return bigints as-is", () => {
+    expect(cloneDeep({ value: BigInt(42) })).to.equal(BigInt(42));
+  });
+
+  // --- Plain objects ---
+
+  it("should clone a shallow object", () => {
+    const original = { a: 1, b: "hello", c: true };
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should clone a nested object", () => {
+    const original = { a: { b: { c: 1 } } };
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned.a).to.not.equal(original.a);
+    expect(cloned.a.b).to.not.equal(original.a.b);
+  });
+
+  it("should clone an empty object", () => {
+    const cloned = cloneDeep({ value: {} });
+    expect(cloned).to.deep.equal({});
+  });
+
+  it("should not mutate original when clone is modified", () => {
+    const original = { a: { b: [1, 2] } };
+    const cloned = cloneDeep({ value: original });
+
+    cloned.a.b.push(3);
+    expect(original.a.b).to.deep.equal([1, 2]);
+  });
+
+  it("should clone objects with null prototype", () => {
+    const original = Object.create(null) as Record<string, unknown>;
+    original.a = 1;
+    original.b = "hello";
+
+    const cloned = cloneDeep({ value: original }) as Record<string, unknown>;
+
+    expect(Object.getPrototypeOf(cloned)).to.equal(null);
+    expect(cloned.a).to.equal(1);
+    expect(cloned.b).to.equal("hello");
+  });
+
+  // --- Arrays ---
+
+  it("should clone a simple array", () => {
+    const original = [1, 2, 3];
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should clone an array of objects", () => {
+    const original = [{ a: 1 }, { b: 2 }];
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned[0]).to.not.equal(original[0]);
+    expect(cloned[1]).to.not.equal(original[1]);
+  });
+
+  it("should clone nested arrays", () => {
+    const original = [
+      [1, 2],
+      [3, [4, 5]],
+    ];
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned[1]).to.not.equal(original[1]);
+  });
+
+  it("should preserve sparse arrays", () => {
+    // biome-ignore lint/suspicious/noSparseArray: testing sparse arrays
+    const original = [1, , 3];
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.have.length(3);
+    expect(0 in cloned).to.be.true;
+    expect(1 in cloned).to.be.false;
+    expect(2 in cloned).to.be.true;
+  });
+
+  // --- Date ---
+
+  it("should clone a Date", () => {
+    const original = new Date("2024-01-15T10:30:00Z");
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Date);
+    expect(cloned.getTime()).to.equal(original.getTime());
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should not affect original when cloned Date is mutated", () => {
+    const original = new Date("2024-01-15");
+    const cloned = cloneDeep({ value: original });
+
+    cloned.setFullYear(2000);
+    expect(original.getFullYear()).to.equal(2024);
+  });
+
+  // --- RegExp ---
+
+  it("should clone a RegExp", () => {
+    const original = /foo/gi;
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(RegExp);
+    expect(cloned.source).to.equal("foo");
+    expect(cloned.flags).to.equal("gi");
+    expect(cloned).to.not.equal(original);
+  });
+
+  // --- Map ---
+
+  it("should clone a Map", () => {
+    const original = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Map);
+    expect(cloned.size).to.equal(2);
+    expect(cloned.get("a")).to.equal(1);
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should deep clone Map object values", () => {
+    const inner = { x: 1 };
+    const original = new Map([["key", inner]]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned.get("key")).to.deep.equal(inner);
+    expect(cloned.get("key")).to.not.equal(inner);
+  });
+
+  it("should keep Map object keys by reference", () => {
+    const key = { id: 1 };
+    const original = new Map([[key, "value"]]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned.has(key)).to.be.true;
+  });
+
+  // --- Set ---
+
+  it("should clone a Set", () => {
+    const original = new Set([1, 2, 3]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Set);
+    expect(cloned.size).to.equal(3);
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should deep clone Set object values", () => {
+    const obj = { a: 1 };
+    const original = new Set([obj]);
+    const cloned = cloneDeep({ value: original });
+
+    const clonedObj = [...cloned][0];
+    expect(clonedObj).to.deep.equal(obj);
+    expect(clonedObj).to.not.equal(obj);
+  });
+
+  // --- TypedArrays ---
+
+  it("should clone a Uint8Array", () => {
+    const original = new Uint8Array([1, 2, 3]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Uint8Array);
+    expect([...cloned]).to.deep.equal([1, 2, 3]);
+    expect(cloned.buffer).to.not.equal(original.buffer);
+  });
+
+  it("should clone a Float64Array", () => {
+    const original = new Float64Array([1.1, 2.2]);
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Float64Array);
+    expect([...cloned]).to.deep.equal([1.1, 2.2]);
+    expect(cloned.buffer).to.not.equal(original.buffer);
+  });
+
+  it("should not affect original when cloned TypedArray is modified", () => {
+    const original = new Uint8Array([10, 20, 30]);
+    const cloned = cloneDeep({ value: original });
+
+    cloned[0] = 99;
+    expect(original[0]).to.equal(10);
+  });
+
+  // --- ArrayBuffer ---
+
+  it("should clone an ArrayBuffer", () => {
+    const original = new ArrayBuffer(8);
+    const view = new Uint8Array(original);
+    view[0] = 42;
+
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(ArrayBuffer);
+    expect(cloned.byteLength).to.equal(8);
+    expect(cloned).to.not.equal(original);
+    expect(new Uint8Array(cloned)[0]).to.equal(42);
+  });
+
+  // --- Error ---
+
+  it("should clone an Error", () => {
+    const original = new Error("test error");
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(Error);
+    expect(cloned.message).to.equal("test error");
+    expect(cloned.stack).to.equal(original.stack);
+    expect(cloned).to.not.equal(original);
+  });
+
+  it("should clone Error subclasses", () => {
+    const original = new TypeError("bad type");
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.be.instanceOf(TypeError);
+    expect(cloned.message).to.equal("bad type");
+  });
+
+  it("should clone Error with custom properties", () => {
+    const original = new Error("fail");
+    (original as Error & { code: number }).code = 404;
+
+    const cloned = cloneDeep({ value: original }) as Error & { code: number };
+
+    expect(cloned.message).to.equal("fail");
+    expect(cloned.code).to.equal(404);
+  });
+
+  // --- Circular references ---
+
+  it("should handle self-referencing objects", () => {
+    const original: Record<string, unknown> = { a: 1 };
+    original.self = original;
+
+    const cloned = cloneDeep({ value: original }) as Record<string, unknown>;
+
+    expect(cloned.a).to.equal(1);
+    expect(cloned.self).to.equal(cloned);
+    expect(cloned.self).to.not.equal(original);
+  });
+
+  it("should handle mutually referencing objects", () => {
+    const a: Record<string, unknown> = { name: "a" };
+    const b: Record<string, unknown> = { name: "b" };
+    a.ref = b;
+    b.ref = a;
+
+    const cloned = cloneDeep({ value: a }) as Record<string, unknown>;
+    const clonedB = cloned.ref as Record<string, unknown>;
+
+    expect(cloned.name).to.equal("a");
+    expect(clonedB.name).to.equal("b");
+    expect(clonedB.ref).to.equal(cloned);
+    expect(clonedB).to.not.equal(b);
+  });
+
+  it("should handle arrays containing themselves", () => {
+    const original: unknown[] = [1, 2];
+    original.push(original);
+
+    const cloned = cloneDeep({ value: original }) as unknown[];
+
+    expect(cloned[0]).to.equal(1);
+    expect(cloned[1]).to.equal(2);
+    expect(cloned[2]).to.equal(cloned);
+    expect(cloned[2]).to.not.equal(original);
+  });
+
+  it("should handle nested circular references", () => {
+    const original: Record<string, unknown> = {
+      child: { value: 1 } as Record<string, unknown>,
+    };
+    (original.child as Record<string, unknown>).parent = original;
+
+    const cloned = cloneDeep({ value: original }) as Record<string, unknown>;
+    const clonedChild = cloned.child as Record<string, unknown>;
+
+    expect(clonedChild.value).to.equal(1);
+    expect(clonedChild.parent).to.equal(cloned);
+  });
+
+  // --- Functions ---
+
+  it("should copy functions by reference", () => {
+    const fn = () => 42;
+    const original = { callback: fn };
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned.callback).to.equal(fn);
+  });
+
+  // --- Deep nesting (stack overflow protection) ---
+
+  it("should handle deeply nested structures without stack overflow", () => {
+    let original: Record<string, unknown> = { value: "leaf" };
+    for (let i = 0; i < 10_000; i++) {
+      original = { child: original };
+    }
+
+    const cloned = cloneDeep({ value: original });
+
+    let node = cloned as Record<string, unknown>;
+    for (let i = 0; i < 10_000; i++) {
+      node = node.child as Record<string, unknown>;
+    }
+    expect(node.value).to.equal("leaf");
+  });
+
+  // --- Mixed structures ---
+
+  it("should clone a complex mixed structure", () => {
+    const original = {
+      name: "test",
+      tags: [1, "two", { three: 3 }],
+      date: new Date("2024-06-01"),
+      pattern: /abc/i,
+      metadata: new Map<string, unknown>([["key", { nested: true }]]),
+      ids: new Set([1, 2, 3]),
+      buffer: new Uint8Array([10, 20]),
+      nested: {
+        deep: {
+          value: 42,
+        },
+      },
+    };
+
+    const cloned = cloneDeep({ value: original });
+
+    expect(cloned).to.deep.equal(original);
+    expect(cloned).to.not.equal(original);
+    expect(cloned.tags).to.not.equal(original.tags);
+    expect(cloned.tags[2]).to.not.equal(original.tags[2]);
+    expect(cloned.date).to.not.equal(original.date);
+    expect(cloned.pattern).to.not.equal(original.pattern);
+    expect(cloned.metadata).to.not.equal(original.metadata);
+    expect(cloned.ids).to.not.equal(original.ids);
+    expect(cloned.buffer).to.not.equal(original.buffer);
+    expect(cloned.nested.deep).to.not.equal(original.nested.deep);
+  });
+});

--- a/src/objects/clone-deep/index.ts
+++ b/src/objects/clone-deep/index.ts
@@ -1,0 +1,129 @@
+import type { CloneDeepParams, CloneDeepResult } from "./types.js";
+
+function createShallowClone(value: object): unknown {
+  if (Array.isArray(value)) return new Array(value.length);
+  if (value instanceof Date) return new Date(value.getTime());
+  if (value instanceof RegExp) return new RegExp(value.source, value.flags);
+  if (value instanceof Map) return new Map();
+  if (value instanceof Set) return new Set();
+  if (value instanceof Error) {
+    const err = new (value.constructor as ErrorConstructor)(value.message);
+    err.stack = value.stack;
+    return err;
+  }
+  if (value instanceof ArrayBuffer) return value.slice(0);
+  if (ArrayBuffer.isView(value)) {
+    const ta = value as {
+      constructor: new (buffer: ArrayBuffer) => ArrayBufferView;
+      buffer: ArrayBuffer;
+      byteOffset: number;
+      byteLength: number;
+    };
+    return new ta.constructor(
+      ta.buffer.slice(ta.byteOffset, ta.byteOffset + ta.byteLength),
+    );
+  }
+  if (Object.getPrototypeOf(value) === null) return Object.create(null);
+  return {};
+}
+
+function isLeaf(value: object): boolean {
+  return (
+    value instanceof Date ||
+    value instanceof RegExp ||
+    value instanceof ArrayBuffer ||
+    ArrayBuffer.isView(value)
+  );
+}
+
+function processValue(
+  val: unknown,
+  seen: WeakMap<object, object>,
+  stack: { source: object; clone: object }[],
+): unknown {
+  if (val === null || typeof val !== "object") return val;
+  const obj = val as object;
+  if (seen.has(obj)) return seen.get(obj);
+  const cloned = createShallowClone(obj);
+  seen.set(obj, cloned as object);
+  if (!isLeaf(obj)) {
+    stack.push({ source: obj, clone: cloned as object });
+  }
+  return cloned;
+}
+
+/**
+ * Creates a deep clone of a value.
+ *
+ * Handles plain objects, arrays, dates, regexes, maps, sets, typed arrays,
+ * array buffers, errors, and circular references. Functions are copied by reference.
+ *
+ * @param params - The parameters object
+ * @param params.value - The value to deep clone
+ * @returns A deep clone of the value
+ *
+ * @example
+ * ```ts
+ * const original = { a: { b: [1, 2] }, date: new Date() };
+ * const cloned = cloneDeep({ value: original });
+ *
+ * cloned.a.b.push(3);
+ * original.a.b; // [1, 2] — unaffected
+ * ```
+ *
+ * @keywords deep clone, deep copy, clone object, copy object, structuredClone alternative
+ *
+ * @see structuredClone - native alternative that fails on classes, functions, and DOM nodes
+ */
+function cloneDeep<T>({ value }: CloneDeepParams<T>): CloneDeepResult<T> {
+  if (value === null || typeof value !== "object") return value;
+
+  const seen = new WeakMap<object, object>();
+  const root = createShallowClone(value as object);
+  seen.set(value as object, root as object);
+
+  if (isLeaf(value as object)) return root as T;
+
+  const stack: { source: object; clone: object }[] = [
+    { source: value as object, clone: root as object },
+  ];
+
+  while (stack.length > 0) {
+    const item = stack.pop();
+    if (!item) break;
+    const { source, clone } = item;
+
+    if (source instanceof Map) {
+      const cloneMap = clone as Map<unknown, unknown>;
+      for (const [key, val] of source) {
+        cloneMap.set(key, processValue(val, seen, stack));
+      }
+    } else if (source instanceof Set) {
+      const cloneSet = clone as Set<unknown>;
+      for (const val of source) {
+        cloneSet.add(processValue(val, seen, stack));
+      }
+    } else if (Array.isArray(source)) {
+      const cloneArr = clone as unknown[];
+      for (let i = 0; i < source.length; i++) {
+        if (!(i in source)) continue;
+        cloneArr[i] = processValue(source[i], seen, stack);
+      }
+    } else {
+      const cloneObj = clone as Record<string, unknown>;
+      const keys = Object.keys(source);
+      for (let i = 0; i < keys.length; i++) {
+        const key = keys[i];
+        cloneObj[key] = processValue(
+          (source as Record<string, unknown>)[key],
+          seen,
+          stack,
+        );
+      }
+    }
+  }
+
+  return root as T;
+}
+
+export { cloneDeep };

--- a/src/objects/clone-deep/types.ts
+++ b/src/objects/clone-deep/types.ts
@@ -1,0 +1,9 @@
+interface CloneDeepParams<T = unknown> {
+  value: T;
+}
+
+type CloneDeepResult<T = unknown> = T;
+
+type CloneDeepFn = <T>(params: CloneDeepParams<T>) => CloneDeepResult<T>;
+
+export type { CloneDeepFn, CloneDeepParams, CloneDeepResult };

--- a/website/src/content/docs/objects/clone-deep.mdx
+++ b/website/src/content/docs/objects/clone-deep.mdx
@@ -1,0 +1,85 @@
+---
+title: cloneDeep
+description: Create a deep clone of a value
+---
+
+Creates a deep clone of any value. Handles plain objects, arrays, `Date`, `RegExp`, `Map`, `Set`, typed arrays, `ArrayBuffer`, `Error`, and circular references. Functions are copied by reference.
+
+Native `structuredClone` is a close alternative but throws on functions, class instances, and DOM nodes. `cloneDeep` covers those gaps and is 2–4× faster than `lodash.cloneDeep`.
+
+:::note[About `radash.clone`]
+`radash.clone` appears faster in benchmarks, but it is **not a true deep clone** — nested objects, arrays, Maps, and Sets keep their original references. It is a shallow-ish copy and not comparable to `cloneDeep`, `lodash.cloneDeep`, or `structuredClone`. If you mutate a nested value on a `radash.clone` result, the original mutates too.
+:::
+
+## Import
+
+```ts
+import { cloneDeep } from "1o1-utils";
+```
+
+```ts
+import { cloneDeep } from "1o1-utils/clone-deep";
+```
+
+## Signature
+
+```ts
+function cloneDeep<T>({ value }: CloneDeepParams<T>): T
+```
+
+## Parameters
+
+| Name    | Type | Required | Description           |
+| ------- | ---- | -------- | --------------------- |
+| `value` | `T`  | Yes      | The value to clone    |
+
+## Returns
+
+`T` — A deep clone of the input. The return type matches the input type.
+
+## Examples
+
+```ts
+const original = { a: { b: [1, 2] }, date: new Date() };
+const cloned = cloneDeep({ value: original });
+
+cloned.a.b.push(3);
+original.a.b; // [1, 2] — unaffected
+```
+
+```ts
+// Circular references are handled
+const node: Record<string, unknown> = { name: "root" };
+node.self = node;
+
+const clone = cloneDeep({ value: node });
+clone.self === clone; // true
+clone.self === node;  // false
+```
+
+```ts
+// Built-in types are preserved
+cloneDeep({ value: new Date("2024-06-01") });       // new Date instance
+cloneDeep({ value: /foo/gi });                      // new RegExp instance
+cloneDeep({ value: new Map([["key", { x: 1 }]]) }); // new Map, values deep cloned
+cloneDeep({ value: new Uint8Array([1, 2, 3]) });    // new TypedArray with independent buffer
+```
+
+## Edge Cases
+
+- Primitives (numbers, strings, booleans, `null`, `undefined`, symbols, bigints) are returned as-is.
+- Functions are copied by reference — not cloned.
+- `Map` values are deep cloned; `Map` keys are kept by reference (so lookups by object keys still work).
+- `Set` object values are deep cloned.
+- Typed arrays clone only the viewed portion of the underlying buffer (respects `byteOffset`/`byteLength`).
+- Circular references are detected via a `WeakMap`; the clone preserves the same cycle structure.
+- Uses an iterative, stack-based algorithm to avoid stack overflow on deeply nested structures.
+- Custom class prototype chains are **not** preserved — cloned objects become plain objects. Use `structuredClone` if you need prototype preservation for serializable classes.
+
+## Also known as
+
+deep clone, deep copy, clone object, copy object, structuredClone alternative
+
+## Prompt suggestion
+
+> `Show me how to use cloneDeep from 1o1-utils to snapshot nested state before mutating it`


### PR DESCRIPTION
## Summary

Adds `cloneDeep` — a deep clone utility that handles plain objects, arrays, `Date`, `RegExp`, `Map`, `Set`, typed arrays, `ArrayBuffer`, `Error`, and circular references. Functions are copied by reference (covers the gap left by `structuredClone`, which throws on them).

- Iterative stack-based algorithm with a `WeakMap` for circular reference detection — no stack overflow on deeply nested structures
- 529 B gzipped (limit: 2 kB)
- Benchmarks: **2.6–4.1× faster than lodash** and **2.6–6.7× faster than native `structuredClone`** across small/deep/mixed/1k-array scenarios
- 38 new tests, all 230 tests passing

Closes #71

## Notes

- `radash.clone` appears faster in benchmarks but is **not a true deep clone** — it keeps nested references intact. Disclaimers were added in both the website doc and the generated benchmark doc to clarify this.

## Test plan

- [x] `pnpm test` — 230 passing
- [x] `pnpm build` — clean
- [x] `pnpm check` — no new warnings
- [x] `pnpm size` — clone-deep at 529 B (under 2 kB limit)
- [x] `pnpm bench clone-deep` — benchmarks run and generate markdown