### PR TITLE
chore: version packages (1.7.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 1o1-utils
 
+## 1.7.1
+
+### Patch Changes
+
+- Republish of 1.7.0 with the full set of advertised subpath exports. The published 1.7.0 tarball was built from a stale tree and shipped without `deep-equal`, `is-nil`, `is-valid-url`, and `safely`. 1.7.0 has been deprecated on npm; upgrade to 1.7.1 to access all utilities listed in the 1.7.0 changelog.
+
 ## 1.7.0
 
 ### Minor Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "1o1-utils",
-	"version": "1.7.0",
+	"version": "1.7.1",
 	"description": "Fast, tree-shakeable, zero-dependency TypeScript utility library. ~2kB gzipped, fully typed, benchmarked for performance.",
 	"keywords": [
 		"utility",


### PR DESCRIPTION
Republish of 1.7.0 with full subpath exports. 1.7.0 deprecated on npm — incomplete tarball. See CHANGELOG.