### PR TITLE
ci: add openssf scorecard and harden supply chain

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,16 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10

--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -7,11 +7,11 @@ jobs:
   bench:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: pnpm
@@ -20,7 +20,7 @@ jobs:
 
       - run: pnpm bench --ci
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: benchmark-results
           path: docs/benchmarks/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: pnpm

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,11 +18,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: pnpm
@@ -36,7 +36,7 @@ jobs:
       - name: Build website
         run: cd website && pnpm build
 
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: website/dist
 
@@ -48,4 +48,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,11 +16,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: pnpm
@@ -42,7 +42,7 @@ jobs:
 
       - name: Create Release PR or Publish
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@6a0a831ff30acef54f2c6aa1cbbc1096b066edaf # v1.7.0
         with:
           publish: pnpm changeset publish
           title: "chore: version packages"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,41 @@
+name: Scorecard supply-chain security
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: '27 6 * * 1'
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@4eaacf0543bb3f2c246792bd56e8cdeffafb205a # v2.4.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: SARIF
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a # v3.35.2
+        with:
+          sarif_file: results.sarif

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -12,18 +12,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 22.x
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
-      - uses: andresz1/size-limit-action@v1
+      - uses: andresz1/size-limit-action@94bc357df29c36c8f8d50ea497c3e225c3c95d1d # v1.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           build_script: build

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
   <a href="https://www.npmjs.com/package/1o1-utils"><img src="https://img.shields.io/npm/v/1o1-utils" alt="npm version"></a>
   <a href="https://bundlephobia.com/package/1o1-utils"><img src="https://img.shields.io/bundlephobia/minzip/1o1-utils" alt="bundle size"></a>
   <a href="https://github.com/pedrotroccoli/1o1-utils/blob/main/LICENSE"><img src="https://img.shields.io/npm/l/1o1-utils" alt="license"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/pedrotroccoli/1o1-utils"><img src="https://api.scorecard.dev/projects/github.com/pedrotroccoli/1o1-utils/badge" alt="OpenSSF Scorecard"></a>
 </p>
 
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,27 @@
+# Security Policy
+
+## Supported Versions
+
+Only the latest minor version of `1o1-utils` receives security updates. Older versions will not be patched — please upgrade.
+
+| Version | Supported |
+| ------- | --------- |
+| latest  | yes       |
+| older   | no        |
+
+## Reporting a Vulnerability
+
+Please report security issues **privately** via GitHub's [Security Advisories](https://github.com/pedrotroccoli/1o1-utils/security/advisories/new). Do not open a public issue.
+
+If GitHub Security Advisories is not an option, email `pedroaugustobelzkai@gmail.com` with:
+
+- A description of the issue
+- Steps to reproduce
+- The version affected
+- Any suggested mitigation
+
+You should receive an acknowledgement within 72 hours. A fix or mitigation plan will follow within 14 days for confirmed issues; critical vulnerabilities are prioritized.
+
+## Scope
+
+This policy covers the `1o1-utils` package published to npm and the code in this repository. Vulnerabilities in transitive dependencies should be reported to their upstream maintainers — though we appreciate a heads-up so we can pin or replace the affected dependency.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,7 +13,7 @@ Only the latest minor version of `1o1-utils` receives security updates. Older ve
 
 Please report security issues **privately** via GitHub's [Security Advisories](https://github.com/pedrotroccoli/1o1-utils/security/advisories/new). Do not open a public issue.
 
-If GitHub Security Advisories is not an option, email `pedroaugustobelzkai@gmail.com` with:
+If GitHub Security Advisories is not an option, email `contact@pedrotroccoli.com` with:
 
 - A description of the issue
 - Steps to reproduce


### PR DESCRIPTION
## Summary

Integrate the [OpenSSF Scorecard](https://scorecard.dev/) to give consumers a standardized supply-chain health signal and to surface concrete gaps.

- **Scorecard workflow** (`scorecard.yml`) — runs weekly (Mon 06:27 UTC), on push to `main`, and on branch-protection-rule changes. Publishes results to `scorecard.dev` and uploads SARIF to the Security tab.
- **README badge** — links to the public Scorecard viewer for this repo.
- **Pinned actions by SHA** in all existing workflows (`bench`, `ci`, `docs`, `release`, `size`) + new `scorecard.yml`. Version kept as trailing comment so Dependabot can bump.
- **Dependabot config** — weekly updates for `npm` + `github-actions` ecosystems. Satisfies the `Dependency-Update-Tool` check.
- **SECURITY.md** — disclosure policy via GitHub Security Advisories + email. Satisfies the `Security-Policy` check.

## Manual follow-ups (GitHub settings, required to maximize score)

- [ ] Protect `main`: require PR, require status checks (`ci`, `Bundle Size`), dismiss stale reviews — unlocks `Branch-Protection` check.
- [ ] Optional: enable CodeQL via Security tab — unlocks `SAST` check.

## Test plan

- [ ] Merge → `Scorecard supply-chain security` workflow appears in Actions and completes (~2min).
- [ ] Score visible at `https://scorecard.dev/viewer/?uri=github.com/pedrotroccoli/1o1-utils` (~1h after first run for indexing).
- [ ] README badge renders.
- [ ] Existing workflows (`CI`, `Release`, `Deploy Docs`, `Bundle Size`, `Benchmarks`) still green on a test PR — pin-by-SHA change verified.