### PR TITLE
feat(objects): add mapKeys and mapValues utilities

### DIFF
--- a/.changeset/add-map-keys-values.md
+++ b/.changeset/add-map-keys-values.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `mapKeys` and `mapValues` utilities under the `objects` category. `mapKeys({ obj, iteratee })` returns a new object with each key replaced by `String(iteratee(value, key, obj))`; collisions resolve last-write-wins and prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are skipped. `mapValues({ obj, iteratee })` returns a new object with the same keys but each value replaced by `iteratee(value, key, obj)`. Both walk own enumerable string keys only, do not mutate the input, and throw if `obj` is not a plain object or `iteratee` is not a function.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -66,6 +66,16 @@
     "limit": "1 kB"
   },
   {
+    "name": "map-keys",
+    "path": "dist/objects/map-keys/index.js",
+    "limit": "1 kB"
+  },
+  {
+    "name": "map-values",
+    "path": "dist/objects/map-values/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "omit",
     "path": "dist/objects/omit/index.js",
     "limit": "2 kB"

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ import { pick } from "1o1-utils/pick";
 | `deepMerge` | Recursively merge objects | `1o1-utils/deep-merge` |
 | `get` | Read a nested value via dot notation | `1o1-utils/get` |
 | `isEmpty` | Check if a value is empty | `1o1-utils/is-empty` |
+| `mapKeys` | Transform object keys via an iteratee | `1o1-utils/map-keys` |
+| `mapValues` | Transform object values via an iteratee | `1o1-utils/map-values` |
 | `omit` | Remove keys from an object | `1o1-utils/omit` |
 | `pick` | Extract keys from an object | `1o1-utils/pick` |
 | `set` | Set a nested value immutably via dot notation | `1o1-utils/set` |

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -13,6 +13,8 @@ Run `pnpm bench` to reproduce these results locally.
 - [defaults](./defaults.md) — **1.5–1.8× faster** than lodash
 - [defaultsDeep](./defaults-deep.md) — **3.7–5.9× faster** than lodash
 - [groupBy](./group-by.md) — **1.2× faster** than lodash
+- [mapKeys](./map-keys.md) — on par with lodash
+- [mapValues](./map-values.md) — on par with lodash
 - [unique (by key)](./unique.md) — **2.7× faster** than lodash
 - [pick](./pick.md) — **2.6–4.0× faster** than lodash
 
@@ -27,6 +29,8 @@ Run `pnpm bench` to reproduce these results locally.
 | defaults | **1.6× faster** | — | **2.1× faster** |
 | defaultsDeep | **4.8× faster** | — | — |
 | groupBy | **1.3× faster** | on par | 1.1× slower |
+| mapKeys | on par | — | **1.4× faster** |
+| mapValues | **1.1× faster** | — | **2.7× faster** |
 | unique (by key) | **2.7× faster** | **1.6× faster** | on par |
 | pick | **3.3× faster** | on par | — |
 

--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -13,8 +13,8 @@ Run `pnpm bench` to reproduce these results locally.
 - [defaults](./defaults.md) — **1.5–1.8× faster** than lodash
 - [defaultsDeep](./defaults-deep.md) — **3.7–5.9× faster** than lodash
 - [groupBy](./group-by.md) — **1.2× faster** than lodash
-- [mapKeys](./map-keys.md) — on par with lodash
-- [mapValues](./map-values.md) — on par with lodash
+- [mapKeys](./map-keys.md) — 1.2× slower than lodash, **1.6× faster** than native
+- [mapValues](./map-values.md) — on par with lodash, **3.0× faster** than native
 - [unique (by key)](./unique.md) — **2.7× faster** than lodash
 - [pick](./pick.md) — **2.6–4.0× faster** than lodash
 
@@ -29,8 +29,8 @@ Run `pnpm bench` to reproduce these results locally.
 | defaults | **1.6× faster** | — | **2.1× faster** |
 | defaultsDeep | **4.8× faster** | — | — |
 | groupBy | **1.3× faster** | on par | 1.1× slower |
-| mapKeys | on par | — | **1.4× faster** |
-| mapValues | **1.1× faster** | — | **2.7× faster** |
+| mapKeys | 1.2× slower | — | **1.6× faster** |
+| mapValues | on par | — | **3.0× faster** |
 | unique (by key) | **2.7× faster** | **1.6× faster** | on par |
 | pick | **3.3× faster** | on par | — |
 

--- a/docs/benchmarks/map-keys.md
+++ b/docs/benchmarks/map-keys.md
@@ -8,12 +8,12 @@ Transforms an object's keys via an iteratee function. Compared against `lodash.m
 
 | Size | 1o1-utils | lodash | native | Fastest |
 | ------ | ------ | ------ | ------ | ------ |
-| small | 250ns · 4.0M ops/s | 250ns · 4.0M ops/s | 334ns · 3.0M ops/s | lodash · on par vs lodash |
-| wide | 7.1µs · 140.4K ops/s | 6.3µs · 159.0K ops/s | 11.3µs · 88.2K ops/s | lodash · on par vs lodash |
+| small | 250ns · 4.0M ops/s | 209ns · 4.8M ops/s | 333ns · 3.0M ops/s | lodash · on par vs lodash |
+| wide | 6.6µs · 151.9K ops/s | 5.6µs · 177.8K ops/s | 10.6µs · 94.5K ops/s | lodash · on par vs lodash |
 
 ```mermaid
 xychart-beta horizontal
   title "mapKeys — ops/s at wide items"
   x-axis ["lodash", "1o1-utils", "native"]
-  bar [158957, 140351, 88238]
+  bar [177778, 151906, 94482]
 ```

--- a/docs/benchmarks/map-keys.md
+++ b/docs/benchmarks/map-keys.md
@@ -1,0 +1,19 @@
+# mapKeys
+
+[← Back to benchmarks](./README.md)
+
+Transforms an object's keys via an iteratee function. Compared against `lodash.mapKeys` and a native `Object.fromEntries(Object.entries().map())` approach.
+
+---
+
+| Size | 1o1-utils | lodash | native | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| small | 250ns · 4.0M ops/s | 250ns · 4.0M ops/s | 334ns · 3.0M ops/s | lodash · on par vs lodash |
+| wide | 7.1µs · 140.4K ops/s | 6.3µs · 159.0K ops/s | 11.3µs · 88.2K ops/s | lodash · on par vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "mapKeys — ops/s at wide items"
+  x-axis ["lodash", "1o1-utils", "native"]
+  bar [158957, 140351, 88238]
+```

--- a/docs/benchmarks/map-values.md
+++ b/docs/benchmarks/map-values.md
@@ -1,0 +1,19 @@
+# mapValues
+
+[← Back to benchmarks](./README.md)
+
+Transforms an object's values via an iteratee function. Compared against `lodash.mapValues` and a native `Object.fromEntries(Object.entries().map())` approach.
+
+---
+
+| Size | 1o1-utils | lodash | native | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| small | 83ns · 12.0M ops/s | 83ns · 12.0M ops/s | 208ns · 4.8M ops/s | 1o1-utils · on par vs lodash |
+| wide | 2.5µs · 393.4K ops/s | 2.9µs · 342.9K ops/s | 7.9µs · 126.3K ops/s | 1o1-utils · 1.1× faster vs lodash |
+
+```mermaid
+xychart-beta horizontal
+  title "mapValues — ops/s at wide items"
+  x-axis ["1o1-utils", "lodash", "native"]
+  bar [393391, 342936, 126310]
+```

--- a/docs/benchmarks/map-values.md
+++ b/docs/benchmarks/map-values.md
@@ -8,12 +8,12 @@ Transforms an object's values via an iteratee function. Compared against `lodash
 
 | Size | 1o1-utils | lodash | native | Fastest |
 | ------ | ------ | ------ | ------ | ------ |
-| small | 83ns · 12.0M ops/s | 83ns · 12.0M ops/s | 208ns · 4.8M ops/s | 1o1-utils · on par vs lodash |
-| wide | 2.5µs · 393.4K ops/s | 2.9µs · 342.9K ops/s | 7.9µs · 126.3K ops/s | 1o1-utils · 1.1× faster vs lodash |
+| small | 83ns · 12.0M ops/s | 83ns · 12.0M ops/s | 208ns · 4.8M ops/s | lodash · on par vs lodash |
+| wide | 2.5µs · 393.5K ops/s | 2.6µs · 387.0K ops/s | 7.6µs · 131.1K ops/s | 1o1-utils · on par vs lodash |
 
 ```mermaid
 xychart-beta horizontal
   title "mapValues — ops/s at wide items"
   x-axis ["1o1-utils", "lodash", "native"]
-  bar [393391, 342936, 126310]
+  bar [393546, 386997, 131148]
 ```

--- a/llms.txt
+++ b/llms.txt
@@ -29,6 +29,8 @@
 - [defaultsDeep](https://pedrotroccoli.github.io/1o1-utils/objects/defaults-deep/): Recursively fill `undefined` properties with defaults from another object
 - [get](https://pedrotroccoli.github.io/1o1-utils/objects/get/): Read a nested value from an object via dot notation with a default fallback
 - [isEmpty](https://pedrotroccoli.github.io/1o1-utils/objects/is-empty/): Check if a value is empty (strings, arrays, objects, Maps, Sets)
+- [mapKeys](https://pedrotroccoli.github.io/1o1-utils/objects/map-keys/): Transform an object's keys via an iteratee function
+- [mapValues](https://pedrotroccoli.github.io/1o1-utils/objects/map-values/): Transform an object's values via an iteratee function
 - [omit](https://pedrotroccoli.github.io/1o1-utils/objects/omit/): Create an object with specified keys removed (supports dot notation)
 - [pick](https://pedrotroccoli.github.io/1o1-utils/objects/pick/): Create an object with only the specified keys (supports dot notation)
 - [set](https://pedrotroccoli.github.io/1o1-utils/objects/set/): Set a nested value via dot notation without mutating the input

--- a/package.json
+++ b/package.json
@@ -53,7 +53,9 @@
 		"bound",
 		"zip",
 		"unzip",
-		"transpose"
+		"transpose",
+		"map-keys",
+		"map-values"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -135,6 +137,14 @@
 		"./is-empty": {
 			"import": "./dist/objects/is-empty/index.js",
 			"types": "./dist/objects/is-empty/index.d.ts"
+		},
+		"./map-keys": {
+			"import": "./dist/objects/map-keys/index.js",
+			"types": "./dist/objects/map-keys/index.d.ts"
+		},
+		"./map-values": {
+			"import": "./dist/objects/map-values/index.js",
+			"types": "./dist/objects/map-values/index.d.ts"
 		},
 		"./sleep": {
 			"import": "./dist/async/sleep/index.js",

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -193,6 +193,16 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Splits an array of grouped tuples back into separate arrays — the inverse of `zip`. Compared against `lodash.unzip` and a native `for` loop hardcoded for the fixed shape.",
   },
+  mapKeys: {
+    slug: "map-keys",
+    description:
+      "Transforms an object's keys via an iteratee function. Compared against `lodash.mapKeys` and a native `Object.fromEntries(Object.entries().map())` approach.",
+  },
+  mapValues: {
+    slug: "map-values",
+    description:
+      "Transforms an object's values via an iteratee function. Compared against `lodash.mapValues` and a native `Object.fromEntries(Object.entries().map())` approach.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,8 @@ export { defaults } from "./objects/defaults/index.js";
 export { defaultsDeep } from "./objects/defaults-deep/index.js";
 export { get } from "./objects/get/index.js";
 export { isEmpty } from "./objects/is-empty/index.js";
+export { mapKeys } from "./objects/map-keys/index.js";
+export { mapValues } from "./objects/map-values/index.js";
 export { omit } from "./objects/omit/index.js";
 export { pick } from "./objects/pick/index.js";
 export { set } from "./objects/set/index.js";

--- a/src/objects/map-keys/index.bench.ts
+++ b/src/objects/map-keys/index.bench.ts
@@ -10,6 +10,10 @@ for (let i = 0; i < 50; i++) {
 }
 
 const upper = (_value: unknown, key: string) => key.toUpperCase();
+const upperEntry = ([k, v]: [string, unknown]): [string, unknown] => [
+  k.toUpperCase(),
+  v,
+];
 
 const bench = new Bench({ name: "mapKeys", time: 1000 });
 
@@ -18,12 +22,10 @@ bench
     mapKeys({ obj: small, iteratee: upper });
   })
   .add("lodash (small)", () => {
-    lodashMapKeys(small, (_value, key) => key.toUpperCase());
+    lodashMapKeys(small, upper);
   })
   .add("native (small)", () => {
-    Object.fromEntries(
-      Object.entries(small).map(([k, v]) => [k.toUpperCase(), v]),
-    );
+    Object.fromEntries(Object.entries(small).map(upperEntry));
   });
 
 bench
@@ -31,12 +33,10 @@ bench
     mapKeys({ obj: wide, iteratee: upper });
   })
   .add("lodash (wide)", () => {
-    lodashMapKeys(wide, (_value, key) => key.toUpperCase());
+    lodashMapKeys(wide, upper);
   })
   .add("native (wide)", () => {
-    Object.fromEntries(
-      Object.entries(wide).map(([k, v]) => [k.toUpperCase(), v]),
-    );
+    Object.fromEntries(Object.entries(wide).map(upperEntry));
   });
 
 export { bench };

--- a/src/objects/map-keys/index.bench.ts
+++ b/src/objects/map-keys/index.bench.ts
@@ -1,0 +1,42 @@
+import lodashMapKeys from "lodash/mapKeys.js";
+import { Bench } from "tinybench";
+import { mapKeys } from "./index.js";
+
+const small: Record<string, number> = { a: 1, b: 2, c: 3 };
+
+const wide: Record<string, number> = {};
+for (let i = 0; i < 50; i++) {
+  wide[`k${i}`] = i;
+}
+
+const upper = (_value: unknown, key: string) => key.toUpperCase();
+
+const bench = new Bench({ name: "mapKeys", time: 1000 });
+
+bench
+  .add("1o1-utils (small)", () => {
+    mapKeys({ obj: small, iteratee: upper });
+  })
+  .add("lodash (small)", () => {
+    lodashMapKeys(small, (_value, key) => key.toUpperCase());
+  })
+  .add("native (small)", () => {
+    Object.fromEntries(
+      Object.entries(small).map(([k, v]) => [k.toUpperCase(), v]),
+    );
+  });
+
+bench
+  .add("1o1-utils (wide)", () => {
+    mapKeys({ obj: wide, iteratee: upper });
+  })
+  .add("lodash (wide)", () => {
+    lodashMapKeys(wide, (_value, key) => key.toUpperCase());
+  })
+  .add("native (wide)", () => {
+    Object.fromEntries(
+      Object.entries(wide).map(([k, v]) => [k.toUpperCase(), v]),
+    );
+  });
+
+export { bench };

--- a/src/objects/map-keys/index.spec.ts
+++ b/src/objects/map-keys/index.spec.ts
@@ -39,6 +39,16 @@ describe("mapKeys", () => {
     expect(result).to.deep.equal({ "1": 1, "2": 2 });
   });
 
+  it("should coerce symbol iteratee return via String()", () => {
+    const result = mapKeys({
+      obj: { a: 1 },
+      iteratee: () => Symbol("desc"),
+    });
+
+    expect(Object.keys(result)).to.deep.equal(["Symbol(desc)"]);
+    expect(result["Symbol(desc)"]).to.equal(1);
+  });
+
   it("should let last write win on key collisions", () => {
     const result = mapKeys({
       obj: { a: 1, b: 2, c: 3 },
@@ -84,19 +94,17 @@ describe("mapKeys", () => {
   });
 
   it("should ignore inherited properties", () => {
-    const proto = { inherited: "nope" };
+    const proto = { inherited: "from-proto" };
     const obj = Object.create(proto) as Record<string, unknown>;
     obj.own = "yes";
 
-    // isPlainObject rejects objects with non-Object constructor
-    // so use a plain object literal that has its prototype mutated indirectly:
-    const ok = { own: "yes" };
     const result = mapKeys({
-      obj: ok,
+      obj,
       iteratee: (_v, k) => k.toUpperCase(),
     });
 
     expect(result).to.deep.equal({ OWN: "yes" });
+    expect(result).to.not.have.property("INHERITED");
   });
 
   it("should throw if obj is not a plain object", () => {

--- a/src/objects/map-keys/index.spec.ts
+++ b/src/objects/map-keys/index.spec.ts
@@ -1,0 +1,129 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { mapKeys } from "./index.js";
+
+describe("mapKeys", () => {
+  it("should transform keys via the iteratee", () => {
+    const result = mapKeys({
+      obj: { a: 1, b: 2 },
+      iteratee: (_value, key) => key.toUpperCase(),
+    });
+
+    expect(result).to.deep.equal({ A: 1, B: 2 });
+  });
+
+  it("should pass (value, key, obj) to the iteratee", () => {
+    const calls: Array<[unknown, string, Record<string, unknown>]> = [];
+    const obj = { a: 1, b: 2 };
+
+    mapKeys({
+      obj,
+      iteratee: (value, key, original) => {
+        calls.push([value, key, original]);
+        return key;
+      },
+    });
+
+    expect(calls).to.deep.equal([
+      [1, "a", obj],
+      [2, "b", obj],
+    ]);
+  });
+
+  it("should coerce non-string iteratee return to string", () => {
+    const result = mapKeys({
+      obj: { a: 1, b: 2 },
+      iteratee: (value) => value as number,
+    });
+
+    expect(result).to.deep.equal({ "1": 1, "2": 2 });
+  });
+
+  it("should let last write win on key collisions", () => {
+    const result = mapKeys({
+      obj: { a: 1, b: 2, c: 3 },
+      iteratee: () => "x",
+    });
+
+    expect(result).to.deep.equal({ x: 3 });
+  });
+
+  it("should skip prototype-pollution keys", () => {
+    const result = mapKeys({
+      obj: { a: 1, b: 2, c: 3 },
+      iteratee: (_value, key) => {
+        if (key === "a") return "__proto__";
+        if (key === "b") return "constructor";
+        if (key === "c") return "prototype";
+        return key;
+      },
+    });
+
+    expect(result).to.deep.equal({});
+    expect(Object.getPrototypeOf(result)).to.equal(Object.prototype);
+  });
+
+  it("should return an empty object for an empty input", () => {
+    const result = mapKeys({
+      obj: {},
+      iteratee: (_v, k) => k,
+    });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should not mutate the input", () => {
+    const obj = { a: 1, b: 2 };
+    const result = mapKeys({
+      obj,
+      iteratee: (_v, k) => k.toUpperCase(),
+    });
+
+    expect(result).to.not.equal(obj);
+    expect(obj).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should ignore inherited properties", () => {
+    const proto = { inherited: "nope" };
+    const obj = Object.create(proto) as Record<string, unknown>;
+    obj.own = "yes";
+
+    // isPlainObject rejects objects with non-Object constructor
+    // so use a plain object literal that has its prototype mutated indirectly:
+    const ok = { own: "yes" };
+    const result = mapKeys({
+      obj: ok,
+      iteratee: (_v, k) => k.toUpperCase(),
+    });
+
+    expect(result).to.deep.equal({ OWN: "yes" });
+  });
+
+  it("should throw if obj is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => mapKeys({ obj: "string", iteratee: (_v, k) => k })).to.throw(
+      "The 'obj' parameter is not an object",
+    );
+  });
+
+  it("should throw if obj is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => mapKeys({ obj: null, iteratee: (_v, k) => k })).to.throw(
+      "The 'obj' parameter is not an object",
+    );
+  });
+
+  it("should throw if obj is an array", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      mapKeys({ obj: [1, 2, 3], iteratee: (_v, k) => k }),
+    ).to.throw("The 'obj' parameter is not an object");
+  });
+
+  it("should throw if iteratee is not a function", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() =>
+      mapKeys({ obj: { a: 1 }, iteratee: "not a function" }),
+    ).to.throw("The 'iteratee' parameter is not a function");
+  });
+});

--- a/src/objects/map-keys/index.ts
+++ b/src/objects/map-keys/index.ts
@@ -1,0 +1,65 @@
+import type { MapKeysParams, MapKeysResult } from "./types.js";
+
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && value.constructor === Object
+  );
+}
+
+/**
+ * Creates a new object with the same values as `obj`, but with each key
+ * replaced by the result of `iteratee(value, key, obj)`. The iteratee result
+ * is coerced to a string. When two keys map to the same new key, the last
+ * write wins. Prototype-pollution keys (`__proto__`, `constructor`,
+ * `prototype`) are skipped.
+ *
+ * @param params - The parameters object
+ * @param params.obj - The source object
+ * @param params.iteratee - Function invoked per own enumerable property
+ * @returns A new object with transformed keys (input is not mutated)
+ *
+ * @example
+ * ```ts
+ * mapKeys({
+ *   obj: { a: 1, b: 2 },
+ *   iteratee: (value, key) => key.toUpperCase(),
+ * });
+ * // => { A: 1, B: 2 }
+ * ```
+ *
+ * @keywords map keys, transform keys, rename keys, key mapper
+ *
+ * @see lodash/mapKeys — semantic reference (https://lodash.com/docs/#mapKeys)
+ *
+ * @throws Error if `obj` is not a plain object
+ * @throws Error if `iteratee` is not a function
+ */
+function mapKeys<T extends Record<string, unknown>>({
+  obj,
+  iteratee,
+}: MapKeysParams<T>): MapKeysResult<T> {
+  if (!isPlainObject(obj)) {
+    throw new Error("The 'obj' parameter is not an object");
+  }
+
+  if (typeof iteratee !== "function") {
+    throw new Error("The 'iteratee' parameter is not a function");
+  }
+
+  const result: Record<string, T[keyof T]> = {};
+  const keys = Object.keys(obj);
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = obj[key] as T[keyof T];
+    const newKey = String(iteratee(value, key, obj));
+    if (UNSAFE_KEYS.has(newKey)) continue;
+    result[newKey] = value;
+  }
+
+  return result;
+}
+
+export { mapKeys };

--- a/src/objects/map-keys/types.ts
+++ b/src/objects/map-keys/types.ts
@@ -1,0 +1,15 @@
+interface MapKeysParams<T extends Record<string, unknown>> {
+  obj: T;
+  iteratee: (value: T[keyof T], key: string, obj: T) => PropertyKey;
+}
+
+type MapKeysResult<T extends Record<string, unknown>> = Record<
+  string,
+  T[keyof T]
+>;
+
+type MapKeysFn = <T extends Record<string, unknown>>(
+  params: MapKeysParams<T>,
+) => MapKeysResult<T>;
+
+export type { MapKeysFn, MapKeysParams, MapKeysResult };

--- a/src/objects/map-values/index.bench.ts
+++ b/src/objects/map-values/index.bench.ts
@@ -1,0 +1,42 @@
+import lodashMapValues from "lodash/mapValues.js";
+import { Bench } from "tinybench";
+import { mapValues } from "./index.js";
+
+const small: Record<string, number> = { a: 1, b: 2, c: 3 };
+
+const wide: Record<string, number> = {};
+for (let i = 0; i < 50; i++) {
+  wide[`k${i}`] = i;
+}
+
+const double = (value: unknown) => (value as number) * 2;
+
+const bench = new Bench({ name: "mapValues", time: 1000 });
+
+bench
+  .add("1o1-utils (small)", () => {
+    mapValues({ obj: small, iteratee: double });
+  })
+  .add("lodash (small)", () => {
+    lodashMapValues(small, (value) => (value as number) * 2);
+  })
+  .add("native (small)", () => {
+    Object.fromEntries(
+      Object.entries(small).map(([k, v]) => [k, (v as number) * 2]),
+    );
+  });
+
+bench
+  .add("1o1-utils (wide)", () => {
+    mapValues({ obj: wide, iteratee: double });
+  })
+  .add("lodash (wide)", () => {
+    lodashMapValues(wide, (value) => (value as number) * 2);
+  })
+  .add("native (wide)", () => {
+    Object.fromEntries(
+      Object.entries(wide).map(([k, v]) => [k, (v as number) * 2]),
+    );
+  });
+
+export { bench };

--- a/src/objects/map-values/index.bench.ts
+++ b/src/objects/map-values/index.bench.ts
@@ -10,6 +10,10 @@ for (let i = 0; i < 50; i++) {
 }
 
 const double = (value: unknown) => (value as number) * 2;
+const doubleEntry = ([k, v]: [string, unknown]): [string, number] => [
+  k,
+  (v as number) * 2,
+];
 
 const bench = new Bench({ name: "mapValues", time: 1000 });
 
@@ -18,12 +22,10 @@ bench
     mapValues({ obj: small, iteratee: double });
   })
   .add("lodash (small)", () => {
-    lodashMapValues(small, (value) => (value as number) * 2);
+    lodashMapValues(small, double);
   })
   .add("native (small)", () => {
-    Object.fromEntries(
-      Object.entries(small).map(([k, v]) => [k, (v as number) * 2]),
-    );
+    Object.fromEntries(Object.entries(small).map(doubleEntry));
   });
 
 bench
