### PR TITLE
feat(numbers): add clamp utility

### DIFF
--- a/.changeset/add-clamp.md
+++ b/.changeset/add-clamp.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `clamp` utility under the `numbers` category. `clamp({ value, min, max })` restricts a number to the inclusive range `[min, max]`: returns `min` if `value` is below the range, `max` if above, otherwise `value`. Bounds are swapped silently when `min > max`. Throws if any parameter is not a number or is `NaN`. Works with `Infinity` bounds and floating-point values.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -154,5 +154,10 @@
     "name": "is-nil",
     "path": "dist/comparisons/is-nil/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "clamp",
+    "path": "dist/numbers/clamp/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/package.json
+++ b/package.json
@@ -47,7 +47,10 @@
 		"tryit",
 		"try-catch",
 		"is-nil",
-		"nullish"
+		"nullish",
+		"clamp",
+		"restrict",
+		"bound"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -189,6 +192,10 @@
 		"./is-nil": {
 			"import": "./dist/comparisons/is-nil/index.js",
 			"types": "./dist/comparisons/is-nil/index.d.ts"
+		},
+		"./clamp": {
+			"import": "./dist/numbers/clamp/index.js",
+			"types": "./dist/numbers/clamp/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ export { isNil } from "./comparisons/is-nil/index.js";
 export { shallowEqual } from "./comparisons/shallow-equal/index.js";
 export { once } from "./functions/once/index.js";
 export { pipe } from "./functions/pipe/index.js";
+export { clamp } from "./numbers/clamp/index.js";
 export { inRange } from "./numbers/in-range/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";

--- a/src/numbers/clamp/index.bench.ts
+++ b/src/numbers/clamp/index.bench.ts
@@ -1,0 +1,88 @@
+import lodashClamp from "lodash/clamp.js";
+import { Bench } from "tinybench";
+import { clamp } from "./index.js";
+
+const inside = { value: 50, min: 0, max: 100 };
+const below = { value: -50, min: 0, max: 100 };
+const above = { value: 150, min: 0, max: 100 };
+const atMin = { value: 0, min: 0, max: 100 };
+const atMax = { value: 100, min: 0, max: 100 };
+const swapped = { value: 50, min: 100, max: 0 };
+
+function nativeClamp(value: number, min: number, max: number): number {
+  const lower = min < max ? min : max;
+  const upper = min < max ? max : min;
+  if (value < lower) return lower;
+  if (value > upper) return upper;
+  return value;
+}
+
+const bench = new Bench({ name: "clamp", time: 1000 });
+
+bench
+  .add("1o1-utils (inside)", () => {
+    clamp(inside);
+  })
+  .add("lodash (inside)", () => {
+    lodashClamp(inside.value, inside.min, inside.max);
+  })
+  .add("native (inside)", () => {
+    nativeClamp(inside.value, inside.min, inside.max);
+  });
+
+bench
+  .add("1o1-utils (below)", () => {
+    clamp(below);
+  })
+  .add("lodash (below)", () => {
+    lodashClamp(below.value, below.min, below.max);
+  })
+  .add("native (below)", () => {
+    nativeClamp(below.value, below.min, below.max);
+  });
+
+bench
+  .add("1o1-utils (above)", () => {
+    clamp(above);
+  })
+  .add("lodash (above)", () => {
+    lodashClamp(above.value, above.min, above.max);
+  })
+  .add("native (above)", () => {
+    nativeClamp(above.value, above.min, above.max);
+  });
+
+bench
+  .add("1o1-utils (at-min)", () => {
+    clamp(atMin);
+  })
+  .add("lodash (at-min)", () => {
+    lodashClamp(atMin.value, atMin.min, atMin.max);
+  })
+  .add("native (at-min)", () => {
+    nativeClamp(atMin.value, atMin.min, atMin.max);
+  });
+
+bench
+  .add("1o1-utils (at-max)", () => {
+    clamp(atMax);
+  })
+  .add("lodash (at-max)", () => {
+    lodashClamp(atMax.value, atMax.min, atMax.max);
+  })
+  .add("native (at-max)", () => {
+    nativeClamp(atMax.value, atMax.min, atMax.max);
+  });
+
+bench
+  .add("1o1-utils (swapped)", () => {
+    clamp(swapped);
+  })
+  .add("lodash (swapped)", () => {
+    lodashClamp(swapped.value, swapped.min, swapped.max);
+  })
+  .add("native (swapped)", () => {
+    nativeClamp(swapped.value, swapped.min, swapped.max);
+  });
+
+export { bench };

--- a/src/numbers/clamp/index.spec.ts
+++ b/src/numbers/clamp/index.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { clamp } from "./index.js";
+
+describe("clamp", () => {
+  it("should return the value when it is inside the range", () => {
+    expect(clamp({ value: 5, min: 0, max: 10 })).to.equal(5);
+  });
+
+  it("should return min when value is below the range", () => {
+    expect(clamp({ value: -5, min: 0, max: 10 })).to.equal(0);
+  });
+
+  it("should return max when value is above the range", () => {
+    expect(clamp({ value: 15, min: 0, max: 10 })).to.equal(10);
+  });
+
+  it("should return value when it equals min (inclusive)", () => {
+    expect(clamp({ value: 0, min: 0, max: 10 })).to.equal(0);
+  });
+
+  it("should return value when it equals max (inclusive)", () => {
+    expect(clamp({ value: 10, min: 0, max: 10 })).to.equal(10);
+  });
+
+  it("should handle negative ranges", () => {
+    expect(clamp({ value: -3, min: -5, max: 5 })).to.equal(-3);
+    expect(clamp({ value: -10, min: -5, max: 0 })).to.equal(-5);
+    expect(clamp({ value: 5, min: -5, max: 0 })).to.equal(0);
+  });
+
+  it("should swap bounds when min is greater than max", () => {
+    expect(clamp({ value: 5, min: 10, max: 0 })).to.equal(5);
+    expect(clamp({ value: -5, min: 10, max: 0 })).to.equal(0);
+    expect(clamp({ value: 15, min: 10, max: 0 })).to.equal(10);
+  });
+
+  it("should return the bound for a zero-width range", () => {
+    expect(clamp({ value: 5, min: 1, max: 1 })).to.equal(1);
+    expect(clamp({ value: -5, min: 1, max: 1 })).to.equal(1);
+    expect(clamp({ value: 1, min: 1, max: 1 })).to.equal(1);
+  });
+
+  it("should handle floating-point values", () => {
+    expect(clamp({ value: 1.5, min: 1, max: 2 })).to.equal(1.5);
+    expect(clamp({ value: 2.5, min: 1, max: 2 })).to.equal(2);
+    expect(clamp({ value: 0.5, min: 1, max: 2 })).to.equal(1);
+  });
+
+  it("should throw if value is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => clamp({ value: "5", min: 0, max: 10 })).to.throw(
+      "The 'value' parameter must be a number",
+    );
+  });
+
+  it("should throw if min is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => clamp({ value: 5, min: "0", max: 10 })).to.throw(
+      "The 'min' parameter must be a number",
+    );
+  });
+
+  it("should throw if max is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => clamp({ value: 5, min: 0, max: "10" })).to.throw(
+      "The 'max' parameter must be a number",
+    );
+  });
+
+  it("should throw if value is NaN", () => {
+    expect(() => clamp({ value: Number.NaN, min: 0, max: 10 })).to.throw(
+      "The 'value' parameter must be a number",
+    );
+  });
+
+  it("should throw if min is NaN", () => {
+    expect(() => clamp({ value: 5, min: Number.NaN, max: 10 })).to.throw(
+      "The 'min' parameter must be a number",
+    );
+  });
+
+  it("should throw if max is NaN", () => {
+    expect(() => clamp({ value: 5, min: 0, max: Number.NaN })).to.throw(
+      "The 'max' parameter must be a number",
+    );
+  });
+
+  it("should handle Infinity bounds", () => {
+    expect(
+      clamp({ value: 1e10, min: 0, max: Number.POSITIVE_INFINITY }),
+    ).to.equal(1e10);
+    expect(
+      clamp({ value: -1e10, min: Number.NEGATIVE_INFINITY, max: 0 }),
+    ).to.equal(-1e10);
+    expect(
+      clamp({
+        value: 5,
+        min: Number.NEGATIVE_INFINITY,
+        max: Number.POSITIVE_INFINITY,
+      }),
+    ).to.equal(5);
+  });
+});

