### PR TITLE
docs(prompts): prefix prompt suggestions with canonical LLM references

### DIFF
--- a/website/src/content/docs/arrays/array-to-hash.mdx
+++ b/website/src/content/docs/arrays/array-to-hash.mdx
@@ -56,4 +56,6 @@ array to object, keyBy, objectify, index by, lookup table, dictionary
 
 ## Prompt suggestion
 
-> `Show me how to use arrayToHash from 1o1-utils to create a lookup table from an API response array`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use arrayToHash to create a lookup table from an API response array
+```

--- a/website/src/content/docs/arrays/chunk.mdx
+++ b/website/src/content/docs/arrays/chunk.mdx
@@ -54,4 +54,6 @@ split array, batch, divide, paginate, group by size
 
 ## Prompt suggestion
 
-> `Show me how to use chunk from 1o1-utils to paginate a list of items client-side`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use chunk to paginate a list of items client-side
+```

--- a/website/src/content/docs/arrays/group-by.mdx
+++ b/website/src/content/docs/arrays/group-by.mdx
@@ -60,4 +60,6 @@ categorize, bucket, cluster, group array
 
 ## Prompt suggestion
 
-> `Show me how to use groupBy from 1o1-utils to group transactions by category`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use groupBy to group transactions by category
+```

--- a/website/src/content/docs/arrays/sort-by.mdx
+++ b/website/src/content/docs/arrays/sort-by.mdx
@@ -59,4 +59,6 @@ order by, sort array, arrange, rank
 
 ## Prompt suggestion
 
-> `Show me how to use sortBy from 1o1-utils to sort a table by nested user.name field`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use sortBy to sort a table by nested user.name field
+```

--- a/website/src/content/docs/arrays/unique.mdx
+++ b/website/src/content/docs/arrays/unique.mdx
@@ -60,4 +60,6 @@ deduplicate, distinct, uniq, remove duplicates
 
 ## Prompt suggestion
 
-> `Show me how to use unique from 1o1-utils to deduplicate an array of objects by ID`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use unique to deduplicate an array of objects by ID
+```

--- a/website/src/content/docs/async/debounce.mdx
+++ b/website/src/content/docs/async/debounce.mdx
@@ -62,4 +62,6 @@ delay call, wait idle, input delay, search delay
 
 ## Prompt suggestion
 
-> `Show me how to use debounce from 1o1-utils to delay a search input API call`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use debounce to delay a search input API call
+```

--- a/website/src/content/docs/async/retry.mdx
+++ b/website/src/content/docs/async/retry.mdx
@@ -69,4 +69,6 @@ retry on failure, exponential backoff, resilient call, auto retry
 
 ## Prompt suggestion
 
-> `Show me how to use retry from 1o1-utils with exponential backoff for a flaky API`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use retry with exponential backoff for a flaky API
+```

--- a/website/src/content/docs/async/sleep.mdx
+++ b/website/src/content/docs/async/sleep.mdx
@@ -49,4 +49,6 @@ wait, delay, pause, setTimeout promise
 
 ## Prompt suggestion
 
-> `Show me how to use sleep from 1o1-utils to add a delay between sequential API calls`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use sleep to add a delay between sequential API calls
+```

--- a/website/src/content/docs/async/throttle.mdx
+++ b/website/src/content/docs/async/throttle.mdx
@@ -61,4 +61,6 @@ rate limit, limit calls, scroll handler, resize handler
 
 ## Prompt suggestion
 
-> `Show me how to use throttle from 1o1-utils to limit a scroll event handler`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use throttle to limit a scroll event handler
+```

--- a/website/src/content/docs/compare/vs-es-toolkit.mdx
+++ b/website/src/content/docs/compare/vs-es-toolkit.mdx
@@ -90,4 +90,6 @@ es-toolkit alternative, smaller es-toolkit, es-toolkit vs 1o1-utils, lodash alte
 
 ## Prompt suggestion
 
-> `Given my project needs [X], compare es-toolkit and 1o1-utils and recommend which to use.`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Given my project needs [X], compare es-toolkit and 1o1-utils and recommend which to use.
+```

--- a/website/src/content/docs/compare/vs-just.mdx
+++ b/website/src/content/docs/compare/vs-just.mdx
@@ -106,4 +106,6 @@ just alternative, just replacement, angus-c just, micro-module utilities, single
 
 ## Prompt suggestion
 
