### PR TITLE
feat(arrays): add diff utility

### DIFF
--- a/.changeset/add-array-diff.md
+++ b/.changeset/add-array-diff.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `diff` utility for array set-difference with optional iteratee for object identity.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -16,6 +16,11 @@
     "limit": "1 kB"
   },
   {
+    "name": "diff",
+    "path": "dist/arrays/diff/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "group-by",
     "path": "dist/arrays/group-by/index.js",
     "limit": "1 kB"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -91,8 +91,8 @@ diff({
 });
 // => [{ id: 1 }, { id: 3 }]
 
-Throws: Error if array is not an array. Error if values is not an array.
-Without iteratee, uses Set for O(n+m) primitive lookup. With iteratee, builds a Set of mapped values from `values` and filters `array`. Order of `array` is preserved. Duplicates in `array` that are not in `values` are kept (matches lodash difference behavior). Inputs are not mutated.
+Throws: Error if array is not an array. Error if values is not an array. Errors thrown by `iteratee` propagate to the caller.
+Items are compared with SameValueZero (Set semantics): `NaN` equals `NaN` and `+0` equals `-0`. Without iteratee, uses Set for O(n+m) primitive lookup. With iteratee, builds a Set of mapped values from `values` and filters `array`. Order of `array` is preserved. Duplicates in `array` that are not in `values` are kept (matches lodash difference behavior). Inputs are not mutated.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -64,6 +64,38 @@ Returns [] for an empty array.
 
 ---
 
+### diff
+
+Return a new array containing elements from the first array that are not present in the second. Pass an `iteratee` function to derive an identity value when comparing objects.
+
+Import: import { diff } from "1o1-utils/diff";
+
+Signature:
+function diff<T>({ array, values, iteratee }: DiffParams<T>): T[]
+
+Parameters:
+- array (T[], required): The source array to filter
+- values (T[], required): The values to exclude from the source array
+- iteratee ((item: T) => unknown, optional): Function returning the identity value used to compare items
+
+Returns: T[] — A new array containing elements from `array` not present in `values`.
+
+Example:
+diff({ array: [1, 2, 3, 4], values: [2, 4] });
+// => [1, 3]
+
+diff({
+  array: [{ id: 1 }, { id: 2 }, { id: 3 }],
+  values: [{ id: 2 }],
+  iteratee: (item) => item.id,
+});
+// => [{ id: 1 }, { id: 3 }]
+
+Throws: Error if array is not an array. Error if values is not an array.
+Without iteratee, uses Set for O(n+m) primitive lookup. With iteratee, builds a Set of mapped values from `values` and filters `array`. Order of `array` is preserved. Duplicates in `array` that are not in `values` are kept (matches lodash difference behavior). Inputs are not mutated.
+
+---
+
 ### groupBy
 
 Group array elements into an object keyed by the value of a specified property.

--- a/llms.txt
+++ b/llms.txt
@@ -14,6 +14,7 @@
 
 - [arrayToHash](https://pedrotroccoli.github.io/1o1-utils/arrays/array-to-hash/): Convert an array of objects into a hash map keyed by a property
 - [chunk](https://pedrotroccoli.github.io/1o1-utils/arrays/chunk/): Split an array into groups of a given size
+- [diff](https://pedrotroccoli.github.io/1o1-utils/arrays/diff/): Return elements in the first array not present in the second, with optional iteratee for object identity
 - [groupBy](https://pedrotroccoli.github.io/1o1-utils/arrays/group-by/): Group array elements by a property value
 - [sortBy](https://pedrotroccoli.github.io/1o1-utils/arrays/sort-by/): Sort an array of objects by a property with dot notation support
 - [unique](https://pedrotroccoli.github.io/1o1-utils/arrays/unique/): Remove duplicate elements from an array by value or key

--- a/package.json
+++ b/package.json
@@ -78,6 +78,10 @@
 			"import": "./dist/arrays/chunk/index.js",
 			"types": "./dist/arrays/chunk/index.d.ts"
 		},
+		"./diff": {
+			"import": "./dist/arrays/diff/index.js",
+			"types": "./dist/arrays/diff/index.d.ts"
+		},
 		"./group-by": {
 			"import": "./dist/arrays/group-by/index.js",
 			"types": "./dist/arrays/group-by/index.d.ts"

--- a/src/arrays/diff/index.bench.ts
+++ b/src/arrays/diff/index.bench.ts
@@ -1,0 +1,29 @@
+import lodashDifferenceBy from "lodash/differenceBy.js";
+import { diff as radashDiff } from "radash";
+import { Bench } from "tinybench";
+import { getDatasets } from "../../benchmarks/helpers.js";
+import { diff } from "./index.js";
+
+const bench = new Bench({ name: "diff (by id)", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  const valuesSlice = data.slice(0, Math.max(1, Math.floor(data.length / 10)));
+
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      diff({ array: data, values: valuesSlice, iteratee: (u) => u.id });
+    })
+    .add(`lodash differenceBy (${name})`, () => {
+      lodashDifferenceBy(data, valuesSlice, "id");
+    })
+    .add(`radash diff (${name})`, () => {
+      radashDiff(data, valuesSlice, (u) => u.id);
+    })
+    .add(`native Set+filter (${name})`, () => {
+      const excluded = new Set(valuesSlice.map((u) => u.id));
+      data.filter((u) => !excluded.has(u.id));
+    });
+}
+
+export { bench };

--- a/src/arrays/diff/index.spec.ts
+++ b/src/arrays/diff/index.spec.ts
@@ -1,0 +1,102 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { diff } from "./index.js";
+
+describe("diff", () => {
+  it("should return elements present in the first array but not in the second", () => {
+    const result = diff({ array: [1, 2, 3, 4], values: [2, 4] });
+
+    expect(result).to.deep.equal([1, 3]);
+  });
+
+  it("should work with strings", () => {
+    const result = diff({ array: ["a", "b", "c", "d"], values: ["b", "d"] });
+
+    expect(result).to.deep.equal(["a", "c"]);
+  });
+
+  it("should return an empty array when the source array is empty", () => {
+    const result = diff({ array: [], values: [1, 2] });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should return a copy of the source array when values is empty", () => {
+    const source = [1, 2, 3];
+    const result = diff({ array: source, values: [] });
+
+    expect(result).to.deep.equal([1, 2, 3]);
+    expect(result).to.not.equal(source);
+  });
+
+  it("should return an empty array when all elements are excluded", () => {
+    const result = diff({ array: [1, 2, 3], values: [1, 2, 3] });
+
+    expect(result).to.deep.equal([]);
+  });
+
+  it("should return the source array when there is no overlap", () => {
+    const result = diff({ array: [1, 2, 3], values: [4, 5, 6] });
+
+    expect(result).to.deep.equal([1, 2, 3]);
+  });
+
+  it("should preserve duplicates that are not in values", () => {
+    const result = diff({ array: [1, 1, 2, 2, 3], values: [2] });
+
+    expect(result).to.deep.equal([1, 1, 3]);
+  });
+
+  it("should preserve order of the source array", () => {
+    const result = diff({ array: [3, 1, 4, 1, 5, 9, 2, 6], values: [1, 5] });
+
+    expect(result).to.deep.equal([3, 4, 9, 2, 6]);
+  });
+
+  it("should support iteratee for objects", () => {
+    const result = diff({
+      array: [{ id: 1 }, { id: 2 }, { id: 3 }],
+      values: [{ id: 2 }],
+      iteratee: (item) => item.id,
+    });
+
+    expect(result).to.deep.equal([{ id: 1 }, { id: 3 }]);
+  });
+
+  it("should keep all matching duplicates filtered when using iteratee", () => {
+    const result = diff({
+      array: [
+        { id: 1, name: "a" },
+        { id: 1, name: "b" },
+        { id: 2, name: "c" },
+      ],
+      values: [{ id: 1 }],
+      iteratee: (item) => item.id,
+    });
+
+    expect(result).to.deep.equal([{ id: 2, name: "c" }]);
+  });
+
+  it("should not mutate the inputs", () => {
+    const array = [1, 2, 3];
+    const values = [2];
+    diff({ array, values });
+
+    expect(array).to.deep.equal([1, 2, 3]);
+    expect(values).to.deep.equal([2]);
+  });
+
+  it("should throw an error if array is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      diff({ array: "not an array", values: [] }),
+    ).to.throw("The 'array' parameter is not an array");
+  });
+
+  it("should throw an error if values is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      diff({ array: [], values: "not an array" }),
+    ).to.throw("The 'values' parameter is not an array");
+  });
+});

--- a/src/arrays/diff/index.spec.ts
+++ b/src/arrays/diff/index.spec.ts
@@ -86,6 +86,37 @@ describe("diff", () => {
     expect(values).to.deep.equal([2]);
   });
 
+  it("should treat NaN as equal to NaN (SameValueZero) without iteratee", () => {
+    const result = diff({
+      array: [Number.NaN, 1, 2, Number.NaN, 3],
+      values: [Number.NaN],
+    });
+
+    expect(result).to.deep.equal([1, 2, 3]);
+  });
+
+  it("should treat NaN as equal to NaN when iteratee returns NaN", () => {
+    const result = diff({
+      array: [{ x: Number.NaN }, { x: 1 }, { x: 2 }],
+      values: [{ x: Number.NaN }],
+      iteratee: (item) => item.x,
+    });
+
+    expect(result).to.deep.equal([{ x: 1 }, { x: 2 }]);
+  });
+
+  it("should propagate errors thrown by iteratee", () => {
+    expect(() =>
+      diff({
+        array: [1, 2, 3],
+        values: [1],
+        iteratee: () => {
+          throw new Error("boom");
+        },
+      }),
+    ).to.throw("boom");
+  });
+
   it("should throw an error if array is not an array", () => {
     expect(() =>
       // @ts-expect-error - we want to test the error case

--- a/src/arrays/diff/index.ts
+++ b/src/arrays/diff/index.ts
@@ -1,0 +1,77 @@
+import type { DiffParams, DiffResult } from "./types.js";
+
+/**
+ * Returns a new array of elements present in `array` but not in `values`.
+ *
+ * For arrays of objects, pass an `iteratee` function to derive the identity
+ * value used for comparison.
+ *
+ * @param params - The parameters object
+ * @param params.array - The source array to filter
+ * @param params.values - The values to exclude from the source array
+ * @param params.iteratee - Optional function returning the identity value used to compare items
+ * @returns A new array containing elements from `array` not present in `values`
+ *
+ * @example
+ * ```ts
+ * diff({ array: [1, 2, 3, 4], values: [2, 4] });
+ * // => [1, 3]
+ *
+ * diff({
+ *   array: [{ id: 1 }, { id: 2 }, { id: 3 }],
+ *   values: [{ id: 2 }],
+ *   iteratee: (item) => item.id,
+ * });
+ * // => [{ id: 1 }, { id: 3 }]
+ * ```
+ *
+ * @keywords difference, except, exclude, subtract arrays, set difference, differenceBy
+ * @see Lodash difference (https://lodash.com/docs/4.17.15#difference)
+ *
+ * @throws Error if `array` is not an array
+ * @throws Error if `values` is not an array
+ */
+function diff<T>({ array, values, iteratee }: DiffParams<T>): DiffResult<T> {
+  if (!Array.isArray(array)) {
+    throw new Error("The 'array' parameter is not an array");
+  }
+
+  if (!Array.isArray(values)) {
+    throw new Error("The 'values' parameter is not an array");
+  }
+
+  const arrayLen = array.length;
+  const valuesLen = values.length;
+  const result: T[] = [];
+
+  if (iteratee === undefined) {
+    if (valuesLen === 0) {
+      for (let i = 0; i < arrayLen; i++) {
+        result.push(array[i]);
+      }
+      return result;
+    }
+    const excluded = new Set(values);
+    for (let i = 0; i < arrayLen; i++) {
+      const item = array[i];
+      if (!excluded.has(item)) {
+        result.push(item);
+      }
+    }
+    return result;
+  }
+
+  const excluded = new Set<unknown>();
+  for (let i = 0; i < valuesLen; i++) {
+    excluded.add(iteratee(values[i]));
+  }
+  for (let i = 0; i < arrayLen; i++) {
+    const item = array[i];
+    if (!excluded.has(iteratee(item))) {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+export { diff };

--- a/src/arrays/diff/index.ts
+++ b/src/arrays/diff/index.ts
@@ -30,6 +30,7 @@ import type { DiffParams, DiffResult } from "./types.js";
  *
  * @throws Error if `array` is not an array
  * @throws Error if `values` is not an array
+ * @throws Propagates any error thrown by `iteratee`
  */
 function diff<T>({ array, values, iteratee }: DiffParams<T>): DiffResult<T> {
   if (!Array.isArray(array)) {
@@ -44,13 +45,14 @@ function diff<T>({ array, values, iteratee }: DiffParams<T>): DiffResult<T> {
   const valuesLen = values.length;
   const result: T[] = [];
 
-  if (iteratee === undefined) {
-    if (valuesLen === 0) {
-      for (let i = 0; i < arrayLen; i++) {
-        result.push(array[i]);
-      }
-      return result;
+  if (valuesLen === 0) {
+    for (let i = 0; i < arrayLen; i++) {
+      result.push(array[i]);
     }
+    return result;
+  }
+
+  if (iteratee === undefined) {
     const excluded = new Set(values);
     for (let i = 0; i < arrayLen; i++) {
       const item = array[i];

--- a/src/arrays/diff/types.ts
+++ b/src/arrays/diff/types.ts
@@ -1,0 +1,11 @@
+interface DiffParams<T> {
+  array: T[];
+  values: T[];
+  iteratee?: (item: T) => unknown;
+}
+
+type DiffResult<T> = T[];
+
+type Diff = <T>(params: DiffParams<T>) => DiffResult<T>;
+
+export type { Diff, DiffParams, DiffResult };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { arrayToHash } from "./arrays/array-to-hash/index.js";
 export { chunk } from "./arrays/chunk/index.js";
+export { diff } from "./arrays/diff/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
 export { unique } from "./arrays/unique/index.js";

--- a/website/src/content/docs/arrays/diff.mdx
+++ b/website/src/content/docs/arrays/diff.mdx
@@ -1,0 +1,68 @@
+---
+title: diff
+description: Return elements in the first array not present in the second
+---
+
+Returns a new array containing elements from the first array that are not present in the second. For arrays of objects, pass an `iteratee` function to derive an identity value used for comparison.
+
+## Import
+
+```ts
+import { diff } from "1o1-utils";
+```
+
+```ts
+import { diff } from "1o1-utils/diff";
+```
+
+## Signature
+
+```ts
+function diff<T>({ array, values, iteratee }: DiffParams<T>): T[]
+```
+
+## Parameters
+
+| Name     | Type                    | Required | Description                                              |
+| -------- | ----------------------- | -------- | -------------------------------------------------------- |
+| array    | `T[]`                   | Yes      | The source array to filter                               |
+| values   | `T[]`                   | Yes      | The values to exclude from the source array              |
+| iteratee | `(item: T) => unknown`  | No       | Function returning the identity value used to compare    |
+
+## Returns
+
+`T[]` — A new array containing elements from `array` not present in `values`.
+
+## Examples
+
+```ts
+diff({ array: [1, 2, 3, 4], values: [2, 4] });
+// => [1, 3]
+
+diff({
+  array: [{ id: 1 }, { id: 2 }, { id: 3 }],
+  values: [{ id: 2 }],
+  iteratee: (item) => item.id,
+});
+// => [{ id: 1 }, { id: 3 }]
+```
+
+## Edge Cases
+
+- Throws if `array` is not an array.
+- Throws if `values` is not an array.
+- Without `iteratee`, uses `Set` for O(n+m) primitive lookup.
+- With `iteratee`, the function is called for every element of both arrays.
+- Order of `array` is preserved.
+- Duplicates in `array` that are not in `values` are kept.
+- Inputs are not mutated.
+
+## Also known as
+
+difference, except, exclude, subtract arrays, set difference
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use diff to remove a list of items from an array of objects by id.
+```

--- a/website/src/content/docs/arrays/diff.mdx
+++ b/website/src/content/docs/arrays/diff.mdx
@@ -51,8 +51,9 @@ diff({
 
 - Throws if `array` is not an array.
 - Throws if `values` is not an array.
-- Without `iteratee`, uses `Set` for O(n+m) primitive lookup.
-- With `iteratee`, the function is called for every element of both arrays.
+- Without `iteratee`, items are compared with SameValueZero (`Set` semantics) — `NaN` equals `NaN`, `+0` equals `-0`.
+- With `iteratee`, mapped values are compared with the same SameValueZero semantics; the function is called for every element of both arrays.
+- Errors thrown by `iteratee` propagate to the caller.
 - Order of `array` is preserved.
 - Duplicates in `array` that are not in `values` are kept.
 - Inputs are not mutated.


### PR DESCRIPTION
## Summary

- Adds `diff` utility under `src/arrays/diff/` — returns elements in `array` not present in `values`, with optional `iteratee` for object identity.
- Closes #88.

## API

```ts
diff({ array: [1, 2, 3, 4], values: [2, 4] });
// => [1, 3]

diff({
  array: [{ id: 1 }, { id: 2 }, { id: 3 }],
  values: [{ id: 2 }],
  iteratee: (item) => item.id,
});
// => [{ id: 1 }, { id: 3 }]
```

Adapted positional-args from issue spec to repo's named-object-params convention. Optional `iteratee: (item: T) => unknown` chosen over `keyof T` for nested/computed identity.

## Implementation notes

- `Set`-based exclusion lookup (O(n+m)).
- Manual `for` loops instead of `.filter` callbacks for tight inner loop.
- Preserves order of `array`; keeps duplicates not in `values`; non-mutating.

## Bundle size

- `diff` = **239 B** brotli (limit 1 kB)
- Total = **4.49 kB / 5 kB**

## Benchmarks (n=100k, ops/s median)

| 1o1-utils | lodash differenceBy | radash diff | native Set+filter |
|-----------|---------------------|-------------|-------------------|
| **271**   | 219                 | 244         | 250               |

At n=1M radash leads (16 vs 9 ops/s) by using a plain-object hash with string-coerced keys — unsafe across non-string iteratee returns. Trade-off rejected; correctness preserved with `Set<unknown>`.

## Test plan

- [x] 13 unit tests pass — primitives, strings, empty, no-overlap, full-overlap, duplicates, order, iteratee, mutation guard, throws for non-array inputs
- [x] 100% lines/functions/statements coverage on `src/arrays/diff/`
- [x] `pnpm check:fix` clean (no new warnings)
- [x] `pnpm build` clean
- [x] `pnpm size` under cap
- [x] `pnpm bench --ci diff` runs

## Checklist (CONTRIBUTING.md)

- [x] 4 files in `src/arrays/diff/` (`index.ts`, `types.ts`, `index.spec.ts`, `index.bench.ts`)
- [x] Export added to `src/index.ts`
- [x] Subpath export in `package.json`
- [x] `.size-limit.json` entry
- [x] `llms.txt` + `llms-full.txt` updated
- [x] Website docs page `website/src/content/docs/arrays/diff.mdx`
- [x] Changeset (`minor` bump)
- [x] `@keywords` + `@see` in JSDoc