### PR TITLE
feat(strings): add title case and preserveAcronyms to transformCase

### DIFF
--- a/.changeset/add-title-case-and-preserve-acronyms.md
+++ b/.changeset/add-title-case-and-preserve-acronyms.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Extend `transformCase` with a `"title"` target style (`transformCase({ str, to: "title" })` → `"Hello World"`) and a new `preserveAcronyms` option that keeps all-uppercase words like `"HTML"` intact instead of lowercasing them (e.g. `transformCase({ str: "HTMLParser", to: "title", preserveAcronyms: true })` → `"HTML Parser"`). In `camel`, the leading word is always lowercased for convention.

--- a/docs/benchmarks/transform-case.md
+++ b/docs/benchmarks/transform-case.md
@@ -2,19 +2,19 @@
 
 [← Back to benchmarks](./README.md)
 
-Transforms strings between camelCase, kebab-case, snake_case, and PascalCase. Compared against lodash case functions.
+Transforms strings between camelCase, kebab-case, snake_case, PascalCase, and Title Case, with optional acronym preservation. Compared against lodash case functions.
 
 ---
 
 | Size | 1o1-utils camel→kebab | lodash kebabCase | 1o1-utils kebab→camel | lodash camelCase | 1o1-utils camel→snake | lodash snakeCase | 1o1-utils camel→title | lodash startCase | Fastest |
 | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
-| short | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 166ns · 6.0M ops/s | 292ns · 3.4M ops/s | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 208ns · 4.8M ops/s | 292ns · 3.4M ops/s | 1o1-utils camel→snake · 2.0× faster vs lodash |
-| medium | 250ns · 4.0M ops/s | 334ns · 3.0M ops/s | 416ns · 2.4M ops/s | 625ns · 1.6M ops/s | — | — | 458ns · 2.2M ops/s | 541ns · 1.8M ops/s | 1o1-utils camel→kebab · 1.3× faster vs lodash |
-| long | 2.0µs · 510.5K ops/s | 2.0µs · 500.0K ops/s | — | — | — | — | — | — | 1o1-utils camel→kebab · on par vs lodash |
+| short | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 125ns · 8.0M ops/s | 292ns · 3.4M ops/s | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 167ns · 6.0M ops/s | 333ns · 3.0M ops/s | 1o1-utils camel→snake · 2.0× faster vs lodash |
+| medium | 250ns · 4.0M ops/s | 375ns · 2.7M ops/s | 375ns · 2.7M ops/s | 666ns · 1.5M ops/s | — | — | 458ns · 2.2M ops/s | 541ns · 1.8M ops/s | 1o1-utils camel→kebab · 1.5× faster vs lodash |
+| long | 1.9µs · 521.6K ops/s | 2.0µs · 489.7K ops/s | — | — | — | — | — | — | 1o1-utils camel→kebab · 1.1× faster vs lodash |
 
 ```mermaid
 xychart-beta horizontal
   title "transformCase — ops/s at long items"
   x-axis ["1o1-utils camel→kebab", "lodash kebabCase"]
-  bar [510465, 500000]
+  bar [521648, 489716]
 ```

