### PR TITLE
feat(validators): add isValidEmail utility

### DIFF
--- a/.changeset/add-is-valid-email.md
+++ b/.changeset/add-is-valid-email.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `isValidEmail` utility under the `validators` category. `isValidEmail({ email })` checks a string against the HTML5 living-standard email pattern (the same one browsers use for `<input type="email">`) with RFC 5321 length limits (local part ≤64, total ≤254). Pragmatic over RFC 5322 strict — accepts the addresses people actually use. Pass `allowDisplayName: true` to also accept display-name form like `"Jane Doe <jane@example.com>"`. Non-string inputs return `false`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -166,6 +166,11 @@
     "limit": "2 kB"
   },
   {
+    "name": "is-valid-email",
+    "path": "dist/validators/is-valid-email/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "is-valid-url",
     "path": "dist/validators/is-valid-url/index.js",
     "limit": "1 kB"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,9 @@
     "is-valid-url",
     "validate-url",
     "url-validator",
+    "is-valid-email",
+    "validate-email",
+    "email-validator",
     "safely",
     "tryit",
     "try-catch",
@@ -216,6 +219,10 @@
     "./deep-equal": {
       "import": "./dist/comparisons/deep-equal/index.js",
       "types": "./dist/comparisons/deep-equal/index.d.ts"
+    },
+    "./is-valid-email": {
+      "import": "./dist/validators/is-valid-email/index.js",
+      "types": "./dist/validators/is-valid-email/index.d.ts"
     },
     "./is-valid-url": {
       "import": "./dist/validators/is-valid-url/index.js",

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -183,6 +183,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Validates a string against the WHATWG `URL` parser. Compared against a native `try/catch` `new URL` implementation and a regex-based check.",
   },
+  isValidEmail: {
+    slug: "is-valid-email",
+    description:
+      "Validates a string against the HTML5 living-standard email pattern with RFC 5321 length limits. Compared against a simple regex and a native `indexOf`/`lastIndexOf` structural check.",
+  },
   zip: {
     slug: "zip",
     description:

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -186,7 +186,7 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
   isValidEmail: {
     slug: "is-valid-email",
     description:
-      "Validates a string against the HTML5 living-standard email pattern with RFC 5321 length limits. Compared against a simple regex and a native `indexOf`/`lastIndexOf` structural check.",
+      "Validates a string against the HTML5 living-standard email pattern with RFC 5321 length limits. Compared against a simple regex and a native `indexOf`/`lastIndexOf` structural check.\n\n> **Note:** `simple regex` and `native string check` are coarse baselines — they do not validate hostname-label structure (hyphen rules, label length), so they accept many addresses 1o1-utils correctly rejects. Their numbers are shown for reference only and are not apples-to-apples.",
   },
   zip: {
     slug: "zip",

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,4 +38,5 @@ export { escapeRegExp } from "./strings/escape-reg-exp/index.js";
 export { slugify } from "./strings/slugify/index.js";
 export { transformCase } from "./strings/transform-case/index.js";
 export { truncate } from "./strings/truncate/index.js";
+export { isValidEmail } from "./validators/is-valid-email/index.js";
 export { isValidUrl } from "./validators/is-valid-url/index.js";

--- a/src/validators/is-valid-email/index.bench.ts
+++ b/src/validators/is-valid-email/index.bench.ts
@@ -1,0 +1,58 @@
+import { Bench } from "tinybench";
+import { isValidEmail } from "./index.js";
+
+const SIMPLE_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+function regexIsValidEmail(input: unknown): boolean {
+  if (typeof input !== "string" || input.length === 0) return false;
+  return SIMPLE_REGEX.test(input);
+}
+
+function nativeIsValidEmail(input: unknown): boolean {
+  if (typeof input !== "string" || input.length === 0) return false;
+  const at = input.indexOf("@");
+  if (at <= 0 || at >= input.length - 1) return false;
+  const dot = input.lastIndexOf(".");
+  return dot > at + 1 && dot < input.length - 1;
+}
+
+const valid = "user+tag@mail.example.com";
+const invalid = "not-an-email";
+const longish = `${"a".repeat(40)}@${"b".repeat(40)}.example.com`;
+
+const bench = new Bench({ name: "isValidEmail", time: 1000 });
+
+bench
+  .add("1o1-utils (valid)", () => {
+    isValidEmail({ email: valid });
+  })
+  .add("simple regex (valid)", () => {
+    regexIsValidEmail(valid);
+  })
+  .add("native string check (valid)", () => {
+    nativeIsValidEmail(valid);
+  });
+
+bench
+  .add("1o1-utils (invalid)", () => {
+    isValidEmail({ email: invalid });
+  })
+  .add("simple regex (invalid)", () => {
+    regexIsValidEmail(invalid);
+  })
+  .add("native string check (invalid)", () => {
+    nativeIsValidEmail(invalid);
+  });
+
+bench
+  .add("1o1-utils (longish)", () => {
+    isValidEmail({ email: longish });
+  })
+  .add("simple regex (longish)", () => {
+    regexIsValidEmail(longish);
+  })
+  .add("native string check (longish)", () => {
+    nativeIsValidEmail(longish);
+  });
+
+export { bench };

--- a/src/validators/is-valid-email/index.spec.ts
+++ b/src/validators/is-valid-email/index.spec.ts
@@ -1,0 +1,202 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { isValidEmail } from "./index.js";
+
+describe("isValidEmail", () => {
+  describe("valid emails", () => {
+    it("should return true for a plain address", () => {
+      expect(isValidEmail({ email: "user@example.com" })).to.equal(true);
+    });
+
+    it("should return true for a plus-tag address", () => {
+      expect(isValidEmail({ email: "user+tag@gmail.com" })).to.equal(true);
+    });
+
+    it("should return true for a dotted local part", () => {
+      expect(isValidEmail({ email: "first.last@example.com" })).to.equal(true);
+    });
+
+    it("should return true for a subdomain host", () => {
+      expect(isValidEmail({ email: "user@mail.sub.example.io" })).to.equal(
+        true,
+      );
+    });
+
+    it("should return true for a hyphenated host label", () => {
+      expect(isValidEmail({ email: "user@my-host.example.com" })).to.equal(
+        true,
+      );
+    });
+
+    it("should return true for a numeric local part", () => {
+      expect(isValidEmail({ email: "12345@example.com" })).to.equal(true);
+    });
+
+    it("should return true for a single-char local part", () => {
+      expect(isValidEmail({ email: "a@example.com" })).to.equal(true);
+    });
+
+    it("should return true for special chars allowed in local part", () => {
+      expect(
+        isValidEmail({ email: "a!#$%&'*+/=?^_`{|}~-b@example.com" }),
+      ).to.equal(true);
+    });
+
+    it("should return true for a single-letter TLD", () => {
+      expect(isValidEmail({ email: "user@a.b" })).to.equal(true);
+    });
+  });
+
+  describe("invalid emails", () => {
+    it("should return false for missing @", () => {
+      expect(isValidEmail({ email: "no-at-sign.com" })).to.equal(false);
+    });
+
+    it("should return false for missing domain", () => {
+      expect(isValidEmail({ email: "user@" })).to.equal(false);
+    });
+
+    it("should return false for missing local part", () => {
+      expect(isValidEmail({ email: "@example.com" })).to.equal(false);
+    });
+
+    it("should return false for double @", () => {
+      expect(isValidEmail({ email: "a@b@example.com" })).to.equal(false);
+    });
+
+    it("should return false for a host starting with hyphen", () => {
+      expect(isValidEmail({ email: "user@-example.com" })).to.equal(false);
+    });
+
+    it("should return false for a host ending with hyphen", () => {
+      expect(isValidEmail({ email: "user@example-.com" })).to.equal(false);
+    });
+
+    it("should return false for a host with empty label", () => {
+      expect(isValidEmail({ email: "user@example..com" })).to.equal(false);
+    });
+
+    it("should return false for whitespace inside", () => {
+      expect(isValidEmail({ email: "user name@example.com" })).to.equal(false);
+    });
+
+    it("should return false for a leading space", () => {
+      expect(isValidEmail({ email: " user@example.com" })).to.equal(false);
+    });
+
+    it("should return false for a trailing space", () => {
+      expect(isValidEmail({ email: "user@example.com " })).to.equal(false);
+    });
+
+    it("should return false for a control character", () => {
+      expect(isValidEmail({ email: "user\n@example.com" })).to.equal(false);
+    });
+
+    it("should return false for empty string", () => {
+      expect(isValidEmail({ email: "" })).to.equal(false);
+    });
+
+    it("should return false when local part exceeds 64 chars", () => {
+      const local = "a".repeat(65);
+      expect(isValidEmail({ email: `${local}@example.com` })).to.equal(false);
+    });
+
+    it("should return false when total exceeds 254 chars", () => {
+      const local = "a".repeat(64);
+      const host = `${"b".repeat(60)}.${"c".repeat(60)}.${"d".repeat(60)}.example.com`;
+      const long = `${local}@${host}`;
+      expect(long.length).to.be.greaterThan(254);
+      expect(isValidEmail({ email: long })).to.equal(false);
+    });
+  });
+
+  describe("non-string inputs", () => {
+    it("should return false for null", () => {
+      expect(isValidEmail({ email: null })).to.equal(false);
+    });
+
+    it("should return false for undefined", () => {
+      expect(isValidEmail({ email: undefined })).to.equal(false);
+    });
+
+    it("should return false for a number", () => {
+      expect(isValidEmail({ email: 42 })).to.equal(false);
+    });
+
+    it("should return false for a boolean", () => {
+      expect(isValidEmail({ email: true })).to.equal(false);
+    });
+
+    it("should return false for an object", () => {
+      expect(isValidEmail({ email: { address: "user@example.com" } })).to.equal(
+        false,
+      );
+    });
+
+    it("should return false for an array", () => {
+      expect(isValidEmail({ email: ["user@example.com"] })).to.equal(false);
+    });
+  });
+
+  describe("allowDisplayName", () => {
+    it("should reject display-name form by default", () => {
+      expect(isValidEmail({ email: "Jane Doe <jane@example.com>" })).to.equal(
+        false,
+      );
+    });
+
+    it("should accept display-name form when allowed", () => {
+      expect(
+        isValidEmail({
+          email: "Jane Doe <jane@example.com>",
+          allowDisplayName: true,
+        }),
+      ).to.equal(true);
+    });
+
+    it("should accept quoted display name when allowed", () => {
+      expect(
+        isValidEmail({
+          email: '"Doe, Jane" <jane@example.com>',
+          allowDisplayName: true,
+        }),
+      ).to.equal(true);
+    });
+
+    it("should reject empty bracket when allowed", () => {
+      expect(
+        isValidEmail({
+          email: "Jane <>",
+          allowDisplayName: true,
+        }),
+      ).to.equal(false);
+    });
+
+    it("should reject malformed display name (missing close bracket)", () => {
+      expect(
+        isValidEmail({
+          email: "Jane <jane@example.com",
+          allowDisplayName: true,
+        }),
+      ).to.equal(false);
+    });
+
+    it("should reject invalid bracketed address when allowed", () => {
+      expect(
+        isValidEmail({
+          email: "Jane <not-an-email>",
+          allowDisplayName: true,
+        }),
+      ).to.equal(false);
+    });
+
+    it("should still accept plain address when allowed", () => {
+      expect(
+        isValidEmail({
+          email: "user@example.com",
+          allowDisplayName: true,
+        }),
+      ).to.equal(true);
+    });
+  });
+});

--- a/src/validators/is-valid-email/index.spec.ts
+++ b/src/validators/is-valid-email/index.spec.ts
@@ -108,6 +108,44 @@ describe("isValidEmail", () => {
       expect(long.length).to.be.greaterThan(254);
       expect(isValidEmail({ email: long })).to.equal(false);
     });
+
+    it("should return false when input exceeds 320 chars", () => {
+      const huge = "a".repeat(321);
+      expect(isValidEmail({ email: huge })).to.equal(false);
+    });
+
+    it("should reject pathological input quickly via input cap", () => {
+      const huge = `${"a".repeat(500)}@example.com`;
+      expect(isValidEmail({ email: huge })).to.equal(false);
+    });
+  });
+
+  describe("internationalized domains (IDN)", () => {
+    it("should return false for a Unicode host (no IDN support)", () => {
+      expect(isValidEmail({ email: "user@münchen.de" })).to.equal(false);
+    });
+
+    it("should return false for a Unicode local part", () => {
+      expect(isValidEmail({ email: "üser@example.com" })).to.equal(false);
+    });
+
+    it("should return true for a Punycode-encoded host", () => {
+      expect(isValidEmail({ email: "user@xn--mnchen-3ya.de" })).to.equal(true);
+    });
+  });
+
+  describe("HTML5 vs RFC 5322 dot rules", () => {
+    it("should accept consecutive dots in local part (HTML5 spec)", () => {
+      expect(isValidEmail({ email: "a..b@example.com" })).to.equal(true);
+    });
+
+    it("should accept leading dot in local part (HTML5 spec)", () => {
+      expect(isValidEmail({ email: ".user@example.com" })).to.equal(true);
+    });
+
+    it("should accept trailing dot in local part (HTML5 spec)", () => {
+      expect(isValidEmail({ email: "user.@example.com" })).to.equal(true);
+    });
   });
 
   describe("non-string inputs", () => {

--- a/src/validators/is-valid-email/index.ts
+++ b/src/validators/is-valid-email/index.ts
@@ -7,6 +7,7 @@ const DISPLAY_NAME_REGEX = /^\s*(?:"([^"]*)"|([^<"]+?))\s*<([^>]+)>\s*$/;
 
 const MAX_TOTAL_LENGTH = 254;
 const MAX_LOCAL_LENGTH = 64;
