### PR TITLE
ci(release): ensure git tag is pushed for each version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,12 +41,29 @@ jobs:
         run: pnpm build
 
       - name: Create Release PR or Publish
+        id: changesets
         uses: changesets/action@v1
         with:
           publish: pnpm changeset publish
           title: "chore: version packages"
           commit: "chore: version packages"
+          createGithubReleases: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Ensure git tag exists for current version
+        if: ${{ startsWith(github.event.head_commit.message, 'chore: version packages') }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          TAG="v${VERSION}"
+          if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} already exists on origin — nothing to do."
+            exit 0
+          fi
+          echo "Tag ${TAG} missing on origin — creating and pushing."
+          git tag -a "${TAG}" -m "${TAG}"
+          git push origin "${TAG}"


### PR DESCRIPTION
## Summary

- Add `createGithubReleases: true` to `changesets/action@v1` so future releases get a GitHub Release alongside the tag.
- Add a fallback step that reads the version from `package.json` and creates/pushes `v<version>` when the HEAD commit is `chore: version packages` and the tag doesn't yet exist on origin — ensures the tag is generated even when `changeset publish` is skipped (version already on npm) or fails.

## Context

Only tag `1.1.0` existed. Versions `1.2.0` → `1.5.0` were published to npm but without a matching git tag because:
- The release job for `chore: version packages (#104)` and `(#109)` failed in CI with `E404` during `npm publish`.
- Publishing was then done manually, but `changesets/action` only creates/pushes the tag after a successful publish in CI.
- Subsequent runs see "already published" and skip publish → no tag gets created.

The missing tags (`v1.2.0`, `v1.3.0`, `v1.4.0`, `v1.4.1`, `v1.5.0`) were backfilled outside this PR, together with GitHub Releases generated from `CHANGELOG.md`.

## Follow-up (outside this PR)

`NPM_TOKEN` in GitHub Secrets needs to be a Granular Access Token with `packages: write` scope on the `1o1-utils` package to avoid the `E404` with `provenance: true` on future publishes.

## Test plan

- [ ] Next "chore: version packages" merge triggers the workflow and creates/pushes `v<new-version>` automatically.
- [ ] `git ls-remote --tags origin` lists the new tag.
- [ ] GitHub Release appears on the releases page.
- [ ] If `changeset publish` skips with "already published", the fallback step still creates the tag.