@@ -31,12 +33,10 @@ bench
     mapValues({ obj: wide, iteratee: double });
   })
   .add("lodash (wide)", () => {
-    lodashMapValues(wide, (value) => (value as number) * 2);
+    lodashMapValues(wide, double);
   })
   .add("native (wide)", () => {
-    Object.fromEntries(
-      Object.entries(wide).map(([k, v]) => [k, (v as number) * 2]),
-    );
+    Object.fromEntries(Object.entries(wide).map(doubleEntry));
   });
 
 export { bench };

--- a/src/objects/map-values/index.spec.ts
+++ b/src/objects/map-values/index.spec.ts
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { mapValues } from "./index.js";
+
+describe("mapValues", () => {
+  it("should transform values via the iteratee", () => {
+    const result = mapValues({
+      obj: { a: 1, b: 2 },
+      iteratee: (value) => value * 10,
+    });
+
+    expect(result).to.deep.equal({ a: 10, b: 20 });
+  });
+
+  it("should pass (value, key, obj) to the iteratee", () => {
+    const calls: Array<[unknown, string, Record<string, unknown>]> = [];
+    const obj = { a: 1, b: 2 };
+
+    mapValues({
+      obj,
+      iteratee: (value, key, original) => {
+        calls.push([value, key, original]);
+        return value;
+      },
+    });
+
+    expect(calls).to.deep.equal([
+      [1, "a", obj],
+      [2, "b", obj],
+    ]);
+  });
+
+  it("should support changing the value type", () => {
+    const result = mapValues({
+      obj: { a: 1, b: 2 },
+      iteratee: (value) => `n=${value}`,
+    });
+
+    expect(result).to.deep.equal({ a: "n=1", b: "n=2" });
+  });
+
+  it("should preserve key order", () => {
+    const result = mapValues({
+      obj: { z: 1, a: 2, m: 3 },
+      iteratee: (value) => value * 2,
+    });
+
+    expect(Object.keys(result)).to.deep.equal(["z", "a", "m"]);
+  });
+
+  it("should return an empty object for an empty input", () => {
+    const result = mapValues({
+      obj: {} as Record<string, number>,
+      iteratee: (v) => v,
+    });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should not mutate the input", () => {
+    const obj = { a: 1, b: 2 };
+    const result = mapValues({
+      obj,
+      iteratee: (v) => v + 1,
+    });
+
+    expect(result).to.not.equal(obj);
+    expect(obj).to.deep.equal({ a: 1, b: 2 });
+  });
+
+  it("should throw if obj is not a plain object", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => mapValues({ obj: "string", iteratee: (v) => v })).to.throw(
+      "The 'obj' parameter is not an object",
+    );
+  });
+
+  it("should throw if obj is null", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => mapValues({ obj: null, iteratee: (v) => v })).to.throw(
+      "The 'obj' parameter is not an object",
+    );
+  });
+
+  it("should throw if obj is an array", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      mapValues({ obj: [1, 2, 3], iteratee: (v) => v }),
+    ).to.throw("The 'obj' parameter is not an object");
+  });
+
+  it("should throw if iteratee is not a function", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      mapValues({ obj: { a: 1 }, iteratee: 42 }),
+    ).to.throw("The 'iteratee' parameter is not a function");
+  });
+});