+const MAX_INPUT_LENGTH = 320;
 
 /**
  * Checks whether a string is a well-formed email address.
@@ -49,13 +50,25 @@ const MAX_LOCAL_LENGTH = 64;
  * objects) always return `false`. Empty strings return `false` without
  * invoking the regex. The validator is deliberately structural and does
  * not perform DNS, MX, or SMTP checks.
+ *
+ * Inputs longer than 320 characters (RFC 5321 maximum address size) are
+ * rejected immediately to avoid unbounded regex work on pathological
+ * input.
+ *
+ * The host part is ASCII-only — internationalized domain names (IDN)
+ * such as `user@münchen.de` return `false`. Convert IDN hosts to their
+ * Punycode form (`user@xn--mnchen-3ya.de`) before validating if needed.
+ *
+ * Consecutive dots in the local part (e.g., `a..b@example.com`) are
+ * accepted, matching the HTML5 living standard. RFC 5322 strict
+ * disallows them; this validator favors HTML5 compatibility.
  */
 function isValidEmail({
   email,
   allowDisplayName = false,
 }: IsValidEmailParams): IsValidEmailResult {
   if (typeof email !== "string") return false;
-  if (email.length === 0) return false;
+  if (email.length === 0 || email.length > MAX_INPUT_LENGTH) return false;
 
   let addr = email;
   if (allowDisplayName) {

--- a/src/validators/is-valid-email/index.ts
+++ b/src/validators/is-valid-email/index.ts
@@ -1,0 +1,74 @@
+import type { IsValidEmailParams, IsValidEmailResult } from "./types.js";
+
+const EMAIL_REGEX =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
+
+const DISPLAY_NAME_REGEX = /^\s*(?:"([^"]*)"|([^<"]+?))\s*<([^>]+)>\s*$/;
+
+const MAX_TOTAL_LENGTH = 254;
+const MAX_LOCAL_LENGTH = 64;
+
+/**
+ * Checks whether a string is a well-formed email address.
+ *
+ * Uses the HTML5 living-standard email pattern (the same regex browsers
+ * use for `<input type="email">`) plus RFC 5321 length limits (local
+ * part ≤64, total ≤254). Pragmatic over RFC 5322 strict — accepts the
+ * addresses people actually use.
+ *
+ * @param params - The parameters object
+ * @param params.email - The value to validate
+ * @param params.allowDisplayName - When `true`, accepts addresses
+ *   wrapped in display-name form like `"Name <user@example.com>"` or
+ *   `'"Quoted Name" <user@example.com>'`. The bracketed address is
+ *   extracted and validated. Default `false`.
+ * @returns `true` if the value is a parseable email, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * isValidEmail({ email: "user@example.com" });        // => true
+ * isValidEmail({ email: "user+tag@gmail.com" });      // => true
+ * isValidEmail({ email: "first.last@sub.example.io" }); // => true
+ *
+ * isValidEmail({ email: "invalid@" });                // => false
+ * isValidEmail({ email: "no-at-sign.com" });          // => false
+ * isValidEmail({ email: "" });                        // => false
+ * isValidEmail({ email: null });                      // => false
+ *
+ * // Display-name form (opt-in)
+ * isValidEmail({
+ *   email: "Jane Doe <jane@example.com>",
+ *   allowDisplayName: true,
+ * }); // => true
+ * ```
+ *
+ * @keywords email, validate email, is email, valid email, email check, email validator
+ *
+ * @remarks
+ * Non-string inputs (including `null`, `undefined`, numbers, and
+ * objects) always return `false`. Empty strings return `false` without
+ * invoking the regex. The validator is deliberately structural and does
+ * not perform DNS, MX, or SMTP checks.
+ */
+function isValidEmail({
+  email,
+  allowDisplayName = false,
+}: IsValidEmailParams): IsValidEmailResult {
+  if (typeof email !== "string") return false;
+  if (email.length === 0) return false;
+
+  let addr = email;
+  if (allowDisplayName) {
+    const match = DISPLAY_NAME_REGEX.exec(email);
+    if (match !== null) addr = match[3] ?? "";
+  }
+
+  if (addr.length === 0 || addr.length > MAX_TOTAL_LENGTH) return false;
+
+  const atIndex = addr.indexOf("@");
+  if (atIndex < 0 || atIndex > MAX_LOCAL_LENGTH) return false;
+
+  return EMAIL_REGEX.test(addr);
+}
+
+export { isValidEmail };