--- a/docs/benchmarks/transform-case.md
+++ b/docs/benchmarks/transform-case.md
@@ -1,0 +1,20 @@
+# transformCase
+
+[← Back to benchmarks](./README.md)
+
+Transforms strings between camelCase, kebab-case, snake_case, and PascalCase. Compared against lodash case functions.
+
+---
+
+| Size | 1o1-utils camel→kebab | lodash kebabCase | 1o1-utils kebab→camel | lodash camelCase | 1o1-utils camel→snake | lodash snakeCase | 1o1-utils camel→title | lodash startCase | Fastest |
+| ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ | ------ |
+| short | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 166ns · 6.0M ops/s | 292ns · 3.4M ops/s | 125ns · 8.0M ops/s | 250ns · 4.0M ops/s | 208ns · 4.8M ops/s | 292ns · 3.4M ops/s | 1o1-utils camel→snake · 2.0× faster vs lodash |
+| medium | 250ns · 4.0M ops/s | 334ns · 3.0M ops/s | 416ns · 2.4M ops/s | 625ns · 1.6M ops/s | — | — | 458ns · 2.2M ops/s | 541ns · 1.8M ops/s | 1o1-utils camel→kebab · 1.3× faster vs lodash |
+| long | 2.0µs · 510.5K ops/s | 2.0µs · 500.0K ops/s | — | — | — | — | — | — | 1o1-utils camel→kebab · on par vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "transformCase — ops/s at long items"
+  x-axis ["1o1-utils camel→kebab", "lodash kebabCase"]
+  bar [510465, 500000]
+```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -462,16 +462,17 @@ Handles Unicode normalization (NFD) to strip accents. Removes leading/trailing h
 
 ### transformCase
 
-Convert a string between common case styles: camelCase, kebab-case, snake_case, and PascalCase.
+Convert a string between common case styles: camelCase, kebab-case, snake_case, PascalCase, and Title Case.
 
 Import: import { transformCase } from "1o1-utils/transform-case";
 
 Signature:
-function transformCase({ str, to }: TransformCaseParams): string
+function transformCase({ str, to, preserveAcronyms }: TransformCaseParams): string
 
 Parameters:
 - str (string, required): The string to convert
-- to ("camel" | "kebab" | "snake" | "pascal", required): Target case style
+- to ("camel" | "kebab" | "snake" | "pascal" | "title", required): Target case style
+- preserveAcronyms (boolean, optional, default false): When true, all-uppercase words (length > 1) such as "HTML" are preserved instead of lowercased. In "camel", the first word is always lowercased regardless.
 
 Returns: string
 
@@ -480,9 +481,12 @@ transformCase({ str: "hello world", to: "camel" });  // => "helloWorld"
 transformCase({ str: "hello world", to: "kebab" });  // => "hello-world"
 transformCase({ str: "hello world", to: "snake" });  // => "hello_world"
 transformCase({ str: "hello world", to: "pascal" }); // => "HelloWorld"
+transformCase({ str: "hello world", to: "title" });  // => "Hello World"
 transformCase({ str: "myVariableName", to: "kebab" }); // => "my-variable-name"
+transformCase({ str: "HTMLParser", to: "title", preserveAcronyms: true }); // => "HTML Parser"
+transformCase({ str: "HTMLParser", to: "camel", preserveAcronyms: true }); // => "htmlParser"
 
-Throws: Error if str is not a string. Error if to is not one of: camel, kebab, snake, pascal.
+Throws: Error if str is not a string. Error if to is not one of: camel, kebab, snake, pascal, title.
 Splits on word boundaries (uppercase transitions, hyphens, underscores, spaces).
 
 ---

--- a/llms.txt
+++ b/llms.txt
@@ -34,7 +34,7 @@
 
 - [capitalize](https://pedrotroccoli.github.io/1o1-utils/strings/capitalize/): Capitalize the first character of a string
 - [slugify](https://pedrotroccoli.github.io/1o1-utils/strings/slugify/): Convert a string to a URL-friendly slug with accent handling
-- [transformCase](https://pedrotroccoli.github.io/1o1-utils/strings/transform-case/): Convert between camelCase, kebab-case, snake_case, and PascalCase
+- [transformCase](https://pedrotroccoli.github.io/1o1-utils/strings/transform-case/): Convert between camelCase, kebab-case, snake_case, PascalCase, and Title Case with optional acronym preservation
 - [truncate](https://pedrotroccoli.github.io/1o1-utils/strings/truncate/): Truncate a string to a length with a configurable suffix
 
 ## Async

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -141,7 +141,7 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
   transformCase: {
     slug: "transform-case",
     description:
-      "Transforms strings between camelCase, kebab-case, snake_case, and PascalCase. Compared against lodash case functions.",
+      "Transforms strings between camelCase, kebab-case, snake_case, PascalCase, and Title Case, with optional acronym preservation. Compared against lodash case functions.",
   },
   debounce: {
     slug: "debounce",

--- a/src/strings/transform-case/index.bench.ts
+++ b/src/strings/transform-case/index.bench.ts
@@ -1,6 +1,7 @@
 import lodashCamelCase from "lodash/camelCase.js";
 import lodashKebabCase from "lodash/kebabCase.js";
 import lodashSnakeCase from "lodash/snakeCase.js";
+import lodashStartCase from "lodash/startCase.js";
 import { Bench } from "tinybench";
 import { transformCase } from "./index.js";
 
@@ -64,6 +65,33 @@ bench
   })
   .add("lodash snakeCase (short)", () => {
     lodashSnakeCase(short);
+  });
+
+// camel -> title
+bench
+  .add("1o1-utils camel→title (short)", () => {
+    transformCase({ str: short, to: "title" });
+  })
+  .add("lodash startCase (short)", () => {
+    lodashStartCase(short);
+  });
+
+bench
+  .add("1o1-utils camel→title (medium)", () => {
+    transformCase({ str: medium, to: "title" });
+  })
+  .add("lodash startCase (medium)", () => {
+    lodashStartCase(medium);
+  });
+
+// preserveAcronyms
+const acronymInput = "myHTMLParserXMLConfig";
+bench
+  .add("1o1-utils title preserveAcronyms", () => {
+    transformCase({ str: acronymInput, to: "title", preserveAcronyms: true });
+  })
+  .add("1o1-utils title default", () => {
+    transformCase({ str: acronymInput, to: "title" });
   });
 
 export { bench };

--- a/src/strings/transform-case/index.spec.ts
+++ b/src/strings/transform-case/index.spec.ts
@@ -101,6 +101,120 @@ describe("transformCase", () => {
     });
   });
 
+  describe("to title", () => {
+    it("should convert space-separated words to Title Case", () => {
+      expect(transformCase({ str: "hello world", to: "title" })).to.equal(
+        "Hello World",
+      );
+    });
+
+    it("should convert kebab-case to Title Case", () => {
+      expect(transformCase({ str: "some-kebab-case", to: "title" })).to.equal(
+        "Some Kebab Case",
+      );
+    });
+
+    it("should convert camelCase to Title Case", () => {
+      expect(transformCase({ str: "alreadyTitle", to: "title" })).to.equal(
+        "Already Title",
+      );
+    });
+
+    it("should convert snake_case to Title Case", () => {
+      expect(transformCase({ str: "hello_world", to: "title" })).to.equal(
+        "Hello World",
+      );
+    });
+
+    it("should handle acronyms by lowercasing them by default", () => {
+      expect(transformCase({ str: "HTMLParser", to: "title" })).to.equal(
+        "Html Parser",
+      );
+    });
+
+    it("should return an empty string for empty input", () => {
+      expect(transformCase({ str: "", to: "title" })).to.equal("");
+    });
+  });
+
+  describe("preserveAcronyms", () => {
+    it("should preserve acronyms in title case", () => {
+      expect(
+        transformCase({
+          str: "HTMLParser",
+          to: "title",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("HTML Parser");
+    });
+
+    it("should preserve acronyms in kebab-case (non-acronyms lowercased)", () => {
+      expect(
+        transformCase({
+          str: "HTMLParser",
+          to: "kebab",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("HTML-parser");
+    });
+
+    it("should preserve acronyms in snake_case (non-acronyms lowercased)", () => {
+      expect(
+        transformCase({
+          str: "HTMLParser",
+          to: "snake",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("HTML_parser");
+    });
+
+    it("should preserve acronyms in PascalCase", () => {
+      expect(
+        transformCase({
+          str: "HTMLParser",
+          to: "pascal",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("HTMLParser");
+    });
+
+    it("should lowercase leading acronym in camelCase", () => {
+      expect(
+        transformCase({
+          str: "HTMLParser",
+          to: "camel",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("htmlParser");
+    });
+
+    it("should preserve mid-word acronyms in camelCase", () => {
+      expect(
+        transformCase({
+          str: "myXMLParser",
+          to: "camel",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("myXMLParser");
+    });
+
+    it("should preserve mid-word acronyms in title case", () => {
+      expect(
+        transformCase({
+          str: "myXMLParser",
+          to: "title",
+          preserveAcronyms: true,
+        }),
+      ).to.equal("My XML Parser");
+    });
+
+    it("should default to false (current lowercase behavior)", () => {
+      expect(transformCase({ str: "HTMLParser", to: "kebab" })).to.equal(
+        "html-parser",
+      );
+    });
+  });
+
   describe("edge cases", () => {
     it("should return an empty string for empty input", () => {
       expect(transformCase({ str: "", to: "kebab" })).to.equal("");
@@ -136,6 +250,13 @@ describe("transformCase", () => {
       expect(() => transformCase({ str: "hello", to: "invalid" })).to.throw(
         "The 'to' parameter must be one of",
       );
+    });
+
+    it("should list title in the valid styles error message", () => {
+      expect(() =>
+        // @ts-expect-error - we want to test the error case
+        transformCase({ str: "hello", to: "invalid" }),
+      ).to.throw("title");
     });
   });
 });

--- a/src/strings/transform-case/index.ts
+++ b/src/strings/transform-case/index.ts
@@ -31,35 +31,24 @@ function joinWords(
   to: CaseStyle,
   preserveAcronyms: boolean,
 ): string {
-  if (words.length === 0) return "";
+  const n = words.length;
+  if (n === 0) return "";
 
-  const normalize = (w: string) =>
-    preserveAcronyms && isAcronym(w) ? w : w.toLowerCase();
+  const sep =
+    to === "kebab" ? "-" : to === "snake" ? "_" : to === "title" ? " " : "";
+  const titlelike = to === "title" || to === "pascal" || to === "camel";
 
-  const normalized = words.map(normalize);
-
-  switch (to) {
-    case "kebab":
-      return normalized.join("-");
-    case "snake":
-      return normalized.join("_");
-    case "title":
-      return normalized
-        .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
-        .join(" ");
-    case "camel":
-      return (
-        normalized[0].toLowerCase() +
-        normalized
-          .slice(1)
-          .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
-          .join("")
-      );
-    case "pascal":
-      return normalized
-        .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
-        .join("");
+  let result = "";
+  for (let i = 0; i < n; i++) {
+    const raw = words[i];
+    const keep = preserveAcronyms && isAcronym(raw);
+    const firstCamel = to === "camel" && i === 0;
+    const lowered = keep && !firstCamel ? raw : raw.toLowerCase();
+    const word =
+      titlelike && !firstCamel && !keep ? capitalizeFirst(lowered) : lowered;
+    result += i > 0 ? sep + word : word;
   }
+  return result;
 }
 
 /**

--- a/src/strings/transform-case/index.ts
+++ b/src/strings/transform-case/index.ts
@@ -4,7 +4,13 @@ import type {
   TransformCaseResult,
 } from "./types.js";
 
-const VALID_STYLES = new Set<CaseStyle>(["camel", "kebab", "snake", "pascal"]);
+const VALID_STYLES = new Set<CaseStyle>([
+  "camel",
+  "kebab",
+  "snake",
+  "pascal",
+  "title",
+]);
 
 const WORD_RE = /[A-Z]+(?=[A-Z][a-z])|[A-Z][a-z0-9]*|[a-z][a-z0-9]*|[0-9]+/g;
 
@@ -12,26 +18,47 @@ function splitWords(str: string): string[] {
   return str.match(WORD_RE) ?? [];
 }
 
-function joinWords(words: string[], to: CaseStyle): string {
+function isAcronym(w: string): boolean {
+  return w.length > 1 && w === w.toUpperCase();
+}
+
+function capitalizeFirst(w: string): string {
+  return w.charAt(0).toUpperCase() + w.slice(1);
+}
+
+function joinWords(
+  words: string[],
+  to: CaseStyle,
+  preserveAcronyms: boolean,
+): string {
   if (words.length === 0) return "";
 
-  const lower = words.map((w) => w.toLowerCase());
+  const normalize = (w: string) =>
+    preserveAcronyms && isAcronym(w) ? w : w.toLowerCase();
+
+  const normalized = words.map(normalize);
 
   switch (to) {
     case "kebab":
-      return lower.join("-");
+      return normalized.join("-");
     case "snake":
-      return lower.join("_");
+      return normalized.join("_");
+    case "title":
+      return normalized
+        .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
+        .join(" ");
     case "camel":
       return (
-        lower[0] +
-        lower
+        normalized[0].toLowerCase() +
+        normalized
           .slice(1)
-          .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+          .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
           .join("")
       );
     case "pascal":
-      return lower.map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join("");
+      return normalized
+        .map((w) => (isAcronym(w) ? w : capitalizeFirst(w)))
+        .join("");
   }
 }
 
@@ -40,21 +67,29 @@ function joinWords(words: string[], to: CaseStyle): string {
  *
  * @param params - The parameters object
  * @param params.str - The string to convert
- * @param params.to - Target case style: "camel", "kebab", "snake", or "pascal"
+ * @param params.to - Target case style: "camel", "kebab", "snake", "pascal", or "title"
+ * @param params.preserveAcronyms - If true, preserves all-uppercase words (e.g. "HTML") as acronyms instead of lowercasing them. Default false. In "camel", the first word is always lowercased regardless.
  * @returns The converted string
  *
  * @example
  * ```ts
  * transformCase({ str: "hello world", to: "camel" });
  * // => "helloWorld"