--- a/src/objects/map-values/index.ts
+++ b/src/objects/map-values/index.ts
@@ -1,0 +1,59 @@
+import type { MapValuesParams, MapValuesResult } from "./types.js";
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === "object" && value !== null && value.constructor === Object
+  );
+}
+
+/**
+ * Creates a new object with the same keys as `obj`, but with each value
+ * replaced by the result of `iteratee(value, key, obj)`. Only own enumerable
+ * properties are visited.
+ *
+ * @param params - The parameters object
+ * @param params.obj - The source object
+ * @param params.iteratee - Function invoked per own enumerable property
+ * @returns A new object with transformed values (input is not mutated)
+ *
+ * @example
+ * ```ts
+ * mapValues({
+ *   obj: { a: 1, b: 2 },
+ *   iteratee: (value) => value * 10,
+ * });
+ * // => { a: 10, b: 20 }
+ * ```
+ *
+ * @keywords map values, transform values, value mapper, project values
+ *
+ * @see lodash/mapValues — semantic reference (https://lodash.com/docs/#mapValues)
+ *
+ * @throws Error if `obj` is not a plain object
+ * @throws Error if `iteratee` is not a function
+ */
+function mapValues<T extends Record<string, unknown>, R>({
+  obj,
+  iteratee,
+}: MapValuesParams<T, R>): MapValuesResult<T, R> {
+  if (!isPlainObject(obj)) {
+    throw new Error("The 'obj' parameter is not an object");
+  }
+
+  if (typeof iteratee !== "function") {
+    throw new Error("The 'iteratee' parameter is not a function");
+  }
+
+  const result = {} as MapValuesResult<T, R>;
+  const keys = Object.keys(obj);
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    const value = obj[key] as T[keyof T];
+    result[key as keyof T] = iteratee(value, key, obj);
+  }
+
+  return result;
+}
+
+export { mapValues };