--- a/src/numbers/clamp/index.ts
+++ b/src/numbers/clamp/index.ts
@@ -1,0 +1,44 @@
+import type { ClampParams, ClampResult } from "./types.js";
+
+/**
+ * Clamps a number to a given range.
+ * Returns `min` if `value` is below the range, `max` if above, otherwise `value`.
+ * If `min` is greater than `max`, the bounds are swapped automatically.
+ *
+ * @param params - The parameters object
+ * @param params.value - The number to clamp
+ * @param params.min - The lower bound (inclusive)
+ * @param params.max - The upper bound (inclusive)
+ * @returns The clamped number within `[min, max]`
+ *
+ * @example
+ * ```ts
+ * clamp({ value: 15, min: 0, max: 10 }); // 10
+ * clamp({ value: -5, min: 0, max: 10 }); // 0
+ * clamp({ value: 5, min: 0, max: 10 });  // 5
+ * ```
+ *
+ * @keywords clamp, restrict, bound, constrain, limit, range
+ *
+ * @throws Error if `value`, `min`, or `max` is not a number or is `NaN`
+ */
+function clamp({ value, min, max }: ClampParams): ClampResult {
+  if (typeof value !== "number" || Number.isNaN(value)) {
+    throw new Error("The 'value' parameter must be a number");
+  }
+  if (typeof min !== "number" || Number.isNaN(min)) {
+    throw new Error("The 'min' parameter must be a number");
+  }
+  if (typeof max !== "number" || Number.isNaN(max)) {
+    throw new Error("The 'max' parameter must be a number");
+  }
+
+  const lower = min < max ? min : max;
+  const upper = min < max ? max : min;
+
+  if (value < lower) return lower;
+  if (value > upper) return upper;
+  return value;
+}
+
+export { clamp };