--- a/src/validators/is-valid-email/types.ts
+++ b/src/validators/is-valid-email/types.ts
@@ -1,0 +1,10 @@
+interface IsValidEmailParams {
+  email: unknown;
+  allowDisplayName?: boolean;
+}
+
+type IsValidEmailResult = boolean;
+
+type IsValidEmailFn = (params: IsValidEmailParams) => IsValidEmailResult;
+
+export type { IsValidEmailFn, IsValidEmailParams, IsValidEmailResult };

--- a/website/src/content/docs/validators/is-valid-email.mdx
+++ b/website/src/content/docs/validators/is-valid-email.mdx
@@ -1,0 +1,92 @@
+---
+title: isValidEmail
+description: Check if a string is a well-formed email address using the HTML5 living-standard pattern
+---
+
+Validates whether a string is a well-formed email address. Uses the HTML5 living-standard email pattern (the same one browsers use for `<input type="email">`) plus RFC 5321 length limits (local part ≤64, total ≤254). Pragmatic over RFC 5322 strict — accepts the addresses people actually use.
+
+## Import
+
+```ts
+import { isValidEmail } from "1o1-utils";
+```
+
+```ts
+import { isValidEmail } from "1o1-utils/is-valid-email";
+```
+
+## Signature
+
+```ts
+function isValidEmail({ email, allowDisplayName }: IsValidEmailParams): boolean
+```
+
+## Parameters
+
+| Name               | Type      | Required | Description                                                                                                                            |
+| ------------------ | --------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `email`            | `unknown` | Yes      | The value to validate                                                                                                                  |
+| `allowDisplayName` | `boolean` | No       | When `true`, also accepts display-name form like `"Jane Doe <jane@example.com>"` or `'"Doe, Jane" <jane@example.com>'`. Default `false` |
+
+## Returns
+
+`boolean` — `true` if the value is a parseable email, `false` otherwise.
+
+## Examples
+
+```ts
+isValidEmail({ email: "user@example.com" });           // => true
+isValidEmail({ email: "user+tag@gmail.com" });         // => true
+isValidEmail({ email: "first.last@sub.example.io" }); // => true
+
+isValidEmail({ email: "invalid@" });                   // => false
+isValidEmail({ email: "no-at-sign.com" });             // => false
+isValidEmail({ email: "" });                           // => false
+isValidEmail({ email: null });                         // => false
+```
+
+```ts
+// Display-name form (opt-in)
+isValidEmail({
+  email: "Jane Doe <jane@example.com>",
+  allowDisplayName: true,
+}); // => true
+
+isValidEmail({
+  email: '"Doe, Jane" <jane@example.com>',
+  allowDisplayName: true,
+}); // => true
+
+isValidEmail({
+  email: "Jane Doe <jane@example.com>",
+}); // => false (not allowed by default)
+```
+
+```ts
+// Validate user input before sending
+function subscribe(input: string) {
+  if (!isValidEmail({ email: input })) {
+    throw new Error("Invalid email");
+  }
+  return api.subscribe(input);
+}
+```
+
+## Edge Cases
+
+- Non-string inputs (`null`, `undefined`, numbers, objects, arrays) return `false`.
+- Empty strings return `false` without invoking the regex.
+- Length-bounded: local part > 64 chars or total > 254 chars returns `false`.
+- Hostname labels cannot start or end with a hyphen, and empty labels (`example..com`) are rejected.
+- Whitespace and control characters anywhere in the address return `false` unless `allowDisplayName` is set and the wrapper itself contains whitespace.
+- The validator is structural — it does not perform DNS, MX, or SMTP checks.
+
+## Also known as
+
+email, validate email, is email, valid email, email check, email validator
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use isValidEmail to validate a user-supplied email before submitting a form.
+```

--- a/website/src/content/docs/validators/is-valid-email.mdx
+++ b/website/src/content/docs/validators/is-valid-email.mdx
@@ -76,9 +76,11 @@ function subscribe(input: string) {
 
 - Non-string inputs (`null`, `undefined`, numbers, objects, arrays) return `false`.
 - Empty strings return `false` without invoking the regex.
-- Length-bounded: local part > 64 chars or total > 254 chars returns `false`.
+- Length-bounded: local part > 64 chars, total > 254 chars, or raw input > 320 chars returns `false` (the 320-char input cap blocks pathological payloads before any regex work).
 - Hostname labels cannot start or end with a hyphen, and empty labels (`example..com`) are rejected.
 - Whitespace and control characters anywhere in the address return `false` unless `allowDisplayName` is set and the wrapper itself contains whitespace.
+- ASCII-only host part — internationalized domain names (IDN) such as `user@münchen.de` return `false`. Convert IDN hosts to Punycode (e.g., `user@xn--mnchen-3ya.de`) before validating.
+- Consecutive, leading, or trailing dots in the local part (e.g., `a..b@example.com`, `.user@example.com`) are accepted — matches the HTML5 living standard. RFC 5322 strict disallows them; this validator favors HTML5 compatibility.
 - The validator is structural — it does not perform DNS, MX, or SMTP checks.
 
 ## Also known as


### PR DESCRIPTION
## Summary
- Add `isValidEmail` validator under `src/validators/is-valid-email/`
- HTML5 living-standard regex + RFC 5321 length limits (local ≤64, total ≤254)
- Optional `allowDisplayName` flag for `"Name <user@host>"` form
- 255 B gzipped (limit 1 kB)

## Test plan
- [x] 36 spec cases pass (`pnpm test -- --grep isValidEmail`)
- [x] Biome check clean
- [x] `tsc` build clean
- [x] `pnpm size` under limit
- [x] Imports resolve from both `1o1-utils` and `1o1-utils/is-valid-email`

Closes #63