### PR TITLE
feat(arrays): add times utility

### DIFF
--- a/.changeset/add-times.md
+++ b/.changeset/add-times.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `times` utility under the `arrays` category. `times({ count, fn })` invokes `fn` `count` times with the current index and returns an array of the results. Strictly validates inputs: throws if `count` is not a non-negative integer or `fn` is not a function. `count: 0` returns `[]`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -174,5 +174,10 @@
     "name": "unzip",
     "path": "dist/arrays/unzip/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "times",
+    "path": "dist/arrays/times/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -155,6 +155,35 @@ Supports both numeric and string comparisons.
 
 ---
 
+### times
+
+Invoke a function N times with the current index (0-based) and return an array of the results.
+
+Import: import { times } from "1o1-utils/times";
+
+Signature:
+function times<T>({ count, fn }: TimesParams<T>): T[]
+
+Parameters:
+- count (number, required): How many times to invoke fn (non-negative integer)
+- fn ((index: number) => T, required): Function called with the current index on each iteration
+
+Returns: T[]
+
+Example:
+times({ count: 3, fn: (i) => i * 2 });
+// => [0, 2, 4]
+
+times({ count: 5, fn: () => Math.random() });
+// => [0.42, 0.91, 0.13, 0.77, 0.05]
+
+times({ count: 0, fn: (i) => i });
+// => []
+
+Throws: Error if count is not a number or is NaN. Error if count is not an integer (Infinity rejected). Error if count is negative. Error if fn is not a function.
+
+---
+
 ### unique
 
 Return a new array with duplicate elements removed. For objects, specify a key to determine uniqueness.

