### PR TITLE
feat(og): increase logo size to 240px

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/pedrotroccoli/1o1-utils/main/website/public/logo.png" alt="1o1-utils logo" width="120">
+  <img src="https://raw.githubusercontent.com/pedrotroccoli/1o1-utils/main/website/public/logo.png" alt="1o1-utils logo" width="240">
   <h1 align="center">1o1-utils</h1>
   <p align="center">Lightweight, fastest, tree-shakeable TypeScript utilities. 2 kB gzipped.</p>
 </p>

--- a/website/src/pages/og/[...slug].ts
+++ b/website/src/pages/og/[...slug].ts
@@ -33,7 +33,7 @@ export const { getStaticPaths, GET } = await OGImageRoute({
     ],
     logo: {
       path: "./public/logo.png",
-      size: [120],
+      size: [240],
     },
     border: {
       color: [107, 92, 231],


### PR DESCRIPTION
## Summary
- Bump OG image logo from 120px → 240px in `website/src/pages/og/[...slug].ts`

## Test plan
- [ ] Run `pnpm --filter website dev` and open `/og/<slug>.png` to confirm the logo renders larger within the 1200×630 canvas