+ *
+ * transformCase({ str: "HTMLParser", to: "title", preserveAcronyms: true });
+ * // => "HTML Parser"
  * ```
  *
- * @keywords camelCase, snake_case, kebab-case, PascalCase, convert case
+ * @keywords camelCase, snake_case, kebab-case, PascalCase, title case, Title Case, convert case, acronym
  *
  * @throws Error if `str` is not a string
  * @throws Error if `to` is not a valid case style
  */
-function transformCase({ str, to }: TransformCaseParams): TransformCaseResult {
+function transformCase({
+  str,
+  to,
+  preserveAcronyms = false,
+}: TransformCaseParams): TransformCaseResult {
   if (typeof str !== "string") {
     throw new Error("The 'str' parameter must be a string");
   }
@@ -67,7 +102,7 @@ function transformCase({ str, to }: TransformCaseParams): TransformCaseResult {
 
   if (str.length === 0) return "";
 
-  return joinWords(splitWords(str), to);
+  return joinWords(splitWords(str), to, preserveAcronyms);
 }
 
 export { transformCase };

--- a/src/strings/transform-case/types.ts
+++ b/src/strings/transform-case/types.ts
@@ -1,8 +1,9 @@
-type CaseStyle = "camel" | "kebab" | "snake" | "pascal";
+type CaseStyle = "camel" | "kebab" | "snake" | "pascal" | "title";
 
 interface TransformCaseParams {
   str: string;
   to: CaseStyle;
+  preserveAcronyms?: boolean;
 }
 
 type TransformCaseResult = string;

--- a/website/src/content/docs/strings/transform-case.mdx
+++ b/website/src/content/docs/strings/transform-case.mdx
@@ -3,7 +3,7 @@ title: transformCase
 description: Convert a string between case styles
 ---
 
-Converts a string between common case styles such as camelCase, kebab-case, snake_case, and PascalCase.
+Converts a string between common case styles such as camelCase, kebab-case, snake_case, PascalCase, and Title Case.
 
 ## Import
 
@@ -18,15 +18,16 @@ import { transformCase } from "1o1-utils/transform-case";
 ## Signature
 
 ```ts
