### PR TITLE
feat(arrays): add zip and unzip utilities

### DIFF
--- a/.changeset/add-zip-unzip.md
+++ b/.changeset/add-zip-unzip.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `zip` and `unzip` utilities under the `arrays` category. `zip({ arrays })` combines arrays by index into tuples; `unzip({ array })` splits an array of tuples back into separate arrays. Both accept an optional `strategy: "fill" | "truncate"` to control behavior on uneven lengths — `"fill"` (default) pads shorter arrays with `undefined`, `"truncate"` cuts to the shortest.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -164,5 +164,15 @@
     "name": "clamp",
     "path": "dist/numbers/clamp/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "zip",
+    "path": "dist/arrays/zip/index.js",
+    "limit": "1 kB"
+  },
+  {
+    "name": "unzip",
+    "path": "dist/arrays/unzip/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/docs/benchmarks/unzip.md
+++ b/docs/benchmarks/unzip.md
@@ -1,0 +1,22 @@
+# unzip
+
+[← Back to benchmarks](./README.md)
+
+Splits an array of grouped tuples back into separate arrays — the inverse of `zip`. Compared against `lodash.unzip` and a native `for` loop hardcoded for the fixed shape.
+
+---
+
+| Size | 1o1-utils | lodash | native for-loop | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| n=100 | 625ns · 1.6M ops/s | 2.3µs · 436.3K ops/s | 417ns · 2.4M ops/s | native for-loop · 5.5× faster vs lodash |
+| n=10k | 61.7µs · 16.2K ops/s | 215.3µs · 4.6K ops/s | 40.1µs · 24.9K ops/s | native for-loop · 5.4× faster vs lodash |
+| n=100k | 1.56ms · 639 ops/s | 4.15ms · 241 ops/s | 1.11ms · 901 ops/s | native for-loop · 3.7× faster vs lodash |
+| n=1M | 15.30ms · 65 ops/s | 36.16ms · 28 ops/s | 8.77ms · 114 ops/s | native for-loop · 4.1× faster vs lodash |
+| n=10M | 268.8ms · 4 ops/s | 668.3ms · 1 ops/s | 135.3ms · 7 ops/s | native for-loop · 4.9× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "unzip — ops/s at n=1M items"
+  x-axis ["native for-loop", "1o1-utils", "lodash"]
+  bar [114, 65, 28]
+```

--- a/docs/benchmarks/zip.md
+++ b/docs/benchmarks/zip.md
@@ -1,0 +1,22 @@
+# zip
+
+[← Back to benchmarks](./README.md)
+
+Combines arrays by index into tuples, with `fill` (default) or `truncate` strategy for uneven lengths. Compared against `lodash.zip`, `radash.zip`, and a native `for` loop hardcoded for the fixed shape.
+
+---
+
+| Size | 1o1-utils | lodash | radash zip | native for-loop | Fastest |
+| ------ | ------ | ------ | ------ | ------ | ------ |
+| n=100 | 792ns · 1.3M ops/s | 1.4µs · 727.3K ops/s | 1.5µs · 685.4K ops/s | 333ns · 3.0M ops/s | native for-loop · 4.1× faster vs lodash |
+| n=10k | 75.1µs · 13.3K ops/s | 132.0µs · 7.6K ops/s | 145.8µs · 6.9K ops/s | 36.1µs · 27.7K ops/s | native for-loop · 3.7× faster vs lodash |
+| n=100k | 1.21ms · 826 ops/s | 2.28ms · 439 ops/s | 3.33ms · 301 ops/s | 1.54ms · 648 ops/s | 1o1-utils · 1.9× faster vs lodash |
+| n=1M | 71.38ms · 14 ops/s | 86.05ms · 12 ops/s | 102.0ms · 10 ops/s | 70.32ms · 14 ops/s | native for-loop · 1.2× faster vs lodash |
+| n=10M | 1305.6ms · 1 ops/s | 1728.5ms · 1 ops/s | 1895.3ms · 1 ops/s | 1615.6ms · 1 ops/s | 1o1-utils · 1.3× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "zip — ops/s at n=1M items"
+  x-axis ["native for-loop", "1o1-utils", "lodash", "radash zip"]
+  bar [14, 14, 12, 10]
+```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -182,6 +182,55 @@ Without key, uses Set for primitive deduplication. With key, keeps the first occ
 
 ---
 
+### zip
+
+Combine arrays by index into tuples. The inverse of unzip.
+
+Import: import { zip } from "1o1-utils/zip";
+
+Signature:
+function zip<T>({ arrays, strategy }: ZipParams<T>): T[][]
+
+Parameters:
+- arrays (T[][], required): The arrays to combine
+- strategy ("fill" | "truncate", optional): How to handle uneven lengths. Default "fill" pads shorter arrays with undefined; "truncate" cuts to the shortest array.
+
+Returns: T[][]
+
+Example:
+zip({ arrays: [["a", "b", "c"], [1, 2, 3]] });
+// => [["a", 1], ["b", 2], ["c", 3]]
+
+zip({ arrays: [["a", "b", "c"], [1, 2]], strategy: "truncate" });
+// => [["a", 1], ["b", 2]]
+
+Throws: Error if arrays is not an array. Error if any element of arrays is not an array. Error if strategy is not "fill" or "truncate".
+
+---
+
+### unzip
+
+Split an array of grouped tuples back into separate arrays. The inverse of zip.
+
+Import: import { unzip } from "1o1-utils/unzip";
+
+Signature:
+function unzip<T>({ array, strategy }: UnzipParams<T>): T[][]
+
+Parameters:
+- array (T[][], required): The array of tuples to ungroup
+- strategy ("fill" | "truncate", optional): How to handle uneven inner lengths. Default "fill" pads shorter tuples with undefined; "truncate" cuts to the shortest tuple.
+
+Returns: T[][]
+
+Example:
+unzip({ array: [["a", 1], ["b", 2], ["c", 3]] });
+// => [["a", "b", "c"], [1, 2, 3]]
+
+Throws: Error if array is not an array. Error if any element of array is not an array. Error if strategy is not "fill" or "truncate".
+
+---
+
 ## Objects
 
 ### cloneDeep

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,8 @@
 - [groupBy](https://pedrotroccoli.github.io/1o1-utils/arrays/group-by/): Group array elements by a property value
 - [sortBy](https://pedrotroccoli.github.io/1o1-utils/arrays/sort-by/): Sort an array of objects by a property with dot notation support
 - [unique](https://pedrotroccoli.github.io/1o1-utils/arrays/unique/): Remove duplicate elements from an array by value or key
+- [unzip](https://pedrotroccoli.github.io/1o1-utils/arrays/unzip/): Split an array of grouped tuples back into separate arrays
+- [zip](https://pedrotroccoli.github.io/1o1-utils/arrays/zip/): Combine arrays by index into tuples, with fill or truncate strategy
 
 ## Objects
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,10 @@
 		"nullish",
 		"clamp",
 		"restrict",
-		"bound"
+		"bound",
+		"zip",
+		"unzip",
+		"transpose"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -200,6 +203,14 @@
 		"./clamp": {
 			"import": "./dist/numbers/clamp/index.js",
 			"types": "./dist/numbers/clamp/index.d.ts"
+		},
+		"./zip": {
+			"import": "./dist/arrays/zip/index.js",
+			"types": "./dist/arrays/zip/index.d.ts"
+		},
+		"./unzip": {
+			"import": "./dist/arrays/unzip/index.js",
+			"types": "./dist/arrays/unzip/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/arrays/unzip/index.bench.ts
+++ b/src/arrays/unzip/index.bench.ts
@@ -1,0 +1,36 @@
+import lodashUnzip from "lodash/unzip.js";
+import { Bench } from "tinybench";
+import { getDatasets } from "../../benchmarks/helpers.js";
+import { unzip } from "./index.js";
+
+const bench = new Bench({ name: "unzip", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  const tuples: [string, string, number][] = data.map((u) => [
+    u.id,
+    u.name,
+    u.age,
+  ]);
+
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      unzip({ array: tuples });
+    })
+    .add(`lodash (${name})`, () => {
+      lodashUnzip(tuples);
+    })
+    .add(`native for-loop (${name})`, () => {
+      const length = tuples.length;
+      const a: string[] = new Array(length);
+      const b: string[] = new Array(length);
+      const c: number[] = new Array(length);
+      for (let i = 0; i < length; i++) {
+        a[i] = tuples[i][0];
+        b[i] = tuples[i][1];
+        c[i] = tuples[i][2];
+      }
+    });
+}
+
+export { bench };

--- a/src/arrays/unzip/index.spec.ts
+++ b/src/arrays/unzip/index.spec.ts
@@ -1,0 +1,100 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { zip } from "../zip/index.js";
+import { unzip } from "./index.js";
+
+describe("unzip", () => {
+  it("should split tuples back into separate arrays", () => {
+    const result = unzip({
+      array: [
+        ["a", 1],
+        ["b", 2],
+        ["c", 3],
+      ],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", "b", "c"],
+      [1, 2, 3],
+    ]);
+  });
+
+  it("should handle three-element tuples", () => {
+    const result = unzip({
+      array: [
+        ["a", 1, true],
+        ["b", 2, false],
+      ],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", "b"],
+      [1, 2],
+      [true, false],
+    ]);
+  });
+
+  it("should pad with undefined when tuples have different lengths (default fill)", () => {
+    const result = unzip({
+      array: [["a", 1], ["b"]],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", "b"],
+      [1, undefined],
+    ]);
+  });
+
+  it("should truncate to the shortest tuple when strategy is 'truncate'", () => {
+    const result = unzip({
+      array: [
+        ["a", 1, true],
+        ["b", 2],
+      ],
+      strategy: "truncate",
+    });
+
+    expect(result).to.deep.equal([
+      ["a", "b"],
+      [1, 2],
+    ]);
+  });
+
+  it("should round-trip with zip", () => {
+    const arrays = [
+      ["a", "b", "c"],
+      [1, 2, 3],
+    ];
+    const zipped = zip<string | number>({ arrays });
+    const unzipped = unzip<string | number>({ array: zipped });
+
+    expect(unzipped).to.deep.equal(arrays);
+  });
+
+  it("should return an empty array when array is empty", () => {
+    const result = unzip({ array: [] });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should throw an error if array is not an array", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => unzip({ array: "not an array" })).to.throw(
+      "The 'array' parameter is not an array",
+    );
+  });
+
+  it("should throw an error if any inner element is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      unzip({ array: [[1, 2], "nope"] }),
+    ).to.throw("All elements of 'array' must be arrays");
+  });
+
+  it("should throw an error if strategy is invalid", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      unzip({ array: [[1, 2]], strategy: "wat" }),
+    ).to.throw("The 'strategy' parameter must be 'fill' or 'truncate'");
+  });
+});

--- a/src/arrays/unzip/index.ts
+++ b/src/arrays/unzip/index.ts
@@ -1,0 +1,67 @@
+import type { UnzipParams, UnzipResult } from "./types.js";
+
+/**
+ * Splits an array of grouped tuples back into separate arrays — the inverse of `zip`.
+ *
+ * @param params - The parameters object
+ * @param params.array - The array of tuples to ungroup
+ * @param params.strategy - How to handle uneven inner lengths: `"fill"` pads shorter tuples with `undefined` (default), `"truncate"` cuts to the shortest tuple
+ * @returns An array of arrays grouped by tuple position
+ *
+ * @example
+ * ```ts
+ * unzip({ array: [["a", 1], ["b", 2], ["c", 3]] });
+ * // => [["a", "b", "c"], [1, 2, 3]]
+ * ```
+ *
+ * @keywords unzip, transpose, ungroup, split tuples
+ *
+ * @throws Error if `array` is not an array
+ * @throws Error if any element of `array` is not an array
+ * @throws Error if `strategy` is not `"fill"` or `"truncate"`
+ */
+function unzip<T>({
+  array,
+  strategy = "fill",
+}: UnzipParams<T>): UnzipResult<T> {
+  if (!Array.isArray(array)) {
+    throw new Error("The 'array' parameter is not an array");
+  }
+
+  if (strategy !== "fill" && strategy !== "truncate") {
+    throw new Error("The 'strategy' parameter must be 'fill' or 'truncate'");
+  }
+
+  for (let i = 0; i < array.length; i++) {
+    if (!Array.isArray(array[i])) {
+      throw new Error("All elements of 'array' must be arrays");
+    }
+  }
+
+  if (array.length === 0) {
+    return [];
+  }
+
+  let length = array[0].length;
+  for (let i = 1; i < array.length; i++) {
+    const innerLength = array[i].length;
+    if (strategy === "fill") {
+      if (innerLength > length) length = innerLength;
+    } else if (innerLength < length) {
+      length = innerLength;
+    }
+  }
+
+  const result: T[][] = new Array(length);
+  for (let i = 0; i < length; i++) {
+    const group: T[] = new Array(array.length);
+    for (let j = 0; j < array.length; j++) {
+      group[j] = array[j][i] as T;
+    }
+    result[i] = group;
+  }
+
+  return result;
+}
+
+export { unzip };

--- a/src/arrays/unzip/types.ts
+++ b/src/arrays/unzip/types.ts
@@ -1,0 +1,12 @@
+type UnzipStrategy = "fill" | "truncate";
+
+interface UnzipParams<T> {
+  array: T[][];
+  strategy?: UnzipStrategy;
+}
+
+type UnzipResult<T> = T[][];
+
+type Unzip<T> = (params: UnzipParams<T>) => UnzipResult<T>;
+
+export type { Unzip, UnzipParams, UnzipResult, UnzipStrategy };

--- a/src/arrays/zip/index.bench.ts
+++ b/src/arrays/zip/index.bench.ts
@@ -1,0 +1,34 @@
+import lodashZip from "lodash/zip.js";
+import { zip as radashZip } from "radash";
+import { Bench } from "tinybench";
+import { getDatasets } from "../../benchmarks/helpers.js";
+import { zip } from "./index.js";
+
+const bench = new Bench({ name: "zip", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  const ids = data.map((u) => u.id);
+  const names = data.map((u) => u.name);
+  const ages = data.map((u) => u.age);
+
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      zip({ arrays: [ids, names, ages] });
+    })
+    .add(`lodash (${name})`, () => {
+      lodashZip(ids, names, ages);
+    })
+    .add(`radash zip (${name})`, () => {
+      radashZip(ids, names, ages);
+    })
+    .add(`native for-loop (${name})`, () => {
+      const length = Math.max(ids.length, names.length, ages.length);
+      const result: unknown[][] = new Array(length);
+      for (let i = 0; i < length; i++) {
+        result[i] = [ids[i], names[i], ages[i]];
+      }
+    });
+}
+
+export { bench };

