### PR TITLE
feat(functions): add once utility

### DIFF
--- a/.changeset/add-once.md
+++ b/.changeset/add-once.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `once` utility and new `functions` category. `once(fn)` returns a wrapper that executes `fn` on the first call, caches the result, and ignores subsequent arguments — ideal for lazy initialization and singleton patterns.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -114,5 +114,10 @@
     "name": "throttle",
     "path": "dist/async/throttle/index.js",
     "limit": "2 kB"
+  },
+  {
+    "name": "once",
+    "path": "dist/functions/once/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -656,4 +656,4 @@ getClient(); // creates client
 getClient(); // returns same instance
 
 Throws: Error if fn is not a function.
-Arguments from the first call are forwarded to fn; later arguments are ignored. The wrapper preserves `this` from the first invocation. A return value of undefined is still cached — fn will not run again.
+Arguments from the first call are forwarded to fn; later arguments are ignored. The wrapper preserves `this` from the first invocation. A return value of undefined is still cached — fn will not run again. If fn throws on the first call, the exception propagates and subsequent calls return undefined without retrying. The reference to fn is released after the first call so any state it captures can be garbage-collected.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -626,3 +626,34 @@ throttledScroll.cancel(); // Cancel pending trailing call
 
 Throws: Error if fn is not a function. Error if ms is not a number, is NaN, or is negative.
 First call executes immediately. Subsequent calls within ms are queued; the last one fires after the interval. .cancel() clears pending calls and resets state.
+
+---
+
+## Functions
+
+### once
+
+Create a version of a function that runs only once. Subsequent calls return the cached result from the first invocation and ignore any new arguments.
+
+Import: import { once } from "1o1-utils/once";
+
+Signature:
+function once<T extends (...args: never[]) => unknown>(fn: T): T
+
+Parameters:
+- fn (T, required): The function to wrap
+
+Returns: T — A wrapped function that executes fn at most once.
+
+Example:
+const init = once(() => ({ id: Math.random() }));
+const a = init();
+const b = init();
+a === b; // true — same cached object
+
+const getClient = once(() => new ApiClient({ token: process.env.TOKEN }));
+getClient(); // creates client
+getClient(); // returns same instance
+
+Throws: Error if fn is not a function.
+Arguments from the first call are forwarded to fn; later arguments are ignored. The wrapper preserves `this` from the first invocation. A return value of undefined is still cached — fn will not run again.

--- a/llms.txt
+++ b/llms.txt
@@ -43,3 +43,7 @@
 - [retry](https://pedrotroccoli.github.io/1o1-utils/async/retry/): Retry async operations with fixed or exponential backoff
 - [sleep](https://pedrotroccoli.github.io/1o1-utils/async/sleep/): Promise-based delay
 - [throttle](https://pedrotroccoli.github.io/1o1-utils/async/throttle/): Create a throttled function with cancel support
+
+## Functions
+
+- [once](https://pedrotroccoli.github.io/1o1-utils/functions/once/): Create a function that runs only once and caches its result

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
 		"capitalize",
 		"truncate",
 		"retry",
-		"sleep"
+		"sleep",
+		"once"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -134,6 +135,10 @@
 		"./truncate": {
 			"import": "./dist/strings/truncate/index.js",
 			"types": "./dist/strings/truncate/index.d.ts"
+		},
+		"./once": {
+			"import": "./dist/functions/once/index.js",
+			"types": "./dist/functions/once/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -163,6 +163,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Recursively fills `undefined` properties in the target with values from the source. Arrays and non-plain-object values in the target are preserved. Compared against `lodash.defaultsDeep`.",
   },
+  once: {
+    slug: "once",
+    description:
+      "Wraps a function so it runs at most once; subsequent calls return the cached result. Compared against `lodash.once`.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/functions/once/index.bench.ts
+++ b/src/functions/once/index.bench.ts
@@ -1,0 +1,28 @@
+import lodashOnce from "lodash/once.js";
+import { Bench } from "tinybench";
+import { once } from "./index.js";
+
+const noop = () => {};
+
+const bench = new Bench({ name: "once", time: 1000 });
+
+bench
+  .add("1o1-utils (creation)", () => {
+    once(noop);
+  })
+  .add("lodash (creation)", () => {
+    lodashOnce(noop);
+  });
+
+const onceOwn = once(noop);
+const onceLodash = lodashOnce(noop);
+
+bench
+  .add("1o1-utils (invocation)", () => {
+    onceOwn();
+  })
+  .add("lodash (invocation)", () => {
+    onceLodash();
+  });
+
+export { bench };

--- a/src/functions/once/index.spec.ts
+++ b/src/functions/once/index.spec.ts
@@ -72,6 +72,19 @@ describe("once", () => {
     expect(obj.getValue()).to.equal(42);
   });
 
+  it("should not retry if fn throws on the first call", () => {
+    let callCount = 0;
+    const wrapped = once(() => {
+      callCount++;
+      throw new Error("boom");
+    });
+
+    expect(() => wrapped()).to.throw("boom");
+    expect(wrapped()).to.equal(undefined);
+    expect(wrapped()).to.equal(undefined);
+    expect(callCount).to.equal(1);
+  });
+
   it("should throw an error if fn is not a function", () => {
     // @ts-expect-error - we want to test the error case
     expect(() => once("not a function")).to.throw(

--- a/src/functions/once/index.spec.ts
+++ b/src/functions/once/index.spec.ts
@@ -1,0 +1,88 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { once } from "./index.js";
+
+describe("once", () => {
+  it("should call the wrapped function only once", () => {
+    let callCount = 0;
+    const wrapped = once(() => {
+      callCount++;
+      return "result";
+    });
+
+    wrapped();
+    wrapped();
+    wrapped();
+
+    expect(callCount).to.equal(1);
+  });
+
+  it("should return the cached result on subsequent calls", () => {
+    const wrapped = once(() => ({ value: Math.random() }));
+
+    const first = wrapped();
+    const second = wrapped();
+    const third = wrapped();
+
+    expect(first).to.equal(second);
+    expect(second).to.equal(third);
+  });
+
+  it("should pass arguments to the wrapped function on the first call", () => {
+    let received: number[] = [];
+    const wrapped = once((...args: number[]) => {
+      received = args;
+      return args.reduce((a, b) => a + b, 0);
+    });
+
+    const result = wrapped(1, 2, 3);
+
+    expect(received).to.deep.equal([1, 2, 3]);
+    expect(result).to.equal(6);
+  });
+
+  it("should ignore arguments on subsequent calls", () => {
+    const wrapped = once((n: number) => n * 2);
+
+    expect(wrapped(5)).to.equal(10);
+    expect(wrapped(10)).to.equal(10);
+    expect(wrapped(100)).to.equal(10);
+  });
+
+  it("should cache an undefined return value", () => {
+    let callCount = 0;
+    const wrapped = once(() => {
+      callCount++;
+      return undefined;
+    });
+
+    expect(wrapped()).to.equal(undefined);
+    expect(wrapped()).to.equal(undefined);
+    expect(callCount).to.equal(1);
+  });
+
+  it("should preserve the `this` context from the first call", () => {
+    const obj = {
+      value: 42,
+      getValue: once(function (this: { value: number }) {
+        return this.value;
+      }),
+    };
+
+    expect(obj.getValue()).to.equal(42);
+  });
+
+  it("should throw an error if fn is not a function", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => once("not a function")).to.throw(
+      "The 'fn' parameter must be a function",
+    );
+  });
+
+  it("should throw an error if fn is undefined", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => once(undefined)).to.throw(
+      "The 'fn' parameter must be a function",
+    );
+  });
+});

--- a/src/functions/once/index.ts
+++ b/src/functions/once/index.ts
@@ -1,0 +1,43 @@
+/**
+ * Creates a version of a function that runs only once. Subsequent calls
+ * return the cached result from the first invocation and ignore any new
+ * arguments.
+ *
+ * @param fn - The function to wrap
+ * @returns A wrapped function that executes `fn` at most once
+ *
+ * @example
+ * ```ts
+ * const init = once(() => ({ id: Math.random() }));
+ * const a = init();
+ * const b = init();
+ * a === b; // true
+ * ```
+ *
+ * @keywords run once, single call, memoize no args, lazy init, singleton
+ *
+ * @throws Error if `fn` is not a function
+ */
+function once<T extends (...args: never[]) => unknown>(fn: T): T {
+  if (typeof fn !== "function") {
+    throw new Error("The 'fn' parameter must be a function");
+  }
+
+  let called = false;
+  let result: unknown;
+
+  function wrapped(this: unknown, ...args: unknown[]): unknown {
+    if (!called) {
+      called = true;
+      result = (fn as unknown as (...a: unknown[]) => unknown).apply(
+        this,
+        args,
+      );
+    }
+    return result;
+  }
+
+  return wrapped as unknown as T;
+}
+
+export { once };

--- a/src/functions/once/index.ts
+++ b/src/functions/once/index.ts
@@ -17,18 +17,25 @@
  * @keywords run once, single call, memoize no args, lazy init, singleton
  *
  * @throws Error if `fn` is not a function
+ *
+ * @remarks
+ * The reference to `fn` is released after the first call so it can be
+ * garbage-collected. If `fn` throws on the first call, the exception
+ * propagates and subsequent calls return `undefined` without retrying.
  */
 function once<T extends (...args: never[]) => unknown>(fn: T): T {
   if (typeof fn !== "function") {
     throw new Error("The 'fn' parameter must be a function");
   }
 
-  let n = 1;
+  let target: T | undefined = fn;
   let result: unknown;
 
   return function (this: unknown) {
-    if (n-- > 0) {
-      result = (fn as unknown as (...a: unknown[]) => unknown).apply(
+    if (target !== undefined) {
+      const f = target;
+      target = undefined;
+      result = (f as unknown as (...a: unknown[]) => unknown).apply(
         this,
         // biome-ignore lint/complexity/noArguments: fast-path, avoids rest-params allocation
         arguments as unknown as unknown[],

--- a/src/functions/once/index.ts
+++ b/src/functions/once/index.ts
@@ -23,21 +23,19 @@ function once<T extends (...args: never[]) => unknown>(fn: T): T {
     throw new Error("The 'fn' parameter must be a function");
   }
 
-  let called = false;
+  let n = 1;
   let result: unknown;
 
-  function wrapped(this: unknown, ...args: unknown[]): unknown {
-    if (!called) {
-      called = true;
+  return function (this: unknown) {
+    if (n-- > 0) {
       result = (fn as unknown as (...a: unknown[]) => unknown).apply(
         this,
-        args,
+        // biome-ignore lint/complexity/noArguments: fast-path, avoids rest-params allocation
+        arguments as unknown as unknown[],
       );
     }
     return result;
-  }
-
-  return wrapped as unknown as T;
+  } as unknown as T;
 }
 
 export { once };

--- a/src/functions/once/types.ts
+++ b/src/functions/once/types.ts
@@ -1,0 +1,3 @@
+type OnceFn = <T extends (...args: never[]) => unknown>(fn: T) => T;
+
+export type { OnceFn };

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export { debounce } from "./async/debounce/index.js";
 export { retry } from "./async/retry/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
+export { once } from "./functions/once/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
 export { defaults } from "./objects/defaults/index.js";

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -79,6 +79,10 @@ export default defineConfig({
           label: "Async",
           autogenerate: { directory: "async" },
         },
+        {
+          label: "Functions",
+          autogenerate: { directory: "functions" },
+        },
       ],
       lastUpdated: true,
       routeMiddleware: "./src/starlightRouteData.ts",

--- a/website/src/content/docs/functions/once.mdx
+++ b/website/src/content/docs/functions/once.mdx
@@ -1,0 +1,65 @@
+---
+title: once
+description: Create a function that runs only once and caches its result
+---
+
+Creates a version of a function that runs only once. Subsequent calls return the cached result from the first invocation and ignore any new arguments.
+
+## Import
+
+```ts
+import { once } from "1o1-utils";
+```
+
+```ts
+import { once } from "1o1-utils/once";
+```
+
+## Signature
+
+```ts
+function once<T extends (...args: never[]) => unknown>(fn: T): T
+```
+
+## Parameters
+
+| Name | Type | Required | Description           |
+| ---- | ---- | -------- | --------------------- |
+| fn   | `T`  | Yes      | The function to wrap  |
+
+## Returns
+
+`T` — A wrapped function with the same signature that executes `fn` at most once.
+
+## Examples
+
+```ts
+const init = once(() => ({ id: Math.random() }));
+
+const a = init();
+const b = init();
+a === b; // true — same cached object
+```
+
+```ts
+// Lazy singleton
+const getClient = once(() => new ApiClient({ token: process.env.TOKEN }));
+
+getClient(); // creates client
+getClient(); // returns same instance
+```
+
+## Edge Cases
+
+- Throws if `fn` is not a function.
+- Arguments from the first call are forwarded to `fn`; later arguments are ignored.
+- The wrapper preserves `this` from the first invocation.
+- A return value of `undefined` is cached — `fn` will not run again.
+
+## Also known as
+
+run once, single call, lazy init, singleton, memoize no-arg
+
+## Prompt suggestion
+
+> `Show me how to use once from 1o1-utils to lazily initialize a singleton client`

--- a/website/src/content/docs/functions/once.mdx
+++ b/website/src/content/docs/functions/once.mdx
@@ -55,6 +55,8 @@ getClient(); // returns same instance
 - Arguments from the first call are forwarded to `fn`; later arguments are ignored.
 - The wrapper preserves `this` from the first invocation.
 - A return value of `undefined` is cached — `fn` will not run again.
+- If `fn` throws on the first call, the exception propagates and subsequent calls return `undefined` without retrying.
+- The reference to `fn` is released after the first call so any state it captures can be garbage-collected.
 
 ## Also known as
 


### PR DESCRIPTION
## Summary

- Adds `once(fn)` — wraps a function so it runs at most once, caches the first result, ignores subsequent arguments.
- Establishes the new `functions` category (sidebar, llms registration, benchmark metadata) so future `memoize`/`pipe`/`compose` have a home.
- On par with `lodash.once` on both creation and invocation (41ns median, 24.4M ops/s). Bundle: 127B gzipped.
- Releases the `fn` reference after the first call so its captured state is eligible for GC.

## Commits

- `feat(functions): add once utility` — utility + tests + bench + docs + registrations + changeset.
- `perf(functions): speed up once creation 5x` — swap rest-params for `arguments` to match lodash shape (208ns → 41ns on creation).
- `fix(functions): release fn reference in once after first call` — clear the captured `target` before applying so GC can reclaim `fn` and a throw in `fn` doesn't leave a dangling reference; adds throw-behavior test and docs.

## Test plan

- [x] `pnpm test` — 306 passing (9 new `once` tests, 100% line / 84% branch coverage)
- [x] `pnpm check` — biome clean (pre-existing warnings only)
- [x] `pnpm build` — tsc clean
- [x] `pnpm size` — `once` 127B / 1kB limit; total 3.01kB / 5kB limit
- [x] `pnpm bench once` — on par with `lodash.once` (creation + invocation)
- [ ] `pnpm docs:dev` — verify Functions > once renders in the sidebar