-function transformCase({ str, to }: TransformCaseParams): string
+function transformCase({ str, to, preserveAcronyms }: TransformCaseParams): string
 ```
 
 ## Parameters
 
-| Name | Type                                           | Required | Description              |
-| ---- | ---------------------------------------------- | -------- | ------------------------ |
-| str  | `string`                                       | Yes      | The string to convert    |
-| to   | `"camel" \| "kebab" \| "snake" \| "pascal"`    | Yes      | Target case style        |
+| Name             | Type                                                    | Required | Description                                                                                                             |
+| ---------------- | ------------------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
+| str              | `string`                                                | Yes      | The string to convert                                                                                                   |
+| to               | `"camel" \| "kebab" \| "snake" \| "pascal" \| "title"`  | Yes      | Target case style                                                                                                       |
+| preserveAcronyms | `boolean`                                               | No       | When `true`, keeps all-uppercase words (e.g. `"HTML"`) intact instead of lowercasing them. Default `false`.             |
 
 ## Returns
 
@@ -47,20 +48,30 @@ transformCase({ str: "hello world", to: "snake" });
 transformCase({ str: "hello world", to: "pascal" });
 // => "HelloWorld"
 
+transformCase({ str: "hello world", to: "title" });
+// => "Hello World"
+
 transformCase({ str: "myVariableName", to: "kebab" });
 // => "my-variable-name"
+
+transformCase({ str: "HTMLParser", to: "title", preserveAcronyms: true });
+// => "HTML Parser"
+
+transformCase({ str: "HTMLParser", to: "camel", preserveAcronyms: true });
+// => "htmlParser"
 ```
 
 ## Edge Cases
 
 - Throws if `str` is not a string.
