### PR TITLE
feat(comparisons): add isNil utility

### DIFF
--- a/.changeset/add-is-nil.md
+++ b/.changeset/add-is-nil.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `isNil` utility under `comparisons`. `isNil({ value })` returns `true` only when the value is `null` or `undefined`, making it the strict existence check that complements `isEmpty`. Useful for defaulting parameters without clobbering falsy-but-valid values like `0`, `""`, or `false`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -134,5 +134,10 @@
     "name": "shallow-equal",
     "path": "dist/comparisons/shallow-equal/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "is-nil",
+    "path": "dist/comparisons/is-nil/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -666,6 +666,31 @@ Throws: Error if promise is not thenable. Error if ms is not a non-negative numb
 
 ## Comparisons
 
+### isNil
+
+Check if a value is `null` or `undefined`. Strict existence check — distinct from `isEmpty`, which also treats empty strings, arrays, objects, Maps, and Sets as empty. `isNil` returns `true` only for the two nullish values.
+
+Import: import { isNil } from "1o1-utils/is-nil";
+
+Signature:
+function isNil({ value }: IsNilParams): boolean
+
+Parameters:
+- value (unknown, required): The value to check
+
+Returns: boolean — `true` if the value is `null` or `undefined`, `false` otherwise.
+
+Example:
+isNil({ value: null });      // => true
+isNil({ value: undefined }); // => true
+isNil({ value: 0 });         // => false
+isNil({ value: "" });        // => false
+isNil({ value: false });     // => false
+
+Edge cases: falsy values that are not nullish (`0`, `""`, `false`, `NaN`, `0n`) return `false`. Empty arrays, empty objects, functions, and symbols are not nil. Use `isEmpty` if you need emptiness checks beyond null/undefined.
+
+---
+
 ### shallowEqual
 
 Compare two values by their top-level entries using `Object.is`. Returns `true` when both values are strictly the same, or when they are arrays or plain objects with identical own-enumerable entries at the first level. Nested values are compared by reference, not structurally — use `deepEqual` for recursive comparison.

--- a/llms.txt
+++ b/llms.txt
@@ -47,6 +47,7 @@
 
 ## Comparisons
 