--- a/src/numbers/clamp/types.ts
+++ b/src/numbers/clamp/types.ts
@@ -1,0 +1,11 @@
+interface ClampParams {
+  value: number;
+  min: number;
+  max: number;
+}
+
+type ClampResult = number;
+
+type Clamp = (params: ClampParams) => ClampResult;
+
+export type { Clamp, ClampParams, ClampResult };

--- a/website/src/content/docs/numbers/clamp.mdx
+++ b/website/src/content/docs/numbers/clamp.mdx
@@ -1,0 +1,70 @@
+---
+title: clamp
+description: Clamp a number to a given range
+---
+
+Clamps a number to a given range. Returns `min` if `value` is below the range, `max` if above, otherwise `value`. If `min` is greater than `max`, the bounds are swapped automatically.
+
+## Import
+
+```ts
+import { clamp } from "1o1-utils";
+```
+
+```ts
+import { clamp } from "1o1-utils/clamp";
+```
+
+## Signature
+
+```ts
+function clamp(params: { value: number; min: number; max: number }): number
+```
+
+## Parameters
+
+| Name  | Type     | Required | Description                          |
+| ----- | -------- | -------- | ------------------------------------ |
+| value | `number` | Yes      | The number to clamp                  |
+| min   | `number` | Yes      | The lower bound (inclusive)          |
+| max   | `number` | Yes      | The upper bound (inclusive)          |
+
+## Returns
+
+`number` — The clamped number within `[min, max]`.
+
+## Examples
+
+```ts
+clamp({ value: 15, min: 0, max: 10 }); // 10
+clamp({ value: -5, min: 0, max: 10 }); // 0
+clamp({ value: 5, min: 0, max: 10 });  // 5
+```
+
+```ts
+// Bounds are swapped automatically when min > max
+clamp({ value: 5, min: 10, max: 0 }); // 5
+```
+
+```ts
+// Floating-point values
+clamp({ value: 1.5, min: 1, max: 2 }); // 1.5
+clamp({ value: 2.5, min: 1, max: 2 }); // 2
+```
+
+## Edge Cases
+
+- Throws if any of `value`, `min`, or `max` is not a number or is `NaN`.
+- A zero-width range (`min === max`) always returns that bound.
+- Works with `Infinity` bounds — e.g. `{ value: 1e10, min: 0, max: Infinity }` returns `1e10`.
+- When `min > max`, the bounds are swapped silently.
+
+## Also known as
+
+restrict, bound, constrain, limit, range cap
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use clamp to restrict a slider value between min and max.
+```


### PR DESCRIPTION
## Summary
- Adds `clamp` utility under `numbers/` category — restricts a number to `[min, max]` inclusive range.
- Object-param signature `clamp({ value, min, max })` matching the existing `inRange` style.
- Swaps bounds silently when `min > max`; throws on non-number/NaN inputs; supports `Infinity` bounds and floats.

Closes #55

## API
```ts
clamp({ value: 15, min: 0, max: 10 }); // 10
clamp({ value: -5, min: 0, max: 10 }); // 0
clamp({ value: 5,  min: 0, max: 10 }); // 5
```

## Verification
- 516 tests pass (16 new for `clamp`)
- `pnpm build` clean
- `pnpm size`: clamp = **150 B** (limit 1 kB), total = **4.46 kB** (limit 5 kB)
- Benchmark: ~33M ops/s, on par with lodash and native (`docs/benchmarks/` not regenerated to avoid clobbering existing report — run `pnpm bench` to regen)

## Files
- `src/numbers/clamp/{index,types,index.spec,index.bench}.ts`
- `website/src/content/docs/numbers/clamp.mdx`
- `.changeset/add-clamp.md` (minor bump)
- `src/index.ts`, `package.json` (subpath export + keywords), `.size-limit.json`

## Test plan
- [x] Unit tests cover: inside, below, above, boundaries, negative ranges, swap, zero-width, floats, NaN/non-number throws, Infinity
- [x] Bundle size under limit
- [x] Benchmark on par with lodash/native