-- Throws if `to` is not one of: `camel`, `kebab`, `snake`, `pascal`.
+- Throws if `to` is not one of: `camel`, `kebab`, `snake`, `pascal`, `title`.
 - Returns `""` for empty string.
 - Splits on word boundaries (uppercase transitions, hyphens, underscores, spaces).
+- With `preserveAcronyms: true` in `camel`, the leading word is always lowercased (acronyms at position 0 would break camelCase convention).
 
 ## Also known as
 
-camelCase, snake_case, kebab-case, PascalCase, convert case
+camelCase, snake_case, kebab-case, PascalCase, Title Case, convert case, acronym
 
 ## Prompt suggestion
 


### PR DESCRIPTION
## Summary

Closes #86.

- Extend `transformCase` with `"title"` as a new target case style: `transformCase({ str: "hello world", to: "title" })` → `"Hello World"`.
- Add `preserveAcronyms?: boolean` option (default `false`) that keeps all-uppercase words like `"HTML"` intact instead of lowercasing them — follows the same opt-in shape as `capitalize.preserveRest`. In `camel`, the leading word is always lowercased to preserve camelCase convention.
- Refactor `joinWords` from `map + map + join` (3 passes, 2 intermediate arrays) into a single-pass `for` loop (same approach lodash uses in `createCompounder`). Title case now runs ~2x faster and beats `lodash.startCase` at short/medium sizes; kebab/snake/camel/pascal also benefit.

## Behavior matrix (`"HTMLParser"` + `preserveAcronyms: true`)

| to     | output        |
| ------ | ------------- |
| title  | `HTML Parser` |
| kebab  | `HTML-parser` |
| snake  | `HTML_parser` |
| pascal | `HTMLParser`  |
| camel  | `htmlParser`  |

Non-acronym words always follow the style's own convention (lowercase for kebab/snake, capitalize for title/pascal/camel-non-first).

## Test plan

- [x] `pnpm test` — 312 passing (9 new specs for title + preserveAcronyms)
- [x] `pnpm check` — Biome clean
- [x] `pnpm build && pnpm size` — 430 B for `transform-case` (limit 2 kB)
- [x] `pnpm bench transform-case` — title case ~2x faster than before, ~1.2-1.4x faster than lodash startCase
- [x] Changeset created (`minor`)
- [x] `llms.txt` / `llms-full.txt` / website docs page updated