### PR TITLE
feat(functions): add pipe utility

### DIFF
--- a/.changeset/add-pipe.md
+++ b/.changeset/add-pipe.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `pipe` utility for left-to-right function composition. `pipe(...fns)` returns a function that applies each `fn` in sequence — the first receives the initial arguments, each next receives the previous return value. Aligned with the TC39 pipe operator proposal. Empty `pipe()` returns an identity function.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -119,5 +119,10 @@
     "name": "once",
     "path": "dist/functions/once/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "pipe",
+    "path": "dist/functions/pipe/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -661,3 +661,39 @@ getClient(); // returns same instance
 
 Throws: Error if fn is not a function.
 Arguments from the first call are forwarded to fn; later arguments are ignored. The wrapper preserves `this` from the first invocation. A return value of undefined is still cached — fn will not run again. If fn throws on the first call, the exception propagates and subsequent calls return undefined without retrying. The reference to fn is released after the first call so any state it captures can be garbage-collected.
+
+### pipe
+
+Compose functions left-to-right into a single function. The first function receives the initial arguments; each subsequent function receives the previous function's return value. Aligned with the TC39 pipe operator proposal.
+
+Import: import { pipe } from "1o1-utils/pipe";
+
+Signature:
+function pipe<A extends unknown[], B, C, ..., R>(
+  f1: (...args: A) => B,
+  f2: (b: B) => C,
+  ...
+): (...args: A) => R
+
+Parameters:
+- fns (functions, variadic): Functions to compose, executed in the order provided. Overloads typed up to 10 functions; beyond that, the return type falls back to `unknown`.
+
+Returns: A function that applies every fn in sequence. With zero arguments, returns an identity function.
+
+Example:
+const slug = pipe(
+  (x: string) => x.trim(),
+  (x: string) => x.toLowerCase(),
+  (x: string) => x.replace(/\s+/g, "-"),
+);
+slug("  Hello World  "); // "hello-world"
+
+// First function can take multiple args
+const sum = pipe(
+  (a: number, b: number) => a + b,
+  (n: number) => n * 2,
+);
+sum(2, 3); // 10
+
+Throws: Error if any argument is not a function.
+Execution is synchronous. If a function returns a Promise, the next function receives the Promise (not the awaited value). `pipe()` with no arguments returns an identity function that passes its first argument through unchanged.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -696,4 +696,4 @@ const sum = pipe(
 sum(2, 3); // 10
 
 Throws: Error if any argument is not a function.
-Execution is synchronous. If a function returns a Promise, the next function receives the Promise (not the awaited value). `pipe()` with no arguments returns an identity function that passes its first argument through unchanged.
+Execution is synchronous. If a function returns a Promise, the next function receives the Promise (not the awaited value). `pipe()` with no arguments returns an identity function that passes its first argument through unchanged. Only the first function receives the caller's `this` context; subsequent stages are called without `this` (differs from lodash/flow and es-toolkit/flow, which forward `this` to every stage).

--- a/llms.txt
+++ b/llms.txt
@@ -47,3 +47,4 @@
 ## Functions
 
 - [once](https://pedrotroccoli.github.io/1o1-utils/functions/once/): Create a function that runs only once and caches its result
+- [pipe](https://pedrotroccoli.github.io/1o1-utils/functions/pipe/): Compose functions left-to-right into a single function

--- a/package.json
+++ b/package.json
@@ -29,7 +29,10 @@
 		"truncate",
 		"retry",
 		"sleep",
-		"once"
+		"once",
+		"pipe",
+		"compose",
+		"flow"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -139,6 +142,10 @@
 		"./once": {
 			"import": "./dist/functions/once/index.js",
 			"types": "./dist/functions/once/index.d.ts"
+		},
+		"./pipe": {
+			"import": "./dist/functions/pipe/index.js",
+			"types": "./dist/functions/pipe/index.d.ts"
 		}
 	},
 	"scripts": {
@@ -175,6 +182,7 @@
 		"@types/mocha": "^10.0.10",
 		"c8": "^11.0.0",
 		"chai": "^5.3.1",
+		"es-toolkit": "^1.45.1",
 		"lodash": "^4.18.1",
 		"mocha": "^11.7.1",
 		"radash": "^12.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       chai:
         specifier: ^5.3.1
         version: 5.3.1
+      es-toolkit:
+        specifier: ^1.45.1
+        version: 1.45.1
       lodash:
         specifier: ^4.18.1
         version: 4.18.1
@@ -770,6 +773,9 @@ packages:
   enquirer@2.4.1:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
+
+  es-toolkit@1.45.1:
+    resolution: {integrity: sha512-/jhoOj/Fx+A+IIyDNOvO3TItGmlMKhtX8ISAHKE90c4b/k1tqaqEZ+uUqfpU8DMnW5cgNJv606zS55jGvza0Xw==}
 
   esbuild@0.25.9:
     resolution: {integrity: sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g==}
@@ -1931,6 +1937,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  es-toolkit@1.45.1: {}
 
   esbuild@0.25.9:
     optionalDependencies:

--- a/src/functions/pipe/index.bench.ts
+++ b/src/functions/pipe/index.bench.ts
@@ -1,0 +1,38 @@
+import { flow as esToolkitFlow } from "es-toolkit";
+import lodashFlow from "lodash/flow.js";
+import { Bench } from "tinybench";
+import { pipe } from "./index.js";
+
+const f1 = (x: number) => x + 1;
+const f2 = (x: number) => x * 2;
+const f3 = (x: number) => x - 3;
+
+const bench = new Bench({ name: "pipe", time: 1000 });
+
+bench
+  .add("1o1-utils (creation)", () => {
+    pipe(f1, f2, f3);
+  })
+  .add("lodash (creation)", () => {
+    lodashFlow(f1, f2, f3);
+  })
+  .add("es-toolkit (creation)", () => {
+    esToolkitFlow(f1, f2, f3);
+  });
+
+const piped = pipe(f1, f2, f3);
+const flowedLodash = lodashFlow(f1, f2, f3);
+const flowedEsToolkit = esToolkitFlow(f1, f2, f3);
+
+bench
+  .add("1o1-utils (invocation)", () => {
+    piped(10);
+  })
+  .add("lodash (invocation)", () => {
+    flowedLodash(10);
+  })
+  .add("es-toolkit (invocation)", () => {
+    flowedEsToolkit(10);
+  });
+
+export { bench };

--- a/src/functions/pipe/index.spec.ts
+++ b/src/functions/pipe/index.spec.ts
@@ -104,6 +104,36 @@ describe("pipe", () => {
     expect(() => failing(1)).to.throw("boom");
   });
 
+  it("should forward `this` to the first function", () => {
+    const obj = {
+      value: 42,
+      compute: pipe(
+        function (this: { value: number }) {
+          return this.value;
+        },
+        (n: number) => n * 2,
+      ),
+    };
+
+    expect(obj.compute()).to.equal(84);
+  });
+
+  it("should not forward the caller's `this` to subsequent stages", () => {
+    let receivedThis: unknown = "not called";
+    const composed = pipe(
+      (x: number) => x + 1,
+      function (this: unknown, x: number) {
+        receivedThis = this;
+        return x * 2;
+      },
+    );
+
+    const callerCtx = { marker: "caller-ctx" };
+    composed.call(callerCtx, 5);
+
+    expect(receivedThis).to.not.equal(callerCtx);
+  });
+
   it("should not mutate the input array of functions", () => {
     const fns = [
       (x: number) => x + 1,

--- a/src/functions/pipe/index.spec.ts
+++ b/src/functions/pipe/index.spec.ts
@@ -1,0 +1,119 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { pipe } from "./index.js";
+
+describe("pipe", () => {
+  it("should compose functions left-to-right", () => {
+    const slug = pipe(
+      (x: string) => x.trim(),
+      (x: string) => x.toLowerCase(),
+      (x: string) => x.replace(/\s+/g, "-"),
+    );
+
+    expect(slug("  Hello World  ")).to.equal("hello-world");
+  });
+
+  it("should pass multiple args to the first function only", () => {
+    const composed = pipe(
+      (a: number, b: number) => a + b,
+      (n: number) => n * 2,
+      (n: number) => `result:${n}`,
+    );
+
+    expect(composed(2, 3)).to.equal("result:10");
+  });
+
+  it("should behave as identity when called with no functions", () => {
+    const identity = pipe();
+
+    expect(identity(42)).to.equal(42);
+    expect(identity("hello")).to.equal("hello");
+
+    const obj = { a: 1 };
+    expect(identity(obj)).to.equal(obj);
+  });
+
+  it("should return the single function when called with one function", () => {
+    const double = pipe((n: number) => n * 2);
+
+    expect(double(5)).to.equal(10);
+  });
+
+  it("should forward all args to a single composed function", () => {
+    const sum = pipe((a: number, b: number, c: number) => a + b + c);
+
+    expect(sum(1, 2, 3)).to.equal(6);
+  });
+
+  it("should work with two functions", () => {
+    const composed = pipe(
+      (x: number) => x + 1,
+      (x: number) => x * 2,
+    );
+
+    expect(composed(3)).to.equal(8);
+  });
+
+  it("should preserve types across the chain", () => {
+    const length = pipe(
+      (x: string) => x.trim(),
+      (x: string) => x.split(""),
+      (chars: string[]) => chars.length,
+    );
+
+    const result: number = length("  abc  ");
+    expect(result).to.equal(3);
+  });
+
+  it("should throw if any argument is not a function", () => {
+    expect(() =>
+      pipe(
+        (x: number) => x + 1,
+        // @ts-expect-error - we want to test the error case
+        "not a function",
+      ),
+    ).to.throw("All 'fns' parameters must be functions");
+  });
+
+  it("should throw if the first argument is not a function", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      pipe(42, (x: number) => x + 1),
+    ).to.throw("All 'fns' parameters must be functions");
+  });
+
+  it("should throw if an argument is undefined", () => {
+    expect(() =>
+      pipe(
+        (x: number) => x + 1,
+        // @ts-expect-error - we want to test the error case
+        undefined,
+      ),
+    ).to.throw("All 'fns' parameters must be functions");
+  });
+
+  it("should propagate exceptions thrown by composed functions", () => {
+    const failing = pipe(
+      (x: number) => x + 1,
+      () => {
+        throw new Error("boom");
+      },
+      (x: number) => x * 2,
+    );
+
+    expect(() => failing(1)).to.throw("boom");
+  });
+
+  it("should not mutate the input array of functions", () => {
+    const fns = [
+      (x: number) => x + 1,
+      (x: number) => x * 2,
+      (x: number) => x - 3,
+    ] as const;
+    const composed = pipe(...fns);
+
+    composed(5);
+
+    expect(fns.length).to.equal(3);
+  });
+});

--- a/src/functions/pipe/index.ts
+++ b/src/functions/pipe/index.ts
@@ -28,6 +28,9 @@ import type { PipeFn } from "./types.js";
  * With zero arguments, returns an identity function that passes its first
  * argument through unchanged. Execution is synchronous — if a function returns
  * a Promise, the next function receives the Promise (not the awaited value).
+ * Only the first function receives the caller's `this` context; subsequent
+ * stages are called without `this` (differs from `lodash/flow` and
+ * `es-toolkit/flow`, which forward `this` to every stage).
  */
 const pipe: PipeFn = ((...fns: Array<(...args: unknown[]) => unknown>) => {
   for (let i = 0; i < fns.length; i++) {
@@ -47,7 +50,8 @@ const pipe: PipeFn = ((...fns: Array<(...args: unknown[]) => unknown>) => {
   return function (this: unknown, ...args: unknown[]) {
     let result = fns[0].apply(this, args);
     for (let i = 1; i < fns.length; i++) {
-      result = fns[i](result);
+      const fn = fns[i];
+      result = fn(result);
     }
     return result;
   };

--- a/src/functions/pipe/index.ts
+++ b/src/functions/pipe/index.ts
@@ -1,0 +1,56 @@
+import type { PipeFn } from "./types.js";
+
+/**
+ * Composes functions left-to-right into a single function. The first function
+ * receives the initial arguments; each subsequent function receives the
+ * previous function's return value.
+ *
+ * @param fns - Functions to compose, executed in the order provided
+ * @returns A function that applies every `fn` in sequence
+ *
+ * @example
+ * ```ts
+ * const slug = pipe(
+ *   (x: string) => x.trim(),
+ *   (x: string) => x.toLowerCase(),
+ *   (x: string) => x.replace(/\s+/g, "-"),
+ * );
+ *
+ * slug("  Hello World  "); // "hello-world"
+ * ```
+ *
+ * @keywords compose, function composition, flow, left-to-right, pipeline, chain, sequence, combine functions
+ * @see TC39 pipe operator proposal (https://github.com/tc39/proposal-pipeline-operator)
+ *
+ * @throws Error if any argument is not a function
+ *
+ * @remarks
+ * With zero arguments, returns an identity function that passes its first
+ * argument through unchanged. Execution is synchronous — if a function returns
+ * a Promise, the next function receives the Promise (not the awaited value).
+ */
+const pipe: PipeFn = ((...fns: Array<(...args: unknown[]) => unknown>) => {
+  for (let i = 0; i < fns.length; i++) {
+    if (typeof fns[i] !== "function") {
+      throw new Error("All 'fns' parameters must be functions");
+    }
+  }
+
+  if (fns.length === 0) {
+    return (x: unknown) => x;
+  }
+
+  if (fns.length === 1) {
+    return fns[0];
+  }
+
+  return function (this: unknown, ...args: unknown[]) {
+    let result = fns[0].apply(this, args);
+    for (let i = 1; i < fns.length; i++) {
+      result = fns[i](result);
+    }
+    return result;
+  };
+}) as PipeFn;
+
+export { pipe };

--- a/src/functions/pipe/types.ts
+++ b/src/functions/pipe/types.ts
@@ -1,7 +1,7 @@
 type AnyFn = (...args: never[]) => unknown;
 
 interface PipeFn {
-  <T>(): (x: T) => T;
+  (): <T>(x: T) => T;
   <A extends unknown[], R>(f1: (...args: A) => R): (...args: A) => R;
   <A extends unknown[], B, R>(
     f1: (...args: A) => B,

--- a/src/functions/pipe/types.ts
+++ b/src/functions/pipe/types.ts
@@ -1,9 +1,7 @@
 type AnyFn = (...args: never[]) => unknown;
 
 interface PipeFn {
-  <A extends unknown[]>(): (
-    ...args: A
-  ) => A extends [infer T, ...unknown[]] ? T : A[0];
+  <T>(): (x: T) => T;
   <A extends unknown[], R>(f1: (...args: A) => R): (...args: A) => R;
   <A extends unknown[], B, R>(
     f1: (...args: A) => B,

--- a/src/functions/pipe/types.ts
+++ b/src/functions/pipe/types.ts
@@ -1,0 +1,83 @@
+type AnyFn = (...args: never[]) => unknown;
+
+interface PipeFn {
+  <A extends unknown[]>(): (
+    ...args: A
+  ) => A extends [infer T, ...unknown[]] ? T : A[0];
+  <A extends unknown[], R>(f1: (...args: A) => R): (...args: A) => R;
+  <A extends unknown[], B, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, F, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => F,
+    f6: (f: F) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, F, G, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => F,
+    f6: (f: F) => G,
+    f7: (g: G) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, F, G, H, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => F,
+    f6: (f: F) => G,
+    f7: (g: G) => H,
+    f8: (h: H) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, F, G, H, I, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => F,
+    f6: (f: F) => G,
+    f7: (g: G) => H,
+    f8: (h: H) => I,
+    f9: (i: I) => R,
+  ): (...args: A) => R;
+  <A extends unknown[], B, C, D, E, F, G, H, I, J, R>(
+    f1: (...args: A) => B,
+    f2: (b: B) => C,
+    f3: (c: C) => D,
+    f4: (d: D) => E,
+    f5: (e: E) => F,
+    f6: (f: F) => G,
+    f7: (g: G) => H,
+    f8: (h: H) => I,
+    f9: (i: I) => J,
+    f10: (j: J) => R,
+  ): (...args: A) => R;
+  (...fns: AnyFn[]): (...args: unknown[]) => unknown;
+}
+
+export type { PipeFn };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { retry } from "./async/retry/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
 export { once } from "./functions/once/index.js";
+export { pipe } from "./functions/pipe/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
 export { defaults } from "./objects/defaults/index.js";

--- a/website/src/content/docs/functions/pipe.mdx
+++ b/website/src/content/docs/functions/pipe.mdx
@@ -77,6 +77,7 @@ const n: number = length("  abc  "); // 3
 - `pipe(fn)` with a single function returns that function unchanged — all arguments are forwarded.
 - Execution is synchronous. If a function returns a `Promise`, the next function receives the `Promise` (not the awaited value).
 - Exceptions thrown by composed functions propagate out of the composed function.
+- Only the first function receives the caller's `this` context; subsequent stages are called without `this`. Differs from `lodash/flow` and `es-toolkit/flow`, which forward `this` to every stage.
 
 ## Also known as
 

--- a/website/src/content/docs/functions/pipe.mdx
+++ b/website/src/content/docs/functions/pipe.mdx
@@ -1,0 +1,89 @@
+---
+title: pipe
+description: Compose functions left-to-right into a single function
+---
+
+Composes functions left-to-right. The first function receives the initial arguments; each subsequent function receives the previous function's return value. Aligned with the [TC39 pipe operator proposal](https://github.com/tc39/proposal-pipeline-operator).
+
+## Import
+
+```ts
+import { pipe } from "1o1-utils";
+```
+
+```ts
+import { pipe } from "1o1-utils/pipe";
+```
+
+## Signature
+
+```ts
+function pipe<A extends unknown[], B, C, ..., R>(
+  f1: (...args: A) => B,
+  f2: (b: B) => C,
+  // ...
+): (...args: A) => R
+```
+
+Overloads are typed up to 10 functions. Beyond that, the return type falls back to `unknown`.
+
+## Parameters
+
+| Name  | Type                       | Required | Description                                                     |
+| ----- | -------------------------- | -------- | --------------------------------------------------------------- |
+| `fns` | `Array<(...args) => any>`  | No       | Functions to compose, executed in the order provided (variadic) |
+
+## Returns
+
+A function that applies every `fn` in sequence. Calling `pipe()` with no arguments returns an identity function that passes its first argument through unchanged.
+
+## Examples
+
+```ts
+const slug = pipe(
+  (x: string) => x.trim(),
+  (x: string) => x.toLowerCase(),
+  (x: string) => x.replace(/\s+/g, "-"),
+);
+
+slug("  Hello World  "); // "hello-world"
+```
+
+```ts
+// First function can take multiple args
+const sum = pipe(
+  (a: number, b: number) => a + b,
+  (n: number) => n * 2,
+);
+
+sum(2, 3); // 10
+```
+
+```ts
+// Type inference flows across the chain
+const length = pipe(
+  (x: string) => x.trim(),
+  (x: string) => x.split(""),
+  (chars: string[]) => chars.length,
+);
+
+const n: number = length("  abc  "); // 3
+```
+
+## Edge Cases
+
+- Throws if any argument is not a function.
+- `pipe()` with zero arguments returns an identity function.
+- `pipe(fn)` with a single function returns that function unchanged — all arguments are forwarded.
+- Execution is synchronous. If a function returns a `Promise`, the next function receives the `Promise` (not the awaited value).
+- Exceptions thrown by composed functions propagate out of the composed function.
+
+## Also known as
+
+compose, function composition, flow, left-to-right, pipeline, chain, sequence, combine functions
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use pipe to compose a string-transformation pipeline
+```


### PR DESCRIPTION
## Summary

Adds `pipe(...fns)` — left-to-right function composition, aligned with the [TC39 pipe operator proposal](https://github.com/tc39/proposal-pipeline-operator). Closes #85.

- 10 typed overloads + variadic fallback
- First fn is variadic (accepts any args), subsequent stages unary
- `pipe()` with no args → identity (preserves input type)
- Validates every arg is a function at creation time

## Perf

Benchmarked against `lodash/flow` and `es-toolkit/flow` (tinybench, 1 s, 3 fns):

| Op         | 1o1-utils | es-toolkit | lodash    |
| ---------- | --------- | ---------- | --------- |
| Creation   | 24.1 ns   | 21.9 ns    | 105.9 ns  |
| Invocation | **44.9 ns** | 59.1 ns | 60.5 ns   |

~30% faster invocation than es-toolkit/lodash by skipping per-stage `.call(this, ...)` — only the first fn receives the caller's `this`, subsequent stages are called directly. Semantic trade-off documented in index.ts, pipe.mdx, and llms-full.txt.

## Bundle size

- `pipe`: 165 B (limit 1 kB)
- Total bundle: 3.15 kB (limit 5 kB)

## Test plan

- [x] `pnpm test` — 335 passing (14 new for pipe)
- [x] `pnpm test:coverage` — pipe 100% stmts/lines, 90% branches
- [x] `pnpm build` — clean
- [x] `pnpm check` — no new warnings
- [x] `pnpm size` — under limits
- [x] `pnpm bench pipe` — perf numbers above
- [x] Smoke: issue example produces `'hello-world'`