### PR TITLE
feat(numbers): add inRange utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,12 @@ import { pick } from "1o1-utils/pick";
 | `pick` | Extract keys from an object | `1o1-utils/pick` |
 | `set` | Set a nested value immutably via dot notation | `1o1-utils/set` |
 
+### Numbers
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `inRange` | Check if a number is within a range | `1o1-utils/in-range` |
+
 ### Strings
 
 | Utility | Description | Import |

--- a/package.json
+++ b/package.json
@@ -32,7 +32,10 @@
 		"once",
 		"pipe",
 		"compose",
-		"flow"
+		"flow",
+		"in-range",
+		"between",
+		"range-check"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -102,6 +105,10 @@
 		"./sort-by": {
 			"import": "./dist/arrays/sort-by/index.js",
 			"types": "./dist/arrays/sort-by/index.d.ts"
+		},
+		"./in-range": {
+			"import": "./dist/numbers/in-range/index.js",
+			"types": "./dist/numbers/in-range/index.d.ts"
 		},
 		"./is-empty": {
 			"import": "./dist/objects/is-empty/index.js",

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -168,6 +168,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Wraps a function so it runs at most once; subsequent calls return the cached result. Compared against `lodash.once`.",
   },
+  inRange: {
+    slug: "in-range",
+    description:
+      "Checks if a number falls within a given range (inclusive start, exclusive end). Compared against `lodash.inRange`, `radash.inRange`, and a native equivalent.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
 export { once } from "./functions/once/index.js";
 export { pipe } from "./functions/pipe/index.js";
+export { inRange } from "./numbers/in-range/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
 export { defaults } from "./objects/defaults/index.js";

--- a/src/numbers/in-range/index.bench.ts
+++ b/src/numbers/in-range/index.bench.ts
@@ -1,0 +1,90 @@
+import { inRange as lodashInRange } from "lodash";
+import { inRange as radashInRange } from "radash";
+import { Bench } from "tinybench";
+import { inRange } from "./index.js";
+
+const inside = { value: 50, start: 0, end: 100 };
+const atStart = { value: 0, start: 0, end: 100 };
+const atEnd = { value: 100, start: 0, end: 100 };
+const outside = { value: 150, start: 0, end: 100 };
+const swapped = { value: 50, start: 100, end: 0 };
+
+function nativeInRange(value: number, start: number, end: number): boolean {
+  const lower = start < end ? start : end;
+  const upper = start < end ? end : start;
+  return value >= lower && value < upper;
+}
+
+const bench = new Bench({ name: "inRange", time: 1000 });
+
+bench
+  .add("1o1-utils (inside)", () => {
+    inRange(inside);
+  })
+  .add("lodash (inside)", () => {
+    lodashInRange(inside.value, inside.start, inside.end);
+  })
+  .add("radash (inside)", () => {
+    radashInRange(inside.value, inside.start, inside.end);
+  })
+  .add("native (inside)", () => {
+    nativeInRange(inside.value, inside.start, inside.end);
+  });
+
+bench
+  .add("1o1-utils (at-start)", () => {
+    inRange(atStart);
+  })
+  .add("lodash (at-start)", () => {
+    lodashInRange(atStart.value, atStart.start, atStart.end);
+  })
+  .add("radash (at-start)", () => {
+    radashInRange(atStart.value, atStart.start, atStart.end);
+  })
+  .add("native (at-start)", () => {
+    nativeInRange(atStart.value, atStart.start, atStart.end);
+  });
+
+bench
+  .add("1o1-utils (at-end)", () => {
+    inRange(atEnd);
+  })
+  .add("lodash (at-end)", () => {
+    lodashInRange(atEnd.value, atEnd.start, atEnd.end);
+  })
+  .add("radash (at-end)", () => {
+    radashInRange(atEnd.value, atEnd.start, atEnd.end);
+  })
+  .add("native (at-end)", () => {
+    nativeInRange(atEnd.value, atEnd.start, atEnd.end);
+  });
+
+bench
+  .add("1o1-utils (outside)", () => {
+    inRange(outside);
+  })
+  .add("lodash (outside)", () => {
+    lodashInRange(outside.value, outside.start, outside.end);
+  })
+  .add("radash (outside)", () => {
+    radashInRange(outside.value, outside.start, outside.end);
+  })
+  .add("native (outside)", () => {
+    nativeInRange(outside.value, outside.start, outside.end);
+  });
+
+bench
+  .add("1o1-utils (swapped)", () => {
+    inRange(swapped);
+  })
+  .add("lodash (swapped)", () => {
+    lodashInRange(swapped.value, swapped.start, swapped.end);
+  })
+  .add("radash (swapped)", () => {
+    radashInRange(swapped.value, swapped.start, swapped.end);
+  })
+  .add("native (swapped)", () => {
+    nativeInRange(swapped.value, swapped.start, swapped.end);
+  });
+
+export { bench };

--- a/src/numbers/in-range/index.bench.ts
+++ b/src/numbers/in-range/index.bench.ts
@@ -1,4 +1,4 @@
-import { inRange as lodashInRange } from "lodash";
+import lodashInRange from "lodash/inRange.js";
 import { inRange as radashInRange } from "radash";
 import { Bench } from "tinybench";
 import { inRange } from "./index.js";

--- a/src/numbers/in-range/index.spec.ts
+++ b/src/numbers/in-range/index.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { inRange } from "./index.js";
+
+describe("inRange", () => {
+  it("should return true when value is inside the range", () => {
+    expect(inRange({ value: 3, start: 1, end: 5 })).to.equal(true);
+  });
+
+  it("should return true at the start bound (inclusive)", () => {
+    expect(inRange({ value: 1, start: 1, end: 5 })).to.equal(true);
+  });
+
+  it("should return false at the end bound (exclusive)", () => {
+    expect(inRange({ value: 5, start: 1, end: 5 })).to.equal(false);
+  });
+
+  it("should handle negative ranges", () => {
+    expect(inRange({ value: -1, start: -5, end: 5 })).to.equal(true);
+    expect(inRange({ value: -5, start: -5, end: 0 })).to.equal(true);
+    expect(inRange({ value: -6, start: -5, end: 0 })).to.equal(false);
+  });
+
+  it("should swap bounds when start is greater than end", () => {
+    expect(inRange({ value: 3, start: 5, end: 1 })).to.equal(true);
+    expect(inRange({ value: 1, start: 5, end: 1 })).to.equal(true);
+    expect(inRange({ value: 5, start: 5, end: 1 })).to.equal(false);
+  });
+
+  it("should return false for a zero-width range", () => {
+    expect(inRange({ value: 1, start: 1, end: 1 })).to.equal(false);
+  });
+
+  it("should handle floating-point values", () => {
+    expect(inRange({ value: 1.5, start: 1, end: 2 })).to.equal(true);
+    expect(inRange({ value: 2, start: 1, end: 2 })).to.equal(false);
+  });
+
+  it("should return false for values below the range", () => {
+    expect(inRange({ value: 0, start: 1, end: 5 })).to.equal(false);
+  });
+
+  it("should return false for values above the range", () => {
+    expect(inRange({ value: 10, start: 1, end: 5 })).to.equal(false);
+  });
+
+  it("should throw if value is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => inRange({ value: "3", start: 1, end: 5 })).to.throw(
+      "The 'value' parameter must be a number",
+    );
+  });
+
+  it("should throw if start is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => inRange({ value: 3, start: "1", end: 5 })).to.throw(
+      "The 'start' parameter must be a number",
+    );
+  });
+
+  it("should throw if end is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => inRange({ value: 3, start: 1, end: "5" })).to.throw(
+      "The 'end' parameter must be a number",
+    );
+  });
+
+  it("should throw if value is NaN", () => {
+    expect(() => inRange({ value: Number.NaN, start: 1, end: 5 })).to.throw(
+      "The 'value' parameter must be a number",
+    );
+  });
+
+  it("should throw if start is NaN", () => {
+    expect(() => inRange({ value: 3, start: Number.NaN, end: 5 })).to.throw(
+      "The 'start' parameter must be a number",
+    );
+  });
+
+  it("should throw if end is NaN", () => {
+    expect(() => inRange({ value: 3, start: 1, end: Number.NaN })).to.throw(
+      "The 'end' parameter must be a number",
+    );
+  });
+
+  it("should handle Infinity bounds", () => {
+    expect(
+      inRange({ value: 1e10, start: 0, end: Number.POSITIVE_INFINITY }),
+    ).to.equal(true);
+    expect(
+      inRange({ value: -1e10, start: Number.NEGATIVE_INFINITY, end: 0 }),
+    ).to.equal(true);
+  });
+});

