### PR TITLE
feat(async): add safely utility

### DIFF
--- a/.changeset/add-safely.md
+++ b/.changeset/add-safely.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `safely` utility to wrap a function so it returns a `[error, result]` tuple instead of throwing. Auto-detects sync and async functions: sync calls return a tuple, async calls return a `Promise` of a tuple. Eliminates verbose try/catch and anticipates the TC39 Safe Assignment Operator proposal. Closes #87.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -106,6 +106,11 @@
     "limit": "2 kB"
   },
   {
+    "name": "safely",
+    "path": "dist/async/safely/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "sleep",
     "path": "dist/async/sleep/index.js",
     "limit": "1 kB"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ import { pick } from "1o1-utils/pick";
 | --- | --- | --- |
 | `debounce` | Debounce function calls | `1o1-utils/debounce` |
 | `retry` | Retry failed async operations | `1o1-utils/retry` |
+| `safely` | Wrap a function to return `[error, result]` instead of throwing | `1o1-utils/safely` |
 | `sleep` | Promise-based delay | `1o1-utils/sleep` |
 | `throttle` | Throttle function calls | `1o1-utils/throttle` |
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -583,6 +583,35 @@ With exponential backoff, delay is delay * 2^i for attempt i. Throws the last er
 
 ---
 
+### safely
+
+Wrap a function so it returns a [error, result] tuple instead of throwing. Auto-detects sync and async functions: sync calls return a tuple, async calls return a Promise of a tuple. Anticipates the TC39 Safe Assignment Operator proposal.
+
+Import: import { safely } from "1o1-utils/safely";
+
+Signature:
+function safely<A extends unknown[], T>(fn: (...args: A) => Promise<T>): (...args: A) => Promise<[undefined, T] | [unknown, undefined]>
+function safely<A extends unknown[], T>(fn: (...args: A) => T): (...args: A) => [undefined, T] | [unknown, undefined]
+
+Parameters:
+- fn ((...args: A) => T | Promise<T>, required): The function to wrap
+
+Returns: A wrapped function. On success returns [undefined, value]. On error returns [error, undefined]. Async functions return a Promise of the tuple.
+
+Example:
+const [err, data] = safely(JSON.parse)('{"a":1}');
+if (err) console.error(err); else console.log(data);
+
+const [fetchErr, user] = await safely(fetchUser)(userId);
+
+const safeParse = safely(JSON.parse);
+const [e1, a] = safeParse('{"x":1}');
+const [e2, b] = safeParse("{bad");
+
+Throws: Error if fn is not a function. Errors caught from fn are typed as unknown — non-Error throws (strings, null, etc.) are preserved as-is. Detects async by checking the return value for a then method, so real Promises and custom thenables both work.
+
+---
+
 ### sleep
 
 Pause execution for a given number of milliseconds by returning a promise.

--- a/llms.txt
+++ b/llms.txt
@@ -41,6 +41,7 @@
 
 - [debounce](https://pedrotroccoli.github.io/1o1-utils/async/debounce/): Create a debounced function with cancel support
 - [retry](https://pedrotroccoli.github.io/1o1-utils/async/retry/): Retry async operations with fixed or exponential backoff
+- [safely](https://pedrotroccoli.github.io/1o1-utils/async/safely/): Wrap a function so it returns a [error, result] tuple instead of throwing
 - [sleep](https://pedrotroccoli.github.io/1o1-utils/async/sleep/): Promise-based delay
 - [throttle](https://pedrotroccoli.github.io/1o1-utils/async/throttle/): Create a throttled function with cancel support
 - [withTimeout](https://pedrotroccoli.github.io/1o1-utils/async/with-timeout/): Race a promise against a timeout with AbortSignal support

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
 		"in-range",
 		"between",
 		"range-check",
-		"shallow-equal"
+		"shallow-equal",
+		"safely",
+		"tryit",
+		"try-catch"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -123,6 +126,10 @@
 		"./retry": {
 			"import": "./dist/async/retry/index.js",
 			"types": "./dist/async/retry/index.d.ts"
+		},
+		"./safely": {
+			"import": "./dist/async/safely/index.js",
+			"types": "./dist/async/safely/index.d.ts"
 		},
 		"./capitalize": {
 			"import": "./dist/strings/capitalize/index.js",

--- a/src/async/safely/index.bench.ts
+++ b/src/async/safely/index.bench.ts
@@ -1,0 +1,53 @@
+import { tryit as radashTryit } from "radash";
+import { Bench } from "tinybench";
+import { safely } from "./index.js";
+
+const bench = new Bench({ name: "safely", time: 500 });
+
+const syncOk = (x: number) => x * 2;
+const syncThrow = () => {
+  throw new Error("nope");
+};
+const asyncOk = async (x: number) => x * 2;
+const asyncThrow = async () => {
+  throw new Error("nope");
+};
+
+bench
+  .add("1o1-utils (sync ok)", () => {
+    safely(syncOk)(21);
+  })
+  .add("native try/catch (sync ok)", () => {
+    try {
+      syncOk(21);
+    } catch {
+      // noop
+    }
+  })
+  .add("radash (sync ok)", async () => {
+    await radashTryit(syncOk)(21);
+  })
+  .add("1o1-utils (sync throw)", () => {
+    safely(syncThrow)();
+  })
+  .add("native try/catch (sync throw)", () => {
+    try {
+      syncThrow();
+    } catch {
+      // noop
+    }
+  })
+  .add("1o1-utils (async ok)", async () => {
+    await safely(asyncOk)(21);
+  })
+  .add("radash (async ok)", async () => {
+    await radashTryit(asyncOk)(21);
+  })
+  .add("1o1-utils (async throw)", async () => {
+    await safely(asyncThrow)();
+  })
+  .add("radash (async throw)", async () => {
+    await radashTryit(asyncThrow)();
+  });
+
+export { bench };

--- a/src/async/safely/index.spec.ts
+++ b/src/async/safely/index.spec.ts
@@ -1,0 +1,158 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { safely } from "./index.js";
+
+describe("safely", () => {
+  describe("sync functions", () => {
+    it("should return [undefined, value] when fn returns a value", () => {
+      const result = safely((x: number) => x * 2)(21);
+      expect(result).to.deep.equal([undefined, 42]);
+    });
+
+    it("should return [error, undefined] when fn throws", () => {
+      const boom = new Error("boom");
+      const result = safely(() => {
+        throw boom;
+      })();
+      expect(result).to.deep.equal([boom, undefined]);
+    });
+
+    it("should pass through multiple arguments", () => {
+      const result = safely((a: number, b: number, c: number) => a + b + c)(
+        1,
+        2,
+        3,
+      );
+      expect(result).to.deep.equal([undefined, 6]);
+    });
+
+    it("should preserve non-Error throws (string)", () => {
+      const result = safely(() => {
+        throw "string error";
+      })();
+      expect(result).to.deep.equal(["string error", undefined]);
+    });
+
+    it("should preserve non-Error throws (null)", () => {
+      const result = safely(() => {
+        throw null;
+      })();
+      expect(result).to.deep.equal([null, undefined]);
+    });
+
+    it("should work with JSON.parse on valid input", () => {
+      const result = safely(JSON.parse)('{"a":1}');
+      expect(result[0]).to.equal(undefined);
+      expect(result[1]).to.deep.equal({ a: 1 });
+    });
+
+    it("should work with JSON.parse on invalid input", () => {
+      const [err, value] = safely(JSON.parse)("{bad");
+      expect(err).to.be.instanceOf(SyntaxError);
+      expect(value).to.equal(undefined);
+    });
+
+    it("should preserve undefined return value", () => {
+      const result = safely(() => undefined)();
+      expect(result).to.deep.equal([undefined, undefined]);
+    });
+
+    it("should preserve null return value", () => {
+      const result = safely(() => null)();
+      expect(result).to.deep.equal([undefined, null]);
+    });
+  });
+
+  describe("async functions", () => {
+    it("should resolve to [undefined, value] when promise resolves", async () => {
+      const result = await safely(async (x: number) => x + 1)(41);
+      expect(result).to.deep.equal([undefined, 42]);
+    });
+
+    it("should resolve to [error, undefined] when promise rejects", async () => {
+      const boom = new Error("async boom");
+      const result = await safely(async () => {
+        throw boom;
+      })();
+      expect(result).to.deep.equal([boom, undefined]);
+    });
+
+    it("should resolve to [error, undefined] for explicit Promise.reject", async () => {
+      const boom = new Error("rejected");
+      const result = await safely(() => Promise.reject(boom))();
+      expect(result).to.deep.equal([boom, undefined]);
+    });
+
+    it("should pass through arguments to async fn", async () => {
+      const result = await safely(async (a: string, b: string) => a + b)(
+        "hello ",
+        "world",
+      );
+      expect(result).to.deep.equal([undefined, "hello world"]);
+    });
+
+    it("should treat custom thenable as async", async () => {
+      const thenable = {
+        // biome-ignore lint/suspicious/noThenProperty: intentionally testing thenable detection
+        then(resolve: (v: number) => void) {
+          resolve(7);
+        },
+      };
+      const result = await safely(
+        () => thenable as unknown as Promise<number>,
+      )();
+      expect(result).to.deep.equal([undefined, 7]);
+    });
+
+    it("should preserve non-Error rejection (string)", async () => {
+      const result = await safely(async () => {
+        throw "rejected string";
+      })();
+      expect(result).to.deep.equal(["rejected string", undefined]);
+    });
+  });
+
+  describe("input validation", () => {
+    it("should throw if fn is not a function (number)", () => {
+      // @ts-expect-error - testing invalid input
+      expect(() => safely(42)).to.throw(
+        "The 'fn' parameter must be a function",
+      );
+    });
+
+    it("should throw if fn is undefined", () => {
+      // @ts-expect-error - testing invalid input
+      expect(() => safely(undefined)).to.throw(
+        "The 'fn' parameter must be a function",
+      );
+    });
+
+    it("should throw if fn is null", () => {
+      // @ts-expect-error - testing invalid input
+      expect(() => safely(null)).to.throw(
+        "The 'fn' parameter must be a function",
+      );
+    });
+  });
+
+  describe("reusability", () => {
+    it("should produce a wrapper that can be called multiple times", () => {
+      const safeDouble = safely((x: number) => x * 2);
+      expect(safeDouble(2)).to.deep.equal([undefined, 4]);
+      expect(safeDouble(5)).to.deep.equal([undefined, 10]);
+    });
+
+    it("should produce an independent async wrapper across calls", async () => {
+      const safeFetch = safely(async (id: number) => {
+        if (id < 0) throw new Error("negative");
+        return id;
+      });
+      const [err1, val1] = await safeFetch(-1);
+      expect(err1).to.be.instanceOf(Error);
+      expect(val1).to.equal(undefined);
+      const [err2, val2] = await safeFetch(3);
+      expect(err2).to.equal(undefined);
+      expect(val2).to.equal(3);
+    });
+  });
+});

--- a/src/async/safely/index.ts
+++ b/src/async/safely/index.ts
@@ -1,0 +1,59 @@
+import type { SafelyResult } from "./types.js";
+
+/**
+ * Wraps a function so it returns a `[error, result]` tuple instead of throwing.
+ * Auto-detects sync and async functions: sync calls return a tuple, async calls
+ * return a `Promise` of a tuple. Anticipates the TC39 Safe Assignment Operator.
+ *
+ * On success the tuple is `[undefined, value]`. On error it is `[error, undefined]`.
+ *
+ * @param fn - The function to wrap
+ * @returns A wrapped function that never throws (sync) or rejects (async)
+ *
+ * @example
+ * ```ts
+ * const [err, data] = safely(JSON.parse)("{invalid");
+ * if (err) console.error(err);
+ * else console.log(data);
+ *
+ * const [fetchErr, user] = await safely(fetchUser)(userId);
+ * ```
+ *
+ * @keywords try catch tuple, go-style errors, safe assignment, error handling, tryit
+ *
+ * @throws Error if `fn` is not a function
+ */
+function safely<A extends unknown[], T>(
+  fn: (...args: A) => Promise<T>,
+): (...args: A) => Promise<SafelyResult<T>>;
+function safely<A extends unknown[], T>(
+  fn: (...args: A) => T,
+): (...args: A) => SafelyResult<T>;
+function safely<A extends unknown[], T>(
+  fn: (...args: A) => T | Promise<T>,
+): (...args: A) => SafelyResult<T> | Promise<SafelyResult<T>> {
+  if (typeof fn !== "function") {
+    throw new Error("The 'fn' parameter must be a function");
+  }
+
+  return (...args: A): SafelyResult<T> | Promise<SafelyResult<T>> => {
+    try {
+      const result = fn(...args);
+      if (
+        result !== null &&
+        typeof result === "object" &&
+        typeof (result as { then?: unknown }).then === "function"
+      ) {
+        return Promise.resolve(result as Promise<T>).then(
+          (value): SafelyResult<T> => [undefined, value],
+          (error: unknown): SafelyResult<T> => [error, undefined],
+        );
+      }
+      return [undefined, result as T];
+    } catch (error) {
+      return [error, undefined];
+    }
+  };
+}
+
+export { safely };

--- a/src/async/safely/types.ts
+++ b/src/async/safely/types.ts
@@ -1,0 +1,12 @@
+type SafelyResult<T> = [undefined, T] | [unknown, undefined];
+
+type SafelyFn = {
+  <A extends unknown[], T>(
+    fn: (...args: A) => Promise<T>,
+  ): (...args: A) => Promise<SafelyResult<T>>;
+  <A extends unknown[], T>(
+    fn: (...args: A) => T,
+  ): (...args: A) => SafelyResult<T>;
+};
+
+export type { SafelyFn, SafelyResult };

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { sortBy } from "./arrays/sort-by/index.js";
 export { unique } from "./arrays/unique/index.js";
 export { debounce } from "./async/debounce/index.js";
 export { retry } from "./async/retry/index.js";
+export { safely } from "./async/safely/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
 export { withTimeout } from "./async/with-timeout/index.js";

--- a/website/src/content/docs/async/safely.mdx
+++ b/website/src/content/docs/async/safely.mdx
@@ -1,0 +1,82 @@
+---
+title: safely
+description: Wrap a function so it returns a [error, result] tuple instead of throwing
+---
+
+Wraps a function so it returns a `[error, result]` tuple instead of throwing. Auto-detects sync and async functions: sync calls return a tuple, async calls return a `Promise` of a tuple. Eliminates verbose `try/catch` blocks and anticipates the [TC39 Safe Assignment Operator](https://github.com/arthurfiorette/proposal-safe-assignment-operator) proposal.
+
+On success the tuple is `[undefined, value]`. On error it is `[error, undefined]`.
+
+## Import
+
+```ts
+import { safely } from "1o1-utils";
+```
+
+```ts
+import { safely } from "1o1-utils/safely";
+```
+
+## Signature
+
+```ts
+function safely<A extends unknown[], T>(
+  fn: (...args: A) => Promise<T>,
+): (...args: A) => Promise<[unknown, T] | [unknown, undefined]>;
+
+function safely<A extends unknown[], T>(
+  fn: (...args: A) => T,
+): (...args: A) => [undefined, T] | [unknown, undefined];
+```
+
+## Parameters
+
+| Name | Type                       | Required | Description                |
+| ---- | -------------------------- | -------- | -------------------------- |
+| fn   | `(...args: A) => T \| Promise<T>` | Yes | The function to wrap |
+
+## Returns
+
+A wrapped function that mirrors the original signature but never throws (sync) or rejects (async). Returns a tuple `[undefined, value]` on success or `[error, undefined]` on failure.
+
+## Examples
+
+```ts
+const [err, data] = safely(JSON.parse)('{"a":1}');
+if (err) console.error(err);
+else console.log(data); // { a: 1 }
+```
+
+```ts
+const [err, user] = await safely(fetchUser)(userId);
+if (err) {
+  console.error("fetch failed:", err);
+  return;
+}
+console.log(user);
+```
+
+```ts
+// reuse the wrapper across calls
+const safeParse = safely(JSON.parse);
+const [err1, a] = safeParse('{"x":1}');
+const [err2, b] = safeParse("{bad");
+```
+
+## Edge Cases
+
+- Throws synchronously if `fn` is not a function.
+- Caught errors are typed as `unknown` — non-`Error` throws (strings, `null`, etc.) are preserved as-is.
+- Detects async by checking the return value for a `then` method (real Promises and custom thenables both work).
+- Multiple arguments are forwarded transparently.
+- The wrapper is reusable: the same wrapped function can be called any number of times.
+
+## Also known as
+
+try catch tuple, go-style errors, safe assignment, error handling, tryit
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use safely to wrap a fetch call and handle errors without try/catch.
+```


### PR DESCRIPTION
## Summary

- Add `safely` utility in `async/` — wraps a function so it returns a `[error, result]` tuple instead of throwing.
- Auto-detects sync and async callers: sync calls return a tuple, async calls return `Promise<tuple>`.
- Errors typed as `unknown`; non-`Error` throws (strings, `null`, custom values) are preserved as-is.
- Docs page, llms.txt / llms-full.txt entries, README async row, and changeset included.

Closes #87.

## API

```ts
const [err, data] = safely(JSON.parse)('{"a":1}');
const [err, user] = await safely(fetchUser)(userId);
```

## Benchmarks

| Task | Latency med | Notes |
| --- | --- | --- |
| sync ok | 41ns | par with native try/catch, ~4× faster than `radash.tryit` |
| sync throw | ~4µs | dominated by Error stack capture |
| async ok | ~208ns | par with `radash.tryit` |
| async throw | ~5.6µs | par with `radash.tryit` |

Bundle size: **169 B** (limit 1 kB).

## Test plan

- [x] `pnpm test` — 18 new specs, all 409 pass
- [x] `pnpm check` — lint/format clean (preexisting warnings only)
- [x] `pnpm build` — tsc compiles
- [x] `pnpm size` — under 1 kB budget
- [x] `pnpm bench safely` — runs vs radash + native