### PR TITLE
feat(objects): add defaults and defaultsDeep utilities

### DIFF
--- a/.changeset/add-defaults-and-defaults-deep.md
+++ b/.changeset/add-defaults-and-defaults-deep.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `defaults` and `defaultsDeep` utilities for filling `undefined` properties with fallback values. `defaults` handles shallow objects; `defaultsDeep` recurses into nested plain objects while preserving arrays and other non-plain values in the target.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -41,6 +41,16 @@
     "limit": "2 kB"
   },
   {
+    "name": "defaults",
+    "path": "dist/objects/defaults/index.js",
+    "limit": "1 kB"
+  },
+  {
+    "name": "defaults-deep",
+    "path": "dist/objects/defaults-deep/index.js",
+    "limit": "2 kB"
+  },
+  {
     "name": "is-empty",
     "path": "dist/objects/is-empty/index.js",
     "limit": "1 kB"

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -10,6 +10,8 @@ Run `pnpm bench` to reproduce these results locally.
 
 - [arrayToHash / keyBy](./array-to-hash.md) — on par with lodash
 - [chunk](./chunk.md) — **1.4–11.4× faster** than lodash
+- [defaults](./defaults.md) — **1.5–1.8× faster** than lodash
+- [defaultsDeep](./defaults-deep.md) — **3.7–5.9× faster** than lodash
 - [groupBy](./group-by.md) — **1.2× faster** than lodash
 - [unique (by key)](./unique.md) — **2.7× faster** than lodash
 - [pick](./pick.md) — **2.6–4.0× faster** than lodash
@@ -22,6 +24,8 @@ Run `pnpm bench` to reproduce these results locally.
 | ------- | --------- | --------- | --------- |
 | arrayToHash / keyBy | on par | on par | on par |
 | chunk | **4.9× faster** | on par | on par |
+| defaults | **1.6× faster** | — | **2.1× faster** |
+| defaultsDeep | **4.8× faster** | — | — |
 | groupBy | **1.3× faster** | on par | 1.1× slower |
 | unique (by key) | **2.7× faster** | **1.6× faster** | on par |
 | pick | **3.3× faster** | on par | — |

--- a/docs/benchmarks/defaults-deep.md
+++ b/docs/benchmarks/defaults-deep.md
@@ -1,0 +1,19 @@
+# defaultsDeep
+
+[← Back to benchmarks](./README.md)
+
+Recursively fills `undefined` properties in the target with values from the source. Arrays and non-plain-object values in the target are preserved. Compared against `lodash.defaultsDeep`.
+
+---
+
+| Size | 1o1-utils | lodash | Fastest |
+| ------ | ------ | ------ | ------ |
+| small | 125ns · 8.0M ops/s | 458ns · 2.2M ops/s | 1o1-utils · 3.7× faster vs lodash |
+| deep | 667ns · 1.5M ops/s | 3.9µs · 255.3K ops/s | 1o1-utils · 5.9× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "defaultsDeep — ops/s at deep items"
+  x-axis ["1o1-utils", "lodash"]
+  bar [1499250, 255297]
+```

--- a/docs/benchmarks/defaults.md
+++ b/docs/benchmarks/defaults.md
@@ -1,0 +1,19 @@
+# defaults
+
+[← Back to benchmarks](./README.md)
+
+Fills `undefined` properties in the target with values from the source. Existing `null`, `0`, `""`, and `false` values are preserved. Compared against `lodash.defaults` and a native `Object.assign` spread.
+
+---
+
+| Size | 1o1-utils | lodash | native | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| small | 167ns · 6.0M ops/s | 292ns · 3.4M ops/s | 84ns · 11.9M ops/s | native · 3.5× faster vs lodash |
+| wide | 3.8µs · 263.7K ops/s | 5.5µs · 180.5K ops/s | 14.3µs · 70.0K ops/s | 1o1-utils · 1.5× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "defaults — ops/s at wide items"
+  x-axis ["1o1-utils", "lodash", "native"]
+  bar [263713, 180473, 69969]
+```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -203,6 +203,66 @@ Uses a stack-based (non-recursive) algorithm to avoid stack overflow on deeply n
 
 ---
 
+### defaults
+
+Fill `undefined` (or missing) properties in target with values from source. Existing defined values — including `null`, `0`, `""`, and `false` — are preserved. Only shallow; for nested objects use `defaultsDeep`.
+
+Import: import { defaults } from "1o1-utils/defaults";
+
+Signature:
+function defaults({ target, source }: DefaultsParams): Record<string, unknown>
+
+Parameters:
+- target (Record<string, unknown>, required): The base object whose defined values win
+- source (Record<string, unknown>, required): The object supplying defaults for missing keys
+
+Returns: Record<string, unknown> — A new object (neither input is mutated).
+
+Example:
+defaults({
+  target: { a: 1 },
+  source: { a: 99, b: 2 },
+});
+// => { a: 1, b: 2 }
+
+defaults({
+  target: { a: null, b: 0, c: "" },
+  source: { a: 1, b: 99, c: "fallback", d: 4 },
+});
+// => { a: null, b: 0, c: "", d: 4 }
+
+Throws: Error if target is not a plain object. Error if source is not a plain object.
+Only `undefined` (or missing) keys are replaced — other falsy values are preserved.
+
+---
+
+### defaultsDeep
+
+Recursively fill `undefined` (or missing) properties in target with values from source. When both sides have plain objects at the same key, they are merged recursively. Arrays in target are preserved (not merged with source arrays).
+
+Import: import { defaultsDeep } from "1o1-utils/defaults-deep";
+
+Signature:
+function defaultsDeep({ target, source }: DefaultsDeepParams): Record<string, unknown>
+
+Parameters:
+- target (Record<string, unknown>, required): The base object whose defined values win
+- source (Record<string, unknown>, required): The object supplying defaults for missing keys
+
+Returns: Record<string, unknown> — A new object (neither input is mutated).
+
+Example:
+defaultsDeep({
+  target: { db: { port: 5432 } },
+  source: { db: { port: 3306, host: "localhost" }, debug: false },
+});
+// => { db: { port: 5432, host: "localhost" }, debug: false }
+
+Throws: Error if target is not a plain object. Error if source is not a plain object.
+Uses a stack-based (non-recursive) algorithm. Arrays and non-plain-object values in target are treated as leaves — not merged.
+
+---
+
 ### isEmpty
 
 Check whether a given value is considered empty. Supports strings, arrays, plain objects, Maps, and Sets.

--- a/llms.txt
+++ b/llms.txt
@@ -22,6 +22,8 @@
 
 - [cloneDeep](https://pedrotroccoli.github.io/1o1-utils/objects/clone-deep/): Deep clone any value — handles objects, arrays, Date, RegExp, Map, Set, typed arrays, and circular references
 - [deepMerge](https://pedrotroccoli.github.io/1o1-utils/objects/deep-merge/): Recursively merge two objects without mutation
+- [defaults](https://pedrotroccoli.github.io/1o1-utils/objects/defaults/): Fill `undefined` properties with defaults from another object
+- [defaultsDeep](https://pedrotroccoli.github.io/1o1-utils/objects/defaults-deep/): Recursively fill `undefined` properties with defaults from another object
 - [isEmpty](https://pedrotroccoli.github.io/1o1-utils/objects/is-empty/): Check if a value is empty (strings, arrays, objects, Maps, Sets)
 - [omit](https://pedrotroccoli.github.io/1o1-utils/objects/omit/): Create an object with specified keys removed (supports dot notation)
 - [pick](https://pedrotroccoli.github.io/1o1-utils/objects/pick/): Create an object with only the specified keys (supports dot notation)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,14 @@
 			"import": "./dist/objects/deep-merge/index.js",
 			"types": "./dist/objects/deep-merge/index.d.ts"
 		},
+		"./defaults": {
+			"import": "./dist/objects/defaults/index.js",
+			"types": "./dist/objects/defaults/index.d.ts"
+		},
+		"./defaults-deep": {
+			"import": "./dist/objects/defaults-deep/index.js",
+			"types": "./dist/objects/defaults-deep/index.d.ts"
+		},
 		"./omit": {
 			"import": "./dist/objects/omit/index.js",
 			"types": "./dist/objects/omit/index.d.ts"

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -153,6 +153,16 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Limits function execution to once per specified time window. Compared against `lodash.throttle`.",
   },
+  defaults: {
+    slug: "defaults",
+    description:
+      'Fills `undefined` properties in the target with values from the source. Existing `null`, `0`, `""`, and `false` values are preserved. Compared against `lodash.defaults` and a native `Object.assign` spread.',
+  },
+  defaultsDeep: {
+    slug: "defaults-deep",
+    description:
+      "Recursively fills `undefined` properties in the target with values from the source. Arrays and non-plain-object values in the target are preserved. Compared against `lodash.defaultsDeep`.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,8 @@ export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
+export { defaults } from "./objects/defaults/index.js";
+export { defaultsDeep } from "./objects/defaults-deep/index.js";
 export { isEmpty } from "./objects/is-empty/index.js";
 export { omit } from "./objects/omit/index.js";
 export { pick } from "./objects/pick/index.js";

--- a/src/objects/defaults-deep/index.bench.ts
+++ b/src/objects/defaults-deep/index.bench.ts
@@ -1,0 +1,43 @@
+import lodashDefaultsDeep from "lodash/defaultsDeep.js";
+import { Bench } from "tinybench";
+import { defaultsDeep } from "./index.js";
+
+const smallTarget = { a: 1, b: "hello", c: true };
+const smallSource = { b: "world", d: 42 };
+
+const deepTarget = {
+  user: {
+    name: "Alice",
+    settings: { theme: "dark", notifications: { email: true } },
+    metadata: { created: "2024-01-01" },
+  },
+  config: { debug: false },
+};
+
+const deepSource = {
+  user: {
+    settings: { notifications: { sms: false, push: true }, lang: "pt" },
+    metadata: { tags: ["beta"], updated: "2024-06-01" },
+  },
+  config: { version: "1.0", env: "prod" },
+};
+
+const bench = new Bench({ name: "defaultsDeep", time: 1000 });
+
+bench
+  .add("1o1-utils (small)", () => {
+    defaultsDeep({ target: smallTarget, source: smallSource });
+  })
+  .add("lodash (small)", () => {
+    lodashDefaultsDeep({}, smallTarget, smallSource);
+  });
+
+bench
+  .add("1o1-utils (deep)", () => {
+    defaultsDeep({ target: deepTarget, source: deepSource });
+  })
+  .add("lodash (deep)", () => {
+    lodashDefaultsDeep({}, deepTarget, deepSource);
+  });
+
+export { bench };

--- a/src/objects/defaults-deep/index.spec.ts
+++ b/src/objects/defaults-deep/index.spec.ts
@@ -1,0 +1,179 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { defaultsDeep } from "./index.js";
+
+describe("defaultsDeep", () => {
+  it("should fill missing top-level keys from source", () => {
+    const result = defaultsDeep({
+      target: { a: 1 },
+      source: { a: 99, b: 2 },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should fill missing nested keys recursively", () => {
+    const result = defaultsDeep({
+      target: { db: { port: 5432 } },
+      source: { db: { port: 3306, host: "localhost" }, debug: false },
+    });
+
+    expect(result).to.deep.equal({
+      db: { port: 5432, host: "localhost" },
+      debug: false,
+    });
+  });
+
+  it("should merge deeply nested objects (3+ levels)", () => {
+    const result = defaultsDeep({
+      target: { a: { b: { c: { d: 1 } } } },
+      source: { a: { b: { c: { e: 2 }, f: 3 }, g: 4 }, h: 5 },
+    });
+
+    expect(result).to.deep.equal({
+      a: { b: { c: { d: 1, e: 2 }, f: 3 }, g: 4 },
+      h: 5,
+    });
+  });
+
+  it("should preserve null values in target", () => {
+    const result = defaultsDeep({
+      target: { a: null },
+      source: { a: 1 },
+    });
+
+    expect(result).to.deep.equal({ a: null });
+  });
+
+  it("should preserve falsy values (0, '', false) in target", () => {
+    const result = defaultsDeep({
+      target: { a: 0, b: "", c: false },
+      source: { a: 1, b: "fallback", c: true },
+    });
+
+    expect(result).to.deep.equal({ a: 0, b: "", c: false });
+  });
+
+  it("should replace undefined values with source values", () => {
+    const result = defaultsDeep({
+      target: { a: undefined, b: 2 },
+      source: { a: { nested: true }, b: 99 },
+    });
+
+    expect(result).to.deep.equal({ a: { nested: true }, b: 2 });
+  });
+
+  it("should preserve target arrays (not merge with source arrays)", () => {
+    const result = defaultsDeep({
+      target: { tags: [1, 2] },
+      source: { tags: [3, 4, 5] },
+    });
+
+    expect(result).to.deep.equal({ tags: [1, 2] });
+  });
+
+  it("should use source array when target key is undefined", () => {
+    const result = defaultsDeep({
+      target: {},
+      source: { tags: [1, 2, 3] },
+    });
+
+    expect(result).to.deep.equal({ tags: [1, 2, 3] });
+  });
+
+  it("should preserve primitive target when source has an object", () => {
+    const result = defaultsDeep({
+      target: { a: "flat" },
+      source: { a: { nested: true } },
+    });
+
+    expect(result).to.deep.equal({ a: "flat" });
+  });
+
+  it("should preserve object target when source has a primitive", () => {
+    const result = defaultsDeep({
+      target: { a: { b: 1 } },
+      source: { a: "flat" },
+    });
+
+    expect(result).to.deep.equal({ a: { b: 1 } });
+  });
+
+  it("should handle empty target", () => {
+    const result = defaultsDeep({
+      target: {},
+      source: { a: 1, b: { c: 2 } },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: { c: 2 } });
+  });
+
+  it("should handle empty source", () => {
+    const result = defaultsDeep({
+      target: { a: 1, b: { c: 2 } },
+      source: {},
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: { c: 2 } });
+  });
+
+  it("should handle both empty objects", () => {
+    const result = defaultsDeep({ target: {}, source: {} });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should not mutate the inputs", () => {
+    const target = { db: { port: 5432 } };
+    const source = { db: { port: 3306, host: "localhost" } };
+    const result = defaultsDeep({ target, source });
+
+    expect(result).to.not.equal(target);
+    expect(result.db).to.not.equal(target.db);
+    expect(target).to.deep.equal({ db: { port: 5432 } });
+    expect(source).to.deep.equal({ db: { port: 3306, host: "localhost" } });
+  });
+
+  it("should not mutate nested source objects when copied", () => {
+    const source = { a: { b: { c: 1 } } };
+    const result = defaultsDeep({ target: {}, source });
+
+    // nested source objects are copied by reference when target lacks the key
+    expect(result.a).to.equal(source.a);
+  });
+
+  it("should throw if target is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaultsDeep({ target: "string", source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if target is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaultsDeep({ target: null, source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if target is an array", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaultsDeep({ target: [1, 2], source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if source is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaultsDeep({ target: {}, source: 42 })).to.throw(
+      "The 'source' parameter is not an object",
+    );
+  });
+
+  it("should throw if source is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaultsDeep({ target: {}, source: null })).to.throw(
+      "The 'source' parameter is not an object",
+    );
+  });
+});

--- a/src/objects/defaults-deep/index.ts
+++ b/src/objects/defaults-deep/index.ts
@@ -1,0 +1,77 @@
+import type { DefaultsDeepParams, DefaultsDeepResult } from "./types.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && value.constructor === Object
+  );
+}
+
+/**
+ * Recursively assigns default values from `source` to `target`. For each
+ * property, if the target's value is `undefined` (or the key is missing), the
+ * source's value is used. When both target and source have plain objects at
+ * the same key, they are merged recursively. Existing `null`, `0`, `""`,
+ * `false`, and array values in the target are preserved.
+ *
+ * @param params - The parameters object
+ * @param params.target - The base object whose defined values win
+ * @param params.source - The object supplying defaults for missing keys
+ * @returns A new object (inputs are not mutated)
+ *
+ * @example
+ * ```ts
+ * defaultsDeep({
+ *   target: { db: { port: 5432 } },
+ *   source: { db: { port: 3306, host: "localhost" }, debug: false },
+ * });
+ * // => { db: { port: 5432, host: "localhost" }, debug: false }
+ * ```
+ *
+ * @keywords deep defaults, nested defaults, fill undefined recursive, fallback object deep
+ *
+ * @see lodash/defaultsDeep — semantic reference (https://lodash.com/docs/#defaultsDeep)
+ *
+ * @throws Error if `target` is not a plain object
+ * @throws Error if `source` is not a plain object
+ */
+function defaultsDeep({
+  target,
+  source,
+}: DefaultsDeepParams): DefaultsDeepResult {
+  if (!isPlainObject(target)) {
+    throw new Error("The 'target' parameter is not an object");
+  }
+
+  if (!isPlainObject(source)) {
+    throw new Error("The 'source' parameter is not an object");
+  }
+
+  const result = Object.assign({}, target);
+
+  const stack: [Record<string, unknown>, Record<string, unknown>][] = [
+    [result, source],
+  ];
+
+  while (stack.length > 0) {
+    const [tgt, src] = stack.pop()!;
+    const sourceKeys = Object.keys(src);
+
+    for (let i = 0; i < sourceKeys.length; i++) {
+      const key = sourceKeys[i];
+      const sourceVal = src[key];
+      const targetVal = tgt[key];
+
+      if (targetVal === undefined) {
+        tgt[key] = sourceVal;
+      } else if (isPlainObject(targetVal) && isPlainObject(sourceVal)) {
+        const copied = Object.assign({}, targetVal);
+        tgt[key] = copied;
+        stack.push([copied, sourceVal]);
+      }
+    }
+  }
+
+  return result;
+}
+
+export { defaultsDeep };

--- a/src/objects/defaults-deep/types.ts
+++ b/src/objects/defaults-deep/types.ts
@@ -1,0 +1,10 @@
+interface DefaultsDeepParams {
+  target: Record<string, unknown>;
+  source: Record<string, unknown>;
+}
+
+type DefaultsDeepResult = Record<string, unknown>;
+
+type DefaultsDeepFn = (params: DefaultsDeepParams) => DefaultsDeepResult;
+
+export type { DefaultsDeepFn, DefaultsDeepParams, DefaultsDeepResult };

--- a/src/objects/defaults/index.bench.ts
+++ b/src/objects/defaults/index.bench.ts
@@ -1,0 +1,39 @@
+import lodashDefaults from "lodash/defaults.js";
+import { Bench } from "tinybench";
+import { defaults } from "./index.js";
+
+const smallTarget = { a: 1, b: "hello", c: true };
+const smallSource = { b: "world", d: 42, e: null };
+
+const wideTarget: Record<string, unknown> = {};
+const wideSource: Record<string, unknown> = {};
+for (let i = 0; i < 50; i++) {
+  if (i % 2 === 0) wideTarget[`k${i}`] = i;
+  wideSource[`k${i}`] = `default-${i}`;
+}
+
+const bench = new Bench({ name: "defaults", time: 1000 });
+
+bench
+  .add("1o1-utils (small)", () => {
+    defaults({ target: smallTarget, source: smallSource });
+  })
+  .add("lodash (small)", () => {
+    lodashDefaults({}, smallTarget, smallSource);
+  })
+  .add("native (small)", () => {
+    Object.assign({}, smallSource, smallTarget);
+  });
+
+bench
+  .add("1o1-utils (wide)", () => {
+    defaults({ target: wideTarget, source: wideSource });
+  })
+  .add("lodash (wide)", () => {
+    lodashDefaults({}, wideTarget, wideSource);
+  })
+  .add("native (wide)", () => {
+    Object.assign({}, wideSource, wideTarget);
+  });
+
+export { bench };

--- a/src/objects/defaults/index.spec.ts
+++ b/src/objects/defaults/index.spec.ts
@@ -1,0 +1,130 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { defaults } from "./index.js";
+
+describe("defaults", () => {
+  it("should fill missing keys from source", () => {
+    const result = defaults({
+      target: { a: 1 },
+      source: { a: 99, b: 2 },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should preserve existing values in target", () => {
+    const result = defaults({
+      target: { a: 1, b: "hello" },
+      source: { a: 99, b: "world", c: 3 },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: "hello", c: 3 });
+  });
+
+  it("should replace undefined values with source values", () => {
+    const result = defaults({
+      target: { a: undefined, b: 2 },
+      source: { a: 1, b: 99 },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should preserve null values in target", () => {
+    const result = defaults({
+      target: { a: null },
+      source: { a: 1 },
+    });
+
+    expect(result).to.deep.equal({ a: null });
+  });
+
+  it("should preserve falsy values (0, '', false) in target", () => {
+    const result = defaults({
+      target: { a: 0, b: "", c: false },
+      source: { a: 1, b: "fallback", c: true },
+    });
+
+    expect(result).to.deep.equal({ a: 0, b: "", c: false });
+  });
+
+  it("should handle empty target", () => {
+    const result = defaults({
+      target: {},
+      source: { a: 1, b: 2 },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should handle empty source", () => {
+    const result = defaults({
+      target: { a: 1, b: 2 },
+      source: {},
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should handle both empty objects", () => {
+    const result = defaults({ target: {}, source: {} });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should not mutate the inputs", () => {
+    const target = { a: 1 };
+    const source = { a: 99, b: 2 };
+    const result = defaults({ target, source });
+
+    expect(result).to.not.equal(target);
+    expect(result).to.not.equal(source);
+    expect(target).to.deep.equal({ a: 1 });
+    expect(source).to.deep.equal({ a: 99, b: 2 });
+  });
+
+  it("should copy nested objects by reference (shallow)", () => {
+    const nested = { x: 1 };
+    const result = defaults({
+      target: {},
+      source: { nested },
+    });
+
+    expect(result.nested).to.equal(nested);
+  });
+
+  it("should throw if target is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaults({ target: "string", source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if target is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaults({ target: null, source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if target is an array", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaults({ target: [1, 2], source: {} })).to.throw(
+      "The 'target' parameter is not an object",
+    );
+  });
+
+  it("should throw if source is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaults({ target: {}, source: 42 })).to.throw(
+      "The 'source' parameter is not an object",
+    );
+  });
+
+  it("should throw if source is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => defaults({ target: {}, source: null })).to.throw(
+      "The 'source' parameter is not an object",
+    );
+  });
+});

--- a/src/objects/defaults/index.ts
+++ b/src/objects/defaults/index.ts
@@ -1,0 +1,54 @@
+import type { DefaultsParams, DefaultsResult } from "./types.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && value.constructor === Object
+  );
+}
+
+/**
+ * Assigns default values from `source` to `target` for properties that are
+ * `undefined` or missing. Existing `null`, `0`, `""`, and `false` values are
+ * preserved — only `undefined` triggers replacement.
+ *
+ * @param params - The parameters object
+ * @param params.target - The base object whose defined values win
+ * @param params.source - The object supplying defaults for missing keys
+ * @returns A new object (inputs are not mutated)
+ *
+ * @example
+ * ```ts
+ * defaults({ target: { a: 1 }, source: { a: 99, b: 2 } });
+ * // => { a: 1, b: 2 }
+ * ```
+ *
+ * @keywords default values, fill undefined, fallback object, defaults, with defaults
+ *
+ * @see lodash/defaults — semantic reference (https://lodash.com/docs/#defaults)
+ *
+ * @throws Error if `target` is not a plain object
+ * @throws Error if `source` is not a plain object
+ */
+function defaults({ target, source }: DefaultsParams): DefaultsResult {
+  if (!isPlainObject(target)) {
+    throw new Error("The 'target' parameter is not an object");
+  }
+
+  if (!isPlainObject(source)) {
+    throw new Error("The 'source' parameter is not an object");
+  }
+
+  const result = Object.assign({}, target);
+  const sourceKeys = Object.keys(source);
+
+  for (let i = 0; i < sourceKeys.length; i++) {
+    const key = sourceKeys[i];
+    if (result[key] === undefined) {
+      result[key] = source[key];
+    }
+  }
+
+  return result;
+}
+
+export { defaults };

--- a/src/objects/defaults/index.ts
+++ b/src/objects/defaults/index.ts
@@ -38,7 +38,17 @@ function defaults({ target, source }: DefaultsParams): DefaultsResult {
     throw new Error("The 'source' parameter is not an object");
   }
 
-  const result = Object.assign({}, target);
+  const result: Record<string, unknown> = {};
+  const targetKeys = Object.keys(target);
+
+  for (let i = 0; i < targetKeys.length; i++) {
+    const key = targetKeys[i];
+    const value = target[key];
+    if (value !== undefined) {
+      result[key] = value;
+    }
+  }
+
   const sourceKeys = Object.keys(source);
 
   for (let i = 0; i < sourceKeys.length; i++) {

--- a/src/objects/defaults/types.ts
+++ b/src/objects/defaults/types.ts
@@ -1,0 +1,10 @@
+interface DefaultsParams {
+  target: Record<string, unknown>;
+  source: Record<string, unknown>;
+}
+
+type DefaultsResult = Record<string, unknown>;
+
+type DefaultsFn = (params: DefaultsParams) => DefaultsResult;
+
+export type { DefaultsFn, DefaultsParams, DefaultsResult };

--- a/website/src/content/docs/objects/defaults-deep.mdx
+++ b/website/src/content/docs/objects/defaults-deep.mdx
@@ -1,0 +1,68 @@
+---
+title: defaultsDeep
+description: Recursively fill undefined properties with defaults from another object
+---
+
+Recursively assigns default values from `source` to `target`. For each property, if the target's value is `undefined` (or missing), the source's value is used. When both sides have plain objects at the same key, they are merged recursively. Existing `null`, `0`, `""`, `false`, and array values in the target are preserved.
+
+## Import
+
+```ts
+import { defaultsDeep } from "1o1-utils";
+```
+
+```ts
+import { defaultsDeep } from "1o1-utils/defaults-deep";
+```
+
+## Signature
+
+```ts
+function defaultsDeep({ target, source }: DefaultsDeepParams): Record<string, unknown>
+```
+
+## Parameters
+
+| Name     | Type                       | Required | Description                                |
+| -------- | -------------------------- | -------- | ------------------------------------------ |
+| `target` | `Record<string, unknown>`  | Yes      | The base object whose defined values win   |
+| `source` | `Record<string, unknown>`  | Yes      | The object supplying defaults              |
+
+## Returns
+
+`Record<string, unknown>` — A new object (neither input is mutated).
+
+## Examples
+
+```ts
+defaultsDeep({
+  target: { db: { port: 5432 } },
+  source: { db: { port: 3306, host: "localhost" }, debug: false },
+});
+// => { db: { port: 5432, host: "localhost" }, debug: false }
+```
+
+```ts
+defaultsDeep({
+  target: { tags: [1, 2] },
+  source: { tags: [3, 4, 5] },
+});
+// => { tags: [1, 2] }  — arrays in target are preserved, not merged
+```
+
+## Edge Cases
+
+- Throws if `target` is not a plain object.
+- Throws if `source` is not a plain object.
+- Only replaces values that are strictly `undefined` — `null`, `0`, `""`, and `false` are preserved.
+- Arrays are treated as leaves — target arrays are preserved and not merged with source arrays.
+- Only merges plain objects recursively; other value types overwrite only when target is `undefined`.
+- Uses a stack-based (non-recursive) algorithm to avoid stack overflow on deeply nested objects.
+
+## Also known as
+
+deep defaults, nested defaults, fill undefined recursive, fallback object deep
+
+## Prompt suggestion
+
+> `Show me how to use defaultsDeep from 1o1-utils to merge a nested config with default values without overriding user settings`

--- a/website/src/content/docs/objects/defaults.mdx
+++ b/website/src/content/docs/objects/defaults.mdx
@@ -1,0 +1,66 @@
+---
+title: defaults
+description: Fill undefined properties with defaults from another object
+---
+
+Assigns default values from `source` to `target` for properties that are `undefined` or missing. Existing `null`, `0`, `""`, and `false` values in the target are preserved — only `undefined` triggers replacement.
+
+## Import
+
+```ts
+import { defaults } from "1o1-utils";
+```
+
+```ts
+import { defaults } from "1o1-utils/defaults";
+```
+
+## Signature
+
+```ts
+function defaults({ target, source }: DefaultsParams): Record<string, unknown>
+```
+
+## Parameters
+
+| Name     | Type                       | Required | Description                                |
+| -------- | -------------------------- | -------- | ------------------------------------------ |
+| `target` | `Record<string, unknown>`  | Yes      | The base object whose defined values win   |
+| `source` | `Record<string, unknown>`  | Yes      | The object supplying defaults              |
+
+## Returns
+
+`Record<string, unknown>` — A new object (neither input is mutated).
+
+## Examples
+
+```ts
+defaults({
+  target: { a: 1 },
+  source: { a: 99, b: 2 },
+});
+// => { a: 1, b: 2 }
+```
+
+```ts
+defaults({
+  target: { a: null, b: 0, c: "" },
+  source: { a: 1, b: 99, c: "fallback", d: 4 },
+});
+// => { a: null, b: 0, c: "", d: 4 }
+```
+
+## Edge Cases
+
+- Throws if `target` is not a plain object.
+- Throws if `source` is not a plain object.
+- Only replaces values that are strictly `undefined` — `null`, `0`, `""`, and `false` are preserved.
+- Nested objects are copied by reference. Use `defaultsDeep` for recursive merging.
+
+## Also known as
+
+default values, fill undefined, fallback object, with defaults
+
+## Prompt suggestion
+
+> `Show me how to use defaults from 1o1-utils to merge a config object with fallback values without overriding explicit nulls`


### PR DESCRIPTION
Closes #93.

## Summary
- Adds `defaults` and `defaultsDeep` to the `objects/` category.
- Immutable, named-params API consistent with `deepMerge`/`cloneDeep`.
- Only replaces strictly `undefined` values — `null`, `0`, `""`, `false`, and arrays in the target are preserved.
- `defaultsDeep` uses a stack-based iterative algorithm (no recursion), same pattern as `deepMerge`.

## Benchmarks (vs lodash)
| Utility | small | wide/deep |
| --- | --- | --- |
| `defaults` | **1.8× faster** (167ns vs 292ns) | **1.5× faster** (3.8µs vs 5.5µs) |
| `defaultsDeep` | **3.7× faster** (125ns vs 458ns) | **5.9× faster** (667ns vs 3.9µs) |

A perf pass on the wide case flipped `defaults` from 1.4× slower to 1.5× faster than lodash by replacing `Object.assign` with a manual target-key loop (see commit `c8f486d`).

## Bundle size
- `defaults`: 200 B (limit 1 kB)
- `defaults-deep`: 263 B (limit 2 kB)

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 265 passing (28 new specs across both utilities)
- [x] `pnpm test:coverage` — 100% lines/functions, ~90% branches
- [x] `pnpm build` — clean
- [x] `pnpm size` — within limits
- [x] `pnpm bench defaults --md` — results in `docs/benchmarks/`
- [x] Changeset created (`minor`)
- [x] `llms.txt`, `llms-full.txt`, and MDX docs added