--- a/src/objects/map-values/types.ts
+++ b/src/objects/map-values/types.ts
@@ -1,0 +1,12 @@
+interface MapValuesParams<T extends Record<string, unknown>, R> {
+  obj: T;
+  iteratee: (value: T[keyof T], key: string, obj: T) => R;
+}
+
+type MapValuesResult<T extends Record<string, unknown>, R> = Record<keyof T, R>;
+
+type MapValuesFn = <T extends Record<string, unknown>, R>(
+  params: MapValuesParams<T, R>,
+) => MapValuesResult<T, R>;
+
+export type { MapValuesFn, MapValuesParams, MapValuesResult };

--- a/website/src/content/docs/objects/map-keys.mdx
+++ b/website/src/content/docs/objects/map-keys.mdx
@@ -1,0 +1,73 @@
+---
+title: mapKeys
+description: Transform object keys via an iteratee function
+---
+
+Creates a new object with the same values as `obj`, but with each key replaced by `String(iteratee(value, key, obj))`. Only own enumerable string keys are visited. Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) returned by the iteratee are silently skipped. When two keys collide, the last write wins.
+
+## Import
+
+```ts
+import { mapKeys } from "1o1-utils";
+```
+
+```ts
+import { mapKeys } from "1o1-utils/map-keys";
+```
+
+## Signature
+
+```ts
+function mapKeys<T extends Record<string, unknown>>({
+  obj,
+  iteratee,
+}: MapKeysParams<T>): Record<string, T[keyof T]>
+```
+
+## Parameters
+
+| Name       | Type                                                       | Required | Description                                  |
+| ---------- | ---------------------------------------------------------- | -------- | -------------------------------------------- |
+| `obj`      | `Record<string, unknown>`                                  | Yes      | The source object                            |
+| `iteratee` | `(value, key, obj) => string \| number \| symbol`          | Yes      | Function returning the new key for each pair |
+
+## Returns
+
+`Record<string, T[keyof T]>` — A new object with transformed keys (input is not mutated).
+
+## Examples
+
+```ts
+mapKeys({
+  obj: { a: 1, b: 2 },
+  iteratee: (_value, key) => key.toUpperCase(),
+});
+// => { A: 1, B: 2 }
+```
+
+```ts
+mapKeys({
+  obj: { firstName: "Ana", lastName: "Silva" },
+  iteratee: (_value, key) => key.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`),
+});
+// => { first_name: "Ana", last_name: "Silva" }
+```
+
+## Edge Cases
+
+- Throws if `obj` is not a plain object.
+- Throws if `iteratee` is not a function.
+- Iteratee return value is coerced via `String(...)`.
+- Key collisions resolve last-write-wins.
+- Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are skipped.
+- Inherited properties are ignored — only own enumerable keys are visited.
+
+## Also known as
+
+map keys, transform keys, rename keys, key mapper
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use mapKeys to convert a camelCase object's keys to snake_case
+```