--- a/src/numbers/in-range/index.ts
+++ b/src/numbers/in-range/index.ts
@@ -20,7 +20,7 @@ import type { InRangeParams, InRangeResult } from "./types.js";
  *
  * @keywords range, between, bounds, numeric check, clamp check
  *
- * @throws Error if `value`, `start`, or `end` is not a finite number
+ * @throws Error if `value`, `start`, or `end` is not a number or is `NaN`
  */
 function inRange({ value, start, end }: InRangeParams): InRangeResult {
   if (typeof value !== "number" || Number.isNaN(value)) {

--- a/src/numbers/in-range/index.ts
+++ b/src/numbers/in-range/index.ts
@@ -1,0 +1,42 @@
+import type { InRangeParams, InRangeResult } from "./types.js";
+
+/**
+ * Checks if a number falls within a given range.
+ * Start is inclusive, end is exclusive. If `start` is greater than `end`,
+ * the bounds are swapped automatically.
+ *
+ * @param params - The parameters object
+ * @param params.value - The number to check
+ * @param params.start - The start of the range (inclusive)
+ * @param params.end - The end of the range (exclusive)
+ * @returns `true` if `value` is within the range, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * inRange({ value: 3, start: 1, end: 5 });  // true
+ * inRange({ value: 5, start: 1, end: 5 });  // false (end exclusive)
+ * inRange({ value: -1, start: -5, end: 5 }); // true
+ * ```
+ *
+ * @keywords range, between, bounds, numeric check, clamp check
+ *
+ * @throws Error if `value`, `start`, or `end` is not a finite number
+ */
+function inRange({ value, start, end }: InRangeParams): InRangeResult {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new Error("The 'value' parameter must be a number");
+  }
+  if (typeof start !== "number" || Number.isNaN(start)) {
+    throw new Error("The 'start' parameter must be a number");
+  }
+  if (typeof end !== "number" || Number.isNaN(end)) {
+    throw new Error("The 'end' parameter must be a number");
+  }
+
+  const lower = start < end ? start : end;
+  const upper = start < end ? end : start;
+
+  return value >= lower && value < upper;
+}
+
+export { inRange };

--- a/src/numbers/in-range/types.ts
+++ b/src/numbers/in-range/types.ts
@@ -1,0 +1,11 @@
+interface InRangeParams {
+  value: number;
+  start: number;
+  end: number;
+}
+
+type InRangeResult = boolean;
+
+type InRange = (params: InRangeParams) => InRangeResult;
+
+export type { InRange, InRangeParams, InRangeResult };

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -68,6 +68,10 @@ export default defineConfig({
           autogenerate: { directory: "arrays" },
         },
         {
+          label: "Numbers",
+          autogenerate: { directory: "numbers" },
+        },
+        {
           label: "Objects",
           autogenerate: { directory: "objects" },
         },

--- a/website/src/content/docs/numbers/in-range.mdx
+++ b/website/src/content/docs/numbers/in-range.mdx
@@ -1,0 +1,70 @@
+---
+title: inRange
+description: Check if a number falls within a given range
+---
+
+Checks if a number falls within a given range. Start is inclusive, end is exclusive. If `start` is greater than `end`, the bounds are swapped automatically.
+
+## Import
+
+```ts
+import { inRange } from "1o1-utils";
+```
+
+```ts
+import { inRange } from "1o1-utils/in-range";
+```
+
+## Signature
+
+```ts
+function inRange(params: { value: number; start: number; end: number }): boolean
+```
+
+## Parameters
+
+| Name  | Type     | Required | Description                                 |
+| ----- | -------- | -------- | ------------------------------------------- |
+| value | `number` | Yes      | The number to check                         |
+| start | `number` | Yes      | The start of the range (inclusive)          |
+| end   | `number` | Yes      | The end of the range (exclusive)            |
+
+## Returns
+
+`boolean` — `true` if `value` is within `[start, end)`, otherwise `false`.
+
+## Examples
+
+```ts
+inRange({ value: 3, start: 1, end: 5 });   // true
+inRange({ value: 5, start: 1, end: 5 });   // false — end is exclusive
+inRange({ value: 1, start: 1, end: 5 });   // true  — start is inclusive
+inRange({ value: -1, start: -5, end: 5 }); // true
+```
+
+```ts
+// Bounds are swapped automatically when start > end
+inRange({ value: 3, start: 5, end: 1 }); // true
+```
+
+```ts
+// Floating-point values
+inRange({ value: 1.5, start: 1, end: 2 }); // true
+```
+
+## Edge Cases
+
+- Throws if `value`, `start`, or `end` is not a finite number (non-number type or `NaN`).
+- A zero-width range (`start === end`) always returns `false`.
+- Works with `Infinity` bounds — e.g. `{ value: 1e10, start: 0, end: Infinity }` returns `true`.
+- When `start > end`, the bounds are swapped silently. The inclusive side follows the lower bound.
+
+## Also known as
+
+between, range check, bounds check, within range, number range
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use inRange to check if a number is within a bounded range.
+```

--- a/website/src/content/docs/numbers/in-range.mdx
+++ b/website/src/content/docs/numbers/in-range.mdx
@@ -54,7 +54,7 @@ inRange({ value: 1.5, start: 1, end: 2 }); // true
 
 ## Edge Cases
 
-- Throws if `value`, `start`, or `end` is not a finite number (non-number type or `NaN`).
+- Throws if any of `value`, `start`, or `end` is not a number or is `NaN`.
 - A zero-width range (`start === end`) always returns `false`.
 - Works with `Infinity` bounds — e.g. `{ value: 1e10, start: 0, end: Infinity }` returns `true`.
 - When `start > end`, the bounds are swapped silently. The inclusive side follows the lower bound.


### PR DESCRIPTION
## Summary

- Add `inRange` — first utility in new `numbers/` category. Returns `true` when `value` falls within `[start, end)` (inclusive start, exclusive end).
- Auto-swaps bounds when `start > end` (lodash/radash parity).
- Wires barrel export, `1o1-utils/in-range` subpath entry, README row, Numbers sidebar section, docs page, and benchmark against lodash, radash, and native.
- Bench result: on par with lodash/radash/native (~24M ops/s) — primitive op, no realistic perf margin.

## Test plan

- [x] `pnpm test` — 16 new specs pass, 351 total
- [x] `pnpm build` — tsc clean
- [x] `pnpm check` — no new biome warnings
- [x] `pnpm bench in-range` — runs end to end
- [x] `pnpm --filter website build` — docs site builds, `/numbers/in-range/` route present
- [x] Manual import: `import('./dist/numbers/in-range/index.js')` and `import('./dist/index.js').inRange` both resolve and return expected values

Closes #94