--- a/src/arrays/zip/index.spec.ts
+++ b/src/arrays/zip/index.spec.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { zip } from "./index.js";
+
+describe("zip", () => {
+  it("should combine two arrays of the same length", () => {
+    const result = zip({
+      arrays: [
+        ["a", "b", "c"],
+        [1, 2, 3],
+      ],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", 1],
+      ["b", 2],
+      ["c", 3],
+    ]);
+  });
+
+  it("should combine three arrays of the same length", () => {
+    const result = zip({
+      arrays: [
+        ["a", "b"],
+        [1, 2],
+        [true, false],
+      ],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", 1, true],
+      ["b", 2, false],
+    ]);
+  });
+
+  it("should pad with undefined when arrays have different lengths (default fill)", () => {
+    const result = zip({
+      arrays: [
+        ["a", "b", "c"],
+        [1, 2],
+      ],
+    });
+
+    expect(result).to.deep.equal([
+      ["a", 1],
+      ["b", 2],
+      ["c", undefined],
+    ]);
+  });
+
+  it("should truncate to the shortest array when strategy is 'truncate'", () => {
+    const result = zip({
+      arrays: [
+        ["a", "b", "c"],
+        [1, 2],
+      ],
+      strategy: "truncate",
+    });
+
+    expect(result).to.deep.equal([
+      ["a", 1],
+      ["b", 2],
+    ]);
+  });
+
+  it("should return an empty array when arrays is empty", () => {
+    const result = zip({ arrays: [] });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should handle a single inner array", () => {
+    const result = zip({ arrays: [[1, 2, 3]] });
+
+    expect(result).to.deep.equal([[1], [2], [3]]);
+  });
+
+  it("should handle inner empty arrays with fill", () => {
+    const result = zip({ arrays: [["a", "b"], []] });
+
+    expect(result).to.deep.equal([
+      ["a", undefined],
+      ["b", undefined],
+    ]);
+  });
+
+  it("should return [] when truncate meets an empty inner array", () => {
+    const result = zip({
+      arrays: [["a", "b"], []],
+      strategy: "truncate",
+    });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should throw an error if arrays is not an array", () => {
+    // @ts-expect-error - we want to test the error case
+    expect(() => zip({ arrays: "not an array" })).to.throw(
+      "The 'arrays' parameter is not an array",
+    );
+  });
+
+  it("should throw an error if any inner element is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      zip({ arrays: [[1, 2], "nope"] }),
+    ).to.throw("All elements of 'arrays' must be arrays");
+  });
+
+  it("should throw an error if strategy is invalid", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      zip({ arrays: [[1, 2]], strategy: "wat" }),
+    ).to.throw("The 'strategy' parameter must be 'fill' or 'truncate'");
+  });
+});