+- [isNil](https://pedrotroccoli.github.io/1o1-utils/comparisons/is-nil/): Check if a value is `null` or `undefined`
 - [shallowEqual](https://pedrotroccoli.github.io/1o1-utils/comparisons/shallow-equal/): Compare two values by their top-level entries using `Object.is`
 
 ## Functions

--- a/package.json
+++ b/package.json
@@ -37,7 +37,9 @@
 		"in-range",
 		"between",
 		"range-check",
-		"shallow-equal"
+		"shallow-equal",
+		"is-nil",
+		"nullish"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -163,6 +165,10 @@
 		"./shallow-equal": {
 			"import": "./dist/comparisons/shallow-equal/index.js",
 			"types": "./dist/comparisons/shallow-equal/index.d.ts"
+		},
+		"./is-nil": {
+			"import": "./dist/comparisons/is-nil/index.js",
+			"types": "./dist/comparisons/is-nil/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/comparisons/is-nil/index.bench.ts
+++ b/src/comparisons/is-nil/index.bench.ts
@@ -1,0 +1,28 @@
+import lodashIsNil from "lodash/isNil.js";
+import { Bench } from "tinybench";
+import { isNil } from "./index.js";
+
+const cases: Array<{ name: string; value: unknown }> = [
+  { name: "null", value: null },
+  { name: "undefined", value: undefined },
+  { name: "number", value: 0 },
+  { name: "object", value: { a: 1 } },
+];
+
+const bench = new Bench({ name: "isNil", time: 1000 });
+
+for (const { name, value } of cases) {
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      isNil({ value });
+    })
+    .add(`lodash (${name})`, () => {
+      lodashIsNil(value);
+    })
+    .add(`native (${name})`, () => {
+      const _ = value === null || value === undefined;
+      void _;
+    });
+}
+
+export { bench };

--- a/src/comparisons/is-nil/index.spec.ts
+++ b/src/comparisons/is-nil/index.spec.ts
@@ -1,0 +1,53 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { isNil } from "./index.js";
+
+describe("isNil", () => {
+  it("returns true for null", () => {
+    expect(isNil({ value: null })).to.equal(true);
+  });
+
+  it("returns true for undefined", () => {
+    expect(isNil({ value: undefined })).to.equal(true);
+  });
+
+  it("returns true for void 0", () => {
+    expect(isNil({ value: void 0 })).to.equal(true);
+  });
+
+  it("returns false for 0", () => {
+    expect(isNil({ value: 0 })).to.equal(false);
+  });
+
+  it("returns false for empty string", () => {
+    expect(isNil({ value: "" })).to.equal(false);
+  });
+
+  it("returns false for false", () => {
+    expect(isNil({ value: false })).to.equal(false);
+  });
+
+  it("returns false for NaN", () => {
+    expect(isNil({ value: Number.NaN })).to.equal(false);
+  });
+
+  it("returns false for empty array", () => {
+    expect(isNil({ value: [] })).to.equal(false);
+  });
+
+  it("returns false for empty object", () => {
+    expect(isNil({ value: {} })).to.equal(false);
+  });
+
+  it("returns false for a function", () => {
+    expect(isNil({ value: () => undefined })).to.equal(false);
+  });
+
+  it("returns false for a Symbol", () => {
+    expect(isNil({ value: Symbol("s") })).to.equal(false);
+  });
+
+  it("returns false for a bigint zero", () => {
+    expect(isNil({ value: 0n })).to.equal(false);
+  });
+});

--- a/src/comparisons/is-nil/index.ts
+++ b/src/comparisons/is-nil/index.ts
@@ -1,0 +1,29 @@
+import type { IsNilParams, IsNilResult } from "./types.js";
+
+/**
+ * Checks if a value is `null` or `undefined`.
+ *
+ * Strict existence check — distinct from `isEmpty`, which also treats empty
+ * strings, arrays, objects, Maps, and Sets as empty. `isNil` returns `true`
+ * only for the two nullish values.
+ *
+ * @param params - The parameters object
+ * @param params.value - The value to check
+ * @returns `true` if the value is `null` or `undefined`, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * isNil({ value: null });      // => true
+ * isNil({ value: undefined }); // => true
+ * isNil({ value: 0 });         // => false
+ * isNil({ value: "" });        // => false
+ * isNil({ value: false });     // => false
+ * ```
+ *
+ * @keywords nil check, null check, undefined check, exists, is nullish, missing value, defined check
+ */
+function isNil({ value }: IsNilParams): IsNilResult {
+  return value === null || value === undefined;
+}
+
+export { isNil };

--- a/src/comparisons/is-nil/types.ts
+++ b/src/comparisons/is-nil/types.ts
@@ -1,0 +1,9 @@
+interface IsNilParams {
+  value: unknown;
+}
+
+type IsNilResult = boolean;
+
+type IsNilFn = (params: IsNilParams) => IsNilResult;
+
+export type { IsNilFn, IsNilParams, IsNilResult };

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export { retry } from "./async/retry/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
 export { withTimeout } from "./async/with-timeout/index.js";
+export { isNil } from "./comparisons/is-nil/index.js";
 export { shallowEqual } from "./comparisons/shallow-equal/index.js";
 export { once } from "./functions/once/index.js";
 export { pipe } from "./functions/pipe/index.js";

--- a/website/src/content/docs/comparisons/is-nil.mdx
+++ b/website/src/content/docs/comparisons/is-nil.mdx
@@ -1,0 +1,68 @@
+---
+title: isNil
+description: Check if a value is null or undefined
+---
+
+Strict existence check for `null` or `undefined`. Distinct from `isEmpty`, which also treats empty strings, arrays, objects, Maps, and Sets as empty. `isNil` returns `true` only for the two nullish values.
+
+## Import
+
+```ts
+import { isNil } from "1o1-utils";
+```
+
+```ts
+import { isNil } from "1o1-utils/is-nil";
+```
+
+## Signature
+
+```ts
+function isNil({ value }: IsNilParams): boolean
+```
+
+## Parameters
+
+| Name  | Type      | Required | Description         |
+| ----- | --------- | -------- | ------------------- |
+| value | `unknown` | Yes      | The value to check  |
+
+## Returns
+
+`boolean` — `true` if the value is `null` or `undefined`, `false` otherwise.
+
+## Examples
+
+```ts
+isNil({ value: null });      // => true
+isNil({ value: undefined }); // => true
+isNil({ value: 0 });         // => false
+isNil({ value: "" });        // => false
+isNil({ value: false });     // => false
+isNil({ value: Number.NaN }); // => false
+```
+
+```ts
+// Default a parameter only when truly absent — preserves 0, "", false
+function greet(name?: string | null) {
+  const safe = isNil({ value: name }) ? "stranger" : name;
+  return `Hello, ${safe}`;
+}
+```
+
+## Edge Cases
+
+- Falsy non-nullish values (`0`, `""`, `false`, `NaN`, `0n`) return `false`.
+- Empty arrays, empty plain objects, functions, and symbols are not nil.
+- Equivalent to the loose-equality idiom `value == null`, with strict-equality semantics for clarity.
+- Use [`isEmpty`](/objects/is-empty/) when you also need to treat empty containers as missing.
+
+## Also known as
+
+null check, undefined check, nullish check, exists check, defined check, missing value
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use isNil to default a value only when it's null or undefined while preserving other falsy values like 0 and "".
+```


### PR DESCRIPTION
## Summary
- Adds `isNil({ value })` under `comparisons/` — strict `null | undefined` check.
- Complements `isEmpty` (which also treats empty strings/arrays/objects as empty).
- 36 B gzipped. Total bundle 3.81 kB.

Closes #54.

## Test plan
- [x] `pnpm check` — clean (only 2 pre-existing unrelated warnings)
- [x] `pnpm test` — 401 passing, 12 new specs for `isNil`
- [x] `pnpm test:coverage` — 100% lines/functions/statements on `comparisons/is-nil`
- [x] `pnpm build && pnpm size` — within 1 kB limit (36 B)
- [x] Changeset added (`minor`)
- [x] `llms.txt`, `llms-full.txt`, and Astro docs page updated