-> `Migrate my project from the just-* family of packages to 1o1-utils, converting positional calls to named-parameter calls.`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Migrate my project from the just-* family of packages to 1o1-utils, converting positional calls to named-parameter calls.
+```

--- a/website/src/content/docs/compare/vs-lodash.mdx
+++ b/website/src/content/docs/compare/vs-lodash.mdx
@@ -112,4 +112,6 @@ lodash alternative, lodash replacement, tiny lodash, lodash-es alternative, ligh
 
 ## Prompt suggestion
 
-> `Migrate my codebase from lodash to 1o1-utils. Replace _.chunk, _.pick, _.omit, _.groupBy, _.debounce, _.throttle calls using the 1o1-utils equivalents with named parameters.`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Migrate my codebase from lodash to 1o1-utils. Replace _.chunk, _.pick, _.omit, _.groupBy, _.debounce, _.throttle calls using the 1o1-utils equivalents with named parameters.
+```

--- a/website/src/content/docs/compare/vs-radash.mdx
+++ b/website/src/content/docs/compare/vs-radash.mdx
@@ -105,4 +105,6 @@ radash alternative, smaller radash, radash vs 1o1-utils, modern typescript utils
 
 ## Prompt suggestion
 
-> `Compare radash and 1o1-utils for my project. Given my use case of [X], which should I pick?`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Compare radash and 1o1-utils for my project. Given my use case of [X], which should I pick?
+```

--- a/website/src/content/docs/contributing.mdx
+++ b/website/src/content/docs/contributing.mdx
@@ -193,8 +193,15 @@ Every utility **must** include:
 3. **"Also known as"** on the docs page — alternative names for the same concept:
    > **Also known as:** limit number, restrict range, min/max bound
 
-4. **"Prompt suggestion"** on the docs page — a ready-to-copy prompt for AI assistants:
-   > **Prompt suggestion:** `Show me how to use clamp from 1o1-utils to restrict a slider value between min and max`
+4. **"Prompt suggestion"** on the docs page — a ready-to-copy prompt for AI assistants. Use a fenced `text` code block (renders a copy button) and always prefix with the canonical references so the LLM can look up the real API:
+
+   ````markdown
+   ## Prompt suggestion
+
+   ```text
+   I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use clamp to restrict a slider value between min and max
+   ```
+   ````
 
 ### Style (enforced by Biome)
 

--- a/website/src/content/docs/functions/once.mdx
+++ b/website/src/content/docs/functions/once.mdx
@@ -64,4 +64,6 @@ run once, single call, lazy init, singleton, memoize no-arg
 
 ## Prompt suggestion
 
-> `Show me how to use once from 1o1-utils to lazily initialize a singleton client`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use once to lazily initialize a singleton client
+```

--- a/website/src/content/docs/objects/clone-deep.mdx
+++ b/website/src/content/docs/objects/clone-deep.mdx
@@ -82,4 +82,6 @@ deep clone, deep copy, clone object, copy object, structuredClone alternative
 
 ## Prompt suggestion
 
-> `Show me how to use cloneDeep from 1o1-utils to snapshot nested state before mutating it`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use cloneDeep to snapshot nested state before mutating it
+```

--- a/website/src/content/docs/objects/deep-merge.mdx
+++ b/website/src/content/docs/objects/deep-merge.mdx
@@ -55,4 +55,6 @@ merge objects, recursive merge, combine objects, extend deep
 
 ## Prompt suggestion
 
-> `Show me how to use deepMerge from 1o1-utils to merge user settings with defaults`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use deepMerge to merge user settings with defaults
+```

--- a/website/src/content/docs/objects/defaults-deep.mdx
+++ b/website/src/content/docs/objects/defaults-deep.mdx
@@ -65,4 +65,6 @@ deep defaults, nested defaults, fill undefined recursive, fallback object deep
 
 ## Prompt suggestion
 
-> `Show me how to use defaultsDeep from 1o1-utils to merge a nested config with default values without overriding user settings`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use defaultsDeep to merge a nested config with default values without overriding user settings
+```

--- a/website/src/content/docs/objects/defaults.mdx
+++ b/website/src/content/docs/objects/defaults.mdx
@@ -63,4 +63,6 @@ default values, fill undefined, fallback object, with defaults
 
 ## Prompt suggestion
 
-> `Show me how to use defaults from 1o1-utils to merge a config object with fallback values without overriding explicit nulls`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use defaults to merge a config object with fallback values without overriding explicit nulls
+```