--- a/src/arrays/zip/index.ts
+++ b/src/arrays/zip/index.ts
@@ -1,0 +1,67 @@
+import type { ZipParams, ZipResult } from "./types.js";
+
+/**
+ * Combines arrays by position into tuples.
+ *
+ * @param params - The parameters object
+ * @param params.arrays - The arrays to combine
+ * @param params.strategy - How to handle uneven lengths: `"fill"` pads shorter arrays with `undefined` (default), `"truncate"` cuts to the shortest array
+ * @returns An array of tuples grouped by index
+ *
+ * @example
+ * ```ts
+ * zip({ arrays: [["a", "b", "c"], [1, 2, 3]] });
+ * // => [["a", 1], ["b", 2], ["c", 3]]
+ *
+ * zip({ arrays: [["a", "b"], [1]], strategy: "truncate" });
+ * // => [["a", 1]]
+ * ```
+ *
+ * @keywords zip, pair, interleave, combine arrays, transpose
+ *
+ * @throws Error if `arrays` is not an array
+ * @throws Error if any element of `arrays` is not an array
+ * @throws Error if `strategy` is not `"fill"` or `"truncate"`
+ */
+function zip<T>({ arrays, strategy = "fill" }: ZipParams<T>): ZipResult<T> {
+  if (!Array.isArray(arrays)) {
+    throw new Error("The 'arrays' parameter is not an array");
+  }
+
+  if (strategy !== "fill" && strategy !== "truncate") {
+    throw new Error("The 'strategy' parameter must be 'fill' or 'truncate'");
+  }
+
+  for (let i = 0; i < arrays.length; i++) {
+    if (!Array.isArray(arrays[i])) {
+      throw new Error("All elements of 'arrays' must be arrays");
+    }
+  }
+
+  if (arrays.length === 0) {
+    return [];
+  }
+
+  let length = arrays[0].length;
+  for (let i = 1; i < arrays.length; i++) {
+    const innerLength = arrays[i].length;
+    if (strategy === "fill") {
+      if (innerLength > length) length = innerLength;
+    } else if (innerLength < length) {
+      length = innerLength;
+    }
+  }
+
+  const result: T[][] = new Array(length);
+  for (let i = 0; i < length; i++) {
+    const tuple: T[] = new Array(arrays.length);
+    for (let j = 0; j < arrays.length; j++) {
+      tuple[j] = arrays[j][i] as T;
+    }
+    result[i] = tuple;
+  }
+
+  return result;
+}
+
+export { zip };