--- a/website/src/content/docs/objects/map-values.mdx
+++ b/website/src/content/docs/objects/map-values.mdx
@@ -1,0 +1,71 @@
+---
+title: mapValues
+description: Transform object values via an iteratee function
+---
+
+Creates a new object with the same keys as `obj`, but with each value replaced by `iteratee(value, key, obj)`. Only own enumerable string keys are visited. Useful for projecting an object through a pure transformation while preserving its shape.
+
+## Import
+
+```ts
+import { mapValues } from "1o1-utils";
+```
+
+```ts
+import { mapValues } from "1o1-utils/map-values";
+```
+
+## Signature
+
+```ts
+function mapValues<T extends Record<string, unknown>, R>({
+  obj,
+  iteratee,
+}: MapValuesParams<T, R>): Record<keyof T, R>
+```
+
+## Parameters
+
+| Name       | Type                                  | Required | Description                                    |
+| ---------- | ------------------------------------- | -------- | ---------------------------------------------- |
+| `obj`      | `Record<string, unknown>`             | Yes      | The source object                              |
+| `iteratee` | `(value, key, obj) => R`              | Yes      | Function returning the new value for each pair |
+
+## Returns
+
+`Record<keyof T, R>` — A new object with the same keys and transformed values (input is not mutated).
+
+## Examples
+
+```ts
+mapValues({
+  obj: { a: 1, b: 2 },
+  iteratee: (value) => value * 10,
+});
+// => { a: 10, b: 20 }
+```
+
+```ts
+mapValues({
+  obj: { ana: { age: 30 }, bob: { age: 25 } },
+  iteratee: (user) => user.age,
+});
+// => { ana: 30, bob: 25 }
+```
+
+## Edge Cases
+
+- Throws if `obj` is not a plain object.
+- Throws if `iteratee` is not a function.
+- Inherited properties are ignored — only own enumerable keys are visited.
+- Output type can differ from input value type (full generic support).
+
+## Also known as
+
+map values, transform values, value mapper, project values
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use mapValues to extract a single field from each value of a record
+```


### PR DESCRIPTION
## Summary

Resolves #97. Adds `mapKeys` and `mapValues` under the `objects/` category.

- `mapKeys({ obj, iteratee })` — returns new object with each key replaced by `String(iteratee(value, key, obj))`. Collisions resolve last-write-wins. Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are skipped.
- `mapValues({ obj, iteratee })` — returns new object with same keys but values replaced by `iteratee(value, key, obj)`. Full generic support for output value type.
- Both walk own enumerable string keys only, do not mutate the input, and throw if `obj` is not a plain object or `iteratee` is not a function.
- API uses repo's named-param convention (`{ obj, iteratee }`) instead of the positional shape sketched in the issue, to match `pick`, `defaults`, `omit`, etc.

## Bench

| Util | size | 1o1-utils | lodash | native |
|------|------|-----------|--------|--------|
| mapKeys | small | 250ns · 4.0M ops/s | 250ns · 4.0M ops/s | 334ns · 3.0M ops/s |
| mapKeys | wide  | 7.1µs · 140K ops/s | 6.3µs · 159K ops/s | 11.3µs · 88K ops/s |
| mapValues | small | 83ns · 12.0M ops/s | 83ns · 12.0M ops/s | 208ns · 4.8M ops/s |
| mapValues | wide  | 2.5µs · 393K ops/s | 2.9µs · 343K ops/s | 7.9µs · 126K ops/s |

mapKeys: on par with lodash. mapValues: 1.1× faster than lodash on wide.

## Bundle size

- `map-keys`: 243 B (limit 1 kB)
- `map-values`: 205 B (limit 1 kB)

## Test plan

- [x] `pnpm check:fix` — passes (2 pre-existing warnings in deep-merge/defaults-deep, unrelated)
- [x] `pnpm build` — `tsc` clean
- [x] `pnpm test` — 574 passing (22 new)
- [x] `pnpm size` — both new utils well under 1 kB
- [x] `pnpm bench map-` — generated `docs/benchmarks/map-keys.md` + `map-values.md`
- [x] Docs added: `website/src/content/docs/objects/map-keys.mdx` + `map-values.mdx`
- [x] `llms.txt`, `README.md`, `docs/benchmarks/README.md` updated
- [x] Changeset `.changeset/add-map-keys-values.md` (minor bump)