--- a/website/src/content/docs/objects/get.mdx
+++ b/website/src/content/docs/objects/get.mdx
@@ -60,4 +60,6 @@ read nested, dot notation, deep access, safe access, property path, lodash get
 
 ## Prompt suggestion
 
-> `Show me how to use get from 1o1-utils to safely read a nested field from an API response with a default fallback`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use get to safely read a nested field from an API response with a default fallback
+```

--- a/website/src/content/docs/objects/is-empty.mdx
+++ b/website/src/content/docs/objects/is-empty.mdx
@@ -66,4 +66,6 @@ is empty, is blank, has value, null check, empty check
 
 ## Prompt suggestion
 
-> `Show me how to use isEmpty from 1o1-utils to validate form fields before submission`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use isEmpty to validate form fields before submission
+```

--- a/website/src/content/docs/objects/omit.mdx
+++ b/website/src/content/docs/objects/omit.mdx
@@ -56,4 +56,6 @@ exclude keys, remove properties, without keys, strip fields
 
 ## Prompt suggestion
 
-> `Show me how to use omit from 1o1-utils to strip sensitive fields before logging`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use omit to strip sensitive fields before logging
+```

--- a/website/src/content/docs/objects/pick.mdx
+++ b/website/src/content/docs/objects/pick.mdx
@@ -56,4 +56,6 @@ select keys, extract properties, subset object, pluck
 
 ## Prompt suggestion
 
-> `Show me how to use pick from 1o1-utils to extract only needed fields from an API response`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use pick to extract only needed fields from an API response
+```

--- a/website/src/content/docs/objects/set.mdx
+++ b/website/src/content/docs/objects/set.mdx
@@ -62,4 +62,6 @@ write nested, dot notation, deep set, property path, immutable set, lodash set
 
 ## Prompt suggestion
 
-> `Show me how to use set from 1o1-utils to immutably update a deeply nested field in a Redux-style state`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use set to immutably update a deeply nested field in a Redux-style state
+```

--- a/website/src/content/docs/strings/capitalize.mdx
+++ b/website/src/content/docs/strings/capitalize.mdx
@@ -56,4 +56,6 @@ uppercase first, first letter uppercase, initial cap
 
 ## Prompt suggestion
 
-> `Show me how to use capitalize from 1o1-utils to format user display names`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use capitalize to format user display names
+```

--- a/website/src/content/docs/strings/slugify.mdx
+++ b/website/src/content/docs/strings/slugify.mdx
@@ -57,4 +57,6 @@ url slug, url friendly, permalink, dash case url
 
 ## Prompt suggestion
 
-> `Show me how to use slugify from 1o1-utils to generate URL slugs from article titles`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use slugify to generate URL slugs from article titles
+```

--- a/website/src/content/docs/strings/transform-case.mdx
+++ b/website/src/content/docs/strings/transform-case.mdx
@@ -75,4 +75,6 @@ camelCase, snake_case, kebab-case, PascalCase, Title Case, convert case, acronym
 
 ## Prompt suggestion
 
-> `Show me how to use transformCase from 1o1-utils to convert API snake_case keys to camelCase`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use transformCase to convert API snake_case keys to camelCase
+```

--- a/website/src/content/docs/strings/truncate.mdx
+++ b/website/src/content/docs/strings/truncate.mdx
@@ -59,4 +59,6 @@ shorten text, ellipsis, cut string, text overflow
 
 ## Prompt suggestion
 
-> `Show me how to use truncate from 1o1-utils to shorten long descriptions in a card component`
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use truncate to shorten long descriptions in a card component
+```


### PR DESCRIPTION
## Summary

- Adds canonical references (npm, GitHub, llms.txt) to every "Prompt suggestion" block so LLMs can look up the real 1o1-utils API instead of hallucinating.
- Converts prompts from blockquote to fenced `text` code block — Expressive Code renders a copy button for free.
- Updates `contributing.mdx` template so future utilities follow the new rule.

Scope: 28 MDX files (22 utilities + 4 compare pages + contributing guide).

## Test plan

- [ ] `cd website && pnpm dev` → open any util page (e.g. `/objects/defaults/`) and confirm the prompt renders as a code block with a copy button
- [ ] Copy a prompt and paste into Claude/ChatGPT — verify it follows the links and returns correct 1o1-utils API usage
- [ ] `pnpm build` succeeds without warnings