--- a/src/arrays/zip/types.ts
+++ b/src/arrays/zip/types.ts
@@ -1,0 +1,12 @@
+type ZipStrategy = "fill" | "truncate";
+
+interface ZipParams<T> {
+  arrays: T[][];
+  strategy?: ZipStrategy;
+}
+
+type ZipResult<T> = T[][];
+
+type Zip<T> = (params: ZipParams<T>) => ZipResult<T>;
+
+export type { Zip, ZipParams, ZipResult, ZipStrategy };

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -183,6 +183,16 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Validates a string against the WHATWG `URL` parser. Compared against a native `try/catch` `new URL` implementation and a regex-based check.",
   },
+  zip: {
+    slug: "zip",
+    description:
+      "Combines arrays by index into tuples, with `fill` (default) or `truncate` strategy for uneven lengths. Compared against `lodash.zip`, `radash.zip`, and a native `for` loop hardcoded for the fixed shape.",
+  },
+  unzip: {
+    slug: "unzip",
+    description:
+      "Splits an array of grouped tuples back into separate arrays — the inverse of `zip`. Compared against `lodash.unzip` and a native `for` loop hardcoded for the fixed shape.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export { diff } from "./arrays/diff/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
 export { unique } from "./arrays/unique/index.js";
+export { unzip } from "./arrays/unzip/index.js";
+export { zip } from "./arrays/zip/index.js";
 export { debounce } from "./async/debounce/index.js";
 export { retry } from "./async/retry/index.js";
 export { safely } from "./async/safely/index.js";

--- a/website/src/content/docs/arrays/unzip.mdx
+++ b/website/src/content/docs/arrays/unzip.mdx
@@ -1,0 +1,69 @@
+---
+title: unzip
+description: Split an array of tuples back into separate arrays
+---
+
+Splits an array of grouped tuples back into separate arrays. The inverse of [zip](./zip.mdx).
+
+## Import
+
+```ts
+import { unzip } from "1o1-utils";
+```
+
+```ts
+import { unzip } from "1o1-utils/unzip";
+```
+
+## Signature
+
+```ts
+function unzip<T>({ array, strategy }: UnzipParams<T>): T[][]
+```
+
+## Parameters
+
+| Name     | Type                       | Required | Description                                                                                                                |
+| -------- | -------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------- |
+| array    | `T[][]`                    | Yes      | The array of tuples to ungroup                                                                                             |
+| strategy | `"fill" \| "truncate"`     | No       | How to handle uneven inner lengths. `"fill"` (default) pads shorter tuples with `undefined`; `"truncate"` cuts to shortest. |
+
+## Returns
+
+`T[][]` — An array of arrays grouped by tuple position.
+
+## Examples
+
+```ts
+unzip({ array: [["a", 1], ["b", 2], ["c", 3]] });
+// => [["a", "b", "c"], [1, 2, 3]]
+
+unzip({ array: [["a", 1], ["b"]] });
+// => [["a", "b"], [1, undefined]]
+
+unzip({
+  array: [
+    ["a", 1, true],
+    ["b", 2],
+  ],
+  strategy: "truncate",
+});
+// => [["a", "b"], [1, 2]]
+```
+
+## Edge Cases
+
+- Throws if `array` is not an array.
+- Throws if any element of `array` is not an array.
+- Throws if `strategy` is not `"fill"` or `"truncate"`.
+- Returns `[]` when `array` is empty.
+
+## Also known as
+
+unzip, transpose, ungroup, split tuples
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use unzip to split an array of [key, value] tuples into two arrays
+```

--- a/website/src/content/docs/arrays/zip.mdx
+++ b/website/src/content/docs/arrays/zip.mdx
@@ -1,0 +1,72 @@
+---
+title: zip
+description: Combine arrays by index into tuples
+---
+
+Combines multiple arrays by position into an array of tuples. The inverse of [unzip](./unzip.mdx).
+
+## Import
+
+```ts
+import { zip } from "1o1-utils";
+```
+
+```ts
+import { zip } from "1o1-utils/zip";
+```
+
+## Signature
+
+```ts
+function zip<T>({ arrays, strategy }: ZipParams<T>): T[][]
+```
+
+## Parameters
+
+| Name     | Type                       | Required | Description                                                                                                              |
+| -------- | -------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------ |
+| arrays   | `T[][]`                    | Yes      | The arrays to combine                                                                                                    |
+| strategy | `"fill" \| "truncate"`     | No       | How to handle uneven lengths. `"fill"` (default) pads shorter arrays with `undefined`; `"truncate"` cuts to the shortest. |
+
+## Returns
+
+`T[][]` — An array of tuples grouped by index.
+
+## Examples
+
+```ts
+zip({ arrays: [["a", "b", "c"], [1, 2, 3]] });
+// => [["a", 1], ["b", 2], ["c", 3]]
+
+zip({
+  arrays: [
+    ["a", "b"],
+    [1, 2],
+    [true, false],
+  ],
+});
+// => [["a", 1, true], ["b", 2, false]]
+
+zip({ arrays: [["a", "b", "c"], [1, 2]] });
+// => [["a", 1], ["b", 2], ["c", undefined]]
+
+zip({ arrays: [["a", "b", "c"], [1, 2]], strategy: "truncate" });
+// => [["a", 1], ["b", 2]]
+```
+
+## Edge Cases
+
+- Throws if `arrays` is not an array.
+- Throws if any element of `arrays` is not an array.
+- Throws if `strategy` is not `"fill"` or `"truncate"`.
+- Returns `[]` when `arrays` is empty.
+
+## Also known as
+
+zip, pair, interleave, combine arrays, transpose
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use zip to pair two parallel arrays into tuples
+```


### PR DESCRIPTION
## Summary

- Adds `zip` and `unzip` array utilities under `src/arrays/`.
- API: `zip({ arrays, strategy? })` / `unzip({ array, strategy? })` — `strategy` is `"fill"` (default, lodash-compatible — pads shorter arrays with `undefined`) or `"truncate"` (cuts to the shortest). Inner non-array inputs throw.
- Wired across `src/index.ts`, `package.json` exports + keywords, `.size-limit.json`, `llms.txt` / `llms-full.txt`, Starlight docs, and benchmark suite metadata.
- Coverage: 100% statements/functions/lines for both. Bundled size: 267 B brotli each.

Closes #100.

## Benchmarks

`zip` vs lodash: ~1.8–2× faster up to n=100k, on par at n=1M+.
`unzip` vs lodash: ~2–3.5× faster across all sizes.
Native hardcoded loop is always fastest but does not generalize to N variable arrays.

## Test plan

- [x] `pnpm check:fix` (no new warnings)
- [x] `pnpm test:coverage` — 520 passing, ≥80% coverage
- [x] `pnpm build && pnpm size` — both utilities under 1 kB limit
- [x] `pnpm bench --md zip` — regenerates `docs/benchmarks/{zip,unzip}.md`