--- a/llms.txt
+++ b/llms.txt
@@ -17,6 +17,7 @@
 - [diff](https://pedrotroccoli.github.io/1o1-utils/arrays/diff/): Return elements in the first array not present in the second, with optional iteratee for object identity
 - [groupBy](https://pedrotroccoli.github.io/1o1-utils/arrays/group-by/): Group array elements by a property value
 - [sortBy](https://pedrotroccoli.github.io/1o1-utils/arrays/sort-by/): Sort an array of objects by a property with dot notation support
+- [times](https://pedrotroccoli.github.io/1o1-utils/arrays/times/): Invoke a function N times with the current index and collect the results
 - [unique](https://pedrotroccoli.github.io/1o1-utils/arrays/unique/): Remove duplicate elements from an array by value or key
 - [unzip](https://pedrotroccoli.github.io/1o1-utils/arrays/unzip/): Split an array of grouped tuples back into separate arrays
 - [zip](https://pedrotroccoli.github.io/1o1-utils/arrays/zip/): Combine arrays by index into tuples, with fill or truncate strategy

--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
 		"bound",
 		"zip",
 		"unzip",
-		"transpose"
+		"transpose",
+		"times",
+		"repeat",
+		"range"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -211,6 +214,10 @@
 		"./unzip": {
 			"import": "./dist/arrays/unzip/index.js",
 			"types": "./dist/arrays/unzip/index.d.ts"
+		},
+		"./times": {
+			"import": "./dist/arrays/times/index.js",
+			"types": "./dist/arrays/times/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/arrays/times/index.bench.ts
+++ b/src/arrays/times/index.bench.ts
@@ -1,0 +1,34 @@
+import lodashTimes from "lodash/times.js";
+import { Bench } from "tinybench";
+import { times } from "./index.js";
+
+const SIZES = [
+  { name: "n=10", count: 10 },
+  { name: "n=1k", count: 1_000 },
+  { name: "n=100k", count: 100_000 },
+];
+
+const fn = (i: number) => i * 2;
+
+const bench = new Bench({ name: "times", time: 1000 });
+
+for (const { name, count } of SIZES) {
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      times({ count, fn });
+    })
+    .add(`lodash (${name})`, () => {
+      lodashTimes(count, fn);
+    })
+    .add(`Array.from (${name})`, () => {
+      Array.from({ length: count }, (_, i) => fn(i));
+    })
+    .add(`native for-loop (${name})`, () => {
+      const result: number[] = new Array(count);
+      for (let i = 0; i < count; i++) {
+        result[i] = fn(i);
+      }
+    });
+}
+
+export { bench };

--- a/src/arrays/times/index.spec.ts
+++ b/src/arrays/times/index.spec.ts
@@ -1,0 +1,99 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { times } from "./index.js";
+
+describe("times", () => {
+  it("should return an array of mapped indices", () => {
+    expect(times({ count: 3, fn: (i) => i * 2 })).to.deep.equal([0, 2, 4]);
+  });
+
+  it("should pass the current index to fn", () => {
+    const seen: number[] = [];
+    times({
+      count: 4,
+      fn: (i) => {
+        seen.push(i);
+        return i;
+      },
+    });
+    expect(seen).to.deep.equal([0, 1, 2, 3]);
+  });
+
+  it("should return an empty array when count is 0", () => {
+    expect(times({ count: 0, fn: (i) => i })).to.deep.equal([]);
+  });
+
+  it("should not invoke fn when count is 0", () => {
+    let calls = 0;
+    times({
+      count: 0,
+      fn: () => {
+        calls++;
+        return null;
+      },
+    });
+    expect(calls).to.equal(0);
+  });
+
+  it("should support arbitrary return types", () => {
+    expect(times({ count: 3, fn: (i) => `item-${i}` })).to.deep.equal([
+      "item-0",
+      "item-1",
+      "item-2",
+    ]);
+
+    expect(times({ count: 2, fn: (i) => ({ id: i }) })).to.deep.equal([
+      { id: 0 },
+      { id: 1 },
+    ]);
+  });
+
+  it("should produce a result array of the requested length", () => {
+    expect(times({ count: 100, fn: () => 0 })).to.have.length(100);
+  });
+
+  it("should throw if count is not a number", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => times({ count: "3", fn: (i) => i })).to.throw(
+      "The 'count' parameter must be a number",
+    );
+  });
+
+  it("should throw if count is NaN", () => {
+    expect(() => times({ count: Number.NaN, fn: (i) => i })).to.throw(
+      "The 'count' parameter must be a number",
+    );
+  });
+
+  it("should throw if count is not an integer", () => {
+    expect(() => times({ count: 3.5, fn: (i) => i })).to.throw(
+      "The 'count' parameter must be an integer",
+    );
+  });
+
+  it("should throw if count is Infinity", () => {
+    expect(() =>
+      times({ count: Number.POSITIVE_INFINITY, fn: (i) => i }),
+    ).to.throw("The 'count' parameter must be an integer");
+  });
+
+  it("should throw if count is negative", () => {
+    expect(() => times({ count: -1, fn: (i) => i })).to.throw(
+      "The 'count' parameter must be non-negative",
+    );
+  });
+
+  it("should throw if fn is not a function", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => times({ count: 3, fn: null })).to.throw(
+      "The 'fn' parameter must be a function",
+    );
+  });
+
+  it("should throw if fn is undefined", () => {
+    // @ts-expect-error - testing invalid input
+    expect(() => times({ count: 3, fn: undefined })).to.throw(
+      "The 'fn' parameter must be a function",
+    );
+  });
+});

--- a/src/arrays/times/index.ts
+++ b/src/arrays/times/index.ts
@@ -1,0 +1,50 @@
+import type { TimesParams, TimesResult } from "./types.js";
+
+/**
+ * Invokes `fn` `count` times and returns an array of the results.
+ * The function receives the current index (0-based) on each call.
+ *
+ * @param params - The parameters object
+ * @param params.count - The number of times to invoke `fn` (non-negative integer)
+ * @param params.fn - The function to invoke; receives the current index
+ * @returns An array of length `count` containing the results of each invocation
+ *
+ * @example
+ * ```ts
+ * times({ count: 3, fn: (i) => i * 2 });
+ * // => [0, 2, 4]
+ *
+ * times({ count: 5, fn: () => Math.random() });
+ * // => [0.42, 0.91, 0.13, 0.77, 0.05]
+ *
+ * times({ count: 0, fn: (i) => i });
+ * // => []
+ * ```
+ *
+ * @keywords times, repeat, range, fill, generate, invoke
+ *
+ * @throws Error if `count` is not a number, is `NaN`, is not an integer, or is negative
+ * @throws Error if `fn` is not a function
+ */
+function times<T>({ count, fn }: TimesParams<T>): TimesResult<T> {
+  if (typeof count !== "number" || Number.isNaN(count)) {
+    throw new Error("The 'count' parameter must be a number");
+  }
+  if (!Number.isInteger(count)) {
+    throw new Error("The 'count' parameter must be an integer");
+  }
+  if (count < 0) {
+    throw new Error("The 'count' parameter must be non-negative");
+  }
+  if (typeof fn !== "function") {
+    throw new Error("The 'fn' parameter must be a function");
+  }
+
+  const result: T[] = new Array(count);
+  for (let i = 0; i < count; i++) {
+    result[i] = fn(i);
+  }
+  return result;
+}
+
+export { times };

--- a/src/arrays/times/types.ts
+++ b/src/arrays/times/types.ts
@@ -1,0 +1,12 @@
+type TimesFn<T> = (index: number) => T;
+
+interface TimesParams<T> {
+  count: number;
+  fn: TimesFn<T>;
+}
+
+type TimesResult<T> = T[];
+
+type Times = <T>(params: TimesParams<T>) => TimesResult<T>;
+
+export type { Times, TimesFn, TimesParams, TimesResult };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export { chunk } from "./arrays/chunk/index.js";
 export { diff } from "./arrays/diff/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
+export { times } from "./arrays/times/index.js";
 export { unique } from "./arrays/unique/index.js";
 export { unzip } from "./arrays/unzip/index.js";
 export { zip } from "./arrays/zip/index.js";

--- a/website/src/content/docs/arrays/times.mdx
+++ b/website/src/content/docs/arrays/times.mdx
@@ -1,0 +1,76 @@
+---
+title: times
+description: Invoke a function N times and collect the results
+---
+
+Invokes `fn` `count` times and returns an array of the results. The function receives the current index (0-based) on each call.
+
+## Import
+
+```ts
+import { times } from "1o1-utils";
+```
+
+```ts
+import { times } from "1o1-utils/times";
+```
+
+## Signature
+
+```ts
+function times<T>(params: { count: number; fn: (index: number) => T }): T[]
+```
+
+## Parameters
+
+| Name  | Type                       | Required | Description                                          |
+| ----- | -------------------------- | -------- | ---------------------------------------------------- |
+| count | `number`                   | Yes      | The number of times to invoke `fn` (non-negative integer) |
+| fn    | `(index: number) => T`     | Yes      | The function to invoke; receives the current index   |
+
+## Returns
+
+`T[]` — An array of length `count` containing the results of each invocation.
+
+## Examples
+
+```ts
+times({ count: 3, fn: (i) => i * 2 });
+// => [0, 2, 4]
+```
+
+```ts
+// Generate a list of objects
+times({ count: 3, fn: (i) => ({ id: i, name: `item-${i}` }) });
+// => [{ id: 0, name: "item-0" }, { id: 1, name: "item-1" }, { id: 2, name: "item-2" }]
+```
+
+```ts
+// Random values
+times({ count: 5, fn: () => Math.random() });
+// => [0.42, 0.91, 0.13, 0.77, 0.05]
+```
+
+```ts
+// Zero count returns an empty array
+times({ count: 0, fn: (i) => i });
+// => []
+```
+
+## Edge Cases
+
+- Throws if `count` is not a number or is `NaN`.
+- Throws if `count` is not an integer (including `Infinity`).
+- Throws if `count` is negative.
+- Throws if `fn` is not a function.
+- `count: 0` returns `[]` and does not invoke `fn`.
+
+## Also known as
+
+repeat, range, fill, generate
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use times to generate an array of N items by invoking a factory function.
+```


### PR DESCRIPTION
## Summary

- Add `times({ count, fn })` array utility — invokes `fn` `count` times with the current index and returns the collected results
- Strict validation: throws if `count` is not a non-negative integer or `fn` is not a function; `count: 0` returns `[]`
- Wires up exports, package subpath, size-limit entry, changeset, MDX docs, and llms.txt / llms-full.txt entries

Closes #95

## Test plan

- [x] `pnpm test` — 565 passing (12 new specs for `times`)
- [x] `pnpm build` — emits `dist/arrays/times/index.js`
- [x] `pnpm size` — 180 B (limit 1 kB); total bundle 4.8 kB (limit 5 kB)
- [x] `pnpm bench times` — ~equal to native for-loop; ~5–15% faster than lodash; ~10–13× faster than `Array.from({length}, fn)`