### PR TITLE
feat(arrays): add partition utility

### DIFF
--- a/.changeset/add-array-partition.md
+++ b/.changeset/add-array-partition.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `partition` utility for splitting an array into two groups by predicate, with type-guard narrowing support.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -204,5 +204,10 @@
     "name": "random-int",
     "path": "dist/numbers/random-int/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "partition",
+    "path": "dist/arrays/partition/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -125,6 +125,33 @@ Groups are keyed by String(value[key]).
 
 ---
 
+### partition
+
+Split an array into two groups based on a predicate. The first group contains items for which the predicate returns truthy; the second contains the rest. Order is preserved within each group. Supports a type-guard predicate to narrow the result types.
+
+Import: import { partition } from "1o1-utils/partition";
+
+Signature:
+function partition<T, U extends T>({ array, predicate }: { array: T[]; predicate: (item: T, index: number) => item is U }): [U[], Exclude<T, U>[]];
+function partition<T>({ array, predicate }: { array: T[]; predicate: (item: T, index: number) => boolean }): [T[], T[]];
+
+Parameters:
+- array (T[], required): The array to partition
+- predicate ((item: T, index: number) => boolean, required): Predicate called for every element
+
+Returns: A tuple `[matches, rest]`.
+
+Example:
+partition({ array: [1, 2, 3, 4, 5], predicate: (n) => n % 2 === 0 });
+// => [[2, 4], [1, 3, 5]]
+
+const users = [{ active: true }, { active: false }];
+const [active, inactive] = partition({ array: users, predicate: (u) => u.active });
+
+Throws: Error if array is not an array. Error if predicate is not a function.
+
+---
+
 ### sortBy
 
 Return a new array sorted by a specified property. Supports ascending/descending and dot notation for nested properties.

--- a/llms.txt
+++ b/llms.txt
@@ -16,6 +16,7 @@
 - [chunk](https://pedrotroccoli.github.io/1o1-utils/arrays/chunk/): Split an array into groups of a given size
 - [diff](https://pedrotroccoli.github.io/1o1-utils/arrays/diff/): Return elements in the first array not present in the second, with optional iteratee for object identity
 - [groupBy](https://pedrotroccoli.github.io/1o1-utils/arrays/group-by/): Group array elements by a property value
+- [partition](https://pedrotroccoli.github.io/1o1-utils/arrays/partition/): Split an array into two groups based on a predicate
 - [range](https://pedrotroccoli.github.io/1o1-utils/arrays/range/): Generate an array of numbers in a given range with optional start and step
 - [sortBy](https://pedrotroccoli.github.io/1o1-utils/arrays/sort-by/): Sort an array of objects by a property with dot notation support
 - [times](https://pedrotroccoli.github.io/1o1-utils/arrays/times/): Invoke a function N times with the current index and collect the results

--- a/package.json
+++ b/package.json
@@ -62,7 +62,10 @@
 		"map-values",
 		"escape-regexp",
 		"escape-regex",
-		"regex-escape"
+		"regex-escape",
+		"partition",
+		"split",
+		"bifurcate"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -244,6 +247,10 @@
 		"./random-int": {
 			"import": "./dist/numbers/random-int/index.js",
 			"types": "./dist/numbers/random-int/index.d.ts"
+		},
+		"./partition": {
+			"import": "./dist/arrays/partition/index.js",
+			"types": "./dist/arrays/partition/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/arrays/partition/index.bench.ts
+++ b/src/arrays/partition/index.bench.ts
@@ -1,0 +1,34 @@
+import lodashPartition from "lodash/partition.js";
+import { Bench } from "tinybench";
+import { getDatasets } from "../../benchmarks/helpers.js";
+import { partition } from "./index.js";
+
+const bench = new Bench({ name: "partition (by role)", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  const isAdmin = (u: { role: string }) => u.role === "admin";
+
+  bench
+    .add(`1o1-utils (${name})`, () => {
+      partition({ array: data, predicate: isAdmin });
+    })
+    .add(`lodash partition (${name})`, () => {
+      lodashPartition(data, isAdmin);
+    })
+    .add(`native two-filter (${name})`, () => {
+      const matches = data.filter(isAdmin);
+      const rest = data.filter((u) => !isAdmin(u));
+      return [matches, rest];
+    })
+    .add(`native single-pass (${name})`, () => {
+      const matches: typeof data = [];
+      const rest: typeof data = [];
+      for (let i = 0; i < data.length; i++) {
+        if (isAdmin(data[i])) matches.push(data[i]);
+        else rest.push(data[i]);
+      }
+    });
+}
+
+export { bench };

--- a/src/arrays/partition/index.bench.ts
+++ b/src/arrays/partition/index.bench.ts
@@ -16,9 +16,20 @@ for (const { name, data: getData } of getDatasets()) {
     .add(`lodash partition (${name})`, () => {
       lodashPartition(data, isAdmin);
     })
+    // Naive two-filter calls the predicate twice per item — included as the
+    // realistic baseline a typical user would write, not a fair single-call
+    // comparison.
     .add(`native two-filter (${name})`, () => {
       const matches = data.filter(isAdmin);
       const rest = data.filter((u) => !isAdmin(u));
+      return [matches, rest];
+    })
+    // Cached two-filter calls the predicate once per item, then partitions
+    // by membership — fair single-call comparison.
+    .add(`native two-filter cached (${name})`, () => {
+      const flags = data.map(isAdmin);
+      const matches = data.filter((_, i) => flags[i]);
+      const rest = data.filter((_, i) => !flags[i]);
       return [matches, rest];
     })
     .add(`native single-pass (${name})`, () => {

--- a/src/arrays/partition/index.spec.ts
+++ b/src/arrays/partition/index.spec.ts
@@ -1,0 +1,161 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { partition } from "./index.js";
+
+describe("partition", () => {
+  it("should split numbers into evens and odds", () => {
+    expect(
+      partition({ array: [1, 2, 3, 4, 5], predicate: (n) => n % 2 === 0 }),
+    ).to.deep.equal([
+      [2, 4],
+      [1, 3, 5],
+    ]);
+  });
+
+  it("should split objects by predicate", () => {
+    const users = [
+      { name: "Alice", isActive: true },
+      { name: "Bob", isActive: false },
+      { name: "Carol", isActive: true },
+    ];
+    const [active, inactive] = partition({
+      array: users,
+      predicate: (u) => u.isActive,
+    });
+    expect(active).to.deep.equal([
+      { name: "Alice", isActive: true },
+      { name: "Carol", isActive: true },
+    ]);
+    expect(inactive).to.deep.equal([{ name: "Bob", isActive: false }]);
+  });
+
+  it("should return all items in the first group when predicate is always true", () => {
+    expect(
+      partition({ array: [1, 2, 3], predicate: () => true }),
+    ).to.deep.equal([[1, 2, 3], []]);
+  });
+
+  it("should return all items in the second group when predicate is always false", () => {
+    expect(
+      partition({ array: [1, 2, 3], predicate: () => false }),
+    ).to.deep.equal([[], [1, 2, 3]]);
+  });
+
+  it("should return two empty arrays for an empty input", () => {
+    expect(partition({ array: [], predicate: () => true })).to.deep.equal([
+      [],
+      [],
+    ]);
+  });
+
+  it("should preserve insertion order within each group", () => {
+    expect(
+      partition({
+        array: [3, 1, 4, 1, 5, 9, 2, 6],
+        predicate: (n) => n > 3,
+      }),
+    ).to.deep.equal([
+      [4, 5, 9, 6],
+      [3, 1, 1, 2],
+    ]);
+  });
+
+  it("should pass index as the second argument to the predicate", () => {
+    const seen: Array<[unknown, number]> = [];
+    partition({
+      array: ["a", "b", "c"],
+      predicate: (item, index) => {
+        seen.push([item, index]);
+        return index % 2 === 0;
+      },
+    });
+    expect(seen).to.deep.equal([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+    ]);
+  });
+
+  it("should partition by index using the second predicate argument", () => {
+    expect(
+      partition({
+        array: ["a", "b", "c", "d"],
+        predicate: (_, i) => i % 2 === 0,
+      }),
+    ).to.deep.equal([
+      ["a", "c"],
+      ["b", "d"],
+    ]);
+  });
+
+  it("should not mutate the input array", () => {
+    const input = [1, 2, 3, 4];
+    const snapshot = [...input];
+    partition({ array: input, predicate: (n) => n > 2 });
+    expect(input).to.deep.equal(snapshot);
+  });
+
+  it("should treat truthy non-boolean predicate returns as matches", () => {
+    expect(
+      partition({
+        array: [0, 1, 2, 0, 3],
+        predicate: (n) => n as unknown as boolean,
+      }),
+    ).to.deep.equal([
+      [1, 2, 3],
+      [0, 0],
+    ]);
+  });
+
+  it("should narrow types via a type-guard predicate", () => {
+    type A = { kind: "a"; a: number };
+    type B = { kind: "b"; b: string };
+    const items: Array<A | B> = [
+      { kind: "a", a: 1 },
+      { kind: "b", b: "x" },
+      { kind: "a", a: 2 },
+    ];
+    const [as, bs] = partition({
+      array: items,
+      predicate: (x): x is A => x.kind === "a",
+    });
+    expect(as).to.deep.equal([
+      { kind: "a", a: 1 },
+      { kind: "a", a: 2 },
+    ]);
+    expect(bs).to.deep.equal([{ kind: "b", b: "x" }]);
+    // Type-level: confirm narrowing compiles.
+    const firstA: A | undefined = as[0];
+    const firstB: B | undefined = bs[0];
+    expect(firstA?.kind).to.equal("a");
+    expect(firstB?.kind).to.equal("b");
+  });
+
+  it("should throw an error if array is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      partition({ array: "abc", predicate: () => true }),
+    ).to.throw("The 'array' parameter is not an array");
+  });
+
+  it("should throw an error if array is null", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      partition({ array: null, predicate: () => true }),
+    ).to.throw("The 'array' parameter is not an array");
+  });
+
+  it("should throw an error if predicate is not a function", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      partition({ array: [1, 2, 3], predicate: "nope" }),
+    ).to.throw("The 'predicate' parameter must be a function");
+  });
+
+  it("should throw an error if predicate is undefined", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      partition({ array: [1, 2, 3] }),
+    ).to.throw("The 'predicate' parameter must be a function");
+  });
+});

--- a/src/arrays/partition/index.spec.ts
+++ b/src/arrays/partition/index.spec.ts
@@ -95,15 +95,16 @@ describe("partition", () => {
     expect(input).to.deep.equal(snapshot);
   });
 
-  it("should treat truthy non-boolean predicate returns as matches", () => {
+  it("should treat truthy non-boolean predicate returns as matches and falsy as rest", () => {
+    const items: unknown[] = [0, 1, "", "x", null, undefined, Number.NaN, {}];
     expect(
       partition({
-        array: [0, 1, 2, 0, 3],
-        predicate: (n) => n as unknown as boolean,
+        array: items,
+        predicate: (v) => v as boolean,
       }),
     ).to.deep.equal([
-      [1, 2, 3],
-      [0, 0],
+      [1, "x", {}],
+      [0, "", null, undefined, Number.NaN],
     ]);
   });
 
@@ -115,18 +116,18 @@ describe("partition", () => {
       { kind: "b", b: "x" },
       { kind: "a", a: 2 },
     ];
-    const [as, bs] = partition({
+    const [aItems, bItems] = partition({
       array: items,
       predicate: (x): x is A => x.kind === "a",
     });
-    expect(as).to.deep.equal([
+    expect(aItems).to.deep.equal([
       { kind: "a", a: 1 },
       { kind: "a", a: 2 },
     ]);
-    expect(bs).to.deep.equal([{ kind: "b", b: "x" }]);
+    expect(bItems).to.deep.equal([{ kind: "b", b: "x" }]);
     // Type-level: confirm narrowing compiles.
-    const firstA: A | undefined = as[0];
-    const firstB: B | undefined = bs[0];
+    const firstA: A | undefined = aItems[0];
+    const firstB: B | undefined = bItems[0];
     expect(firstA?.kind).to.equal("a");
     expect(firstB?.kind).to.equal("b");
   });

--- a/src/arrays/partition/index.ts
+++ b/src/arrays/partition/index.ts
@@ -1,0 +1,65 @@
+import type {
+  PartitionParams,
+  PartitionResult,
+  PartitionTypeGuardParams,
+  PartitionTypeGuardResult,
+} from "./types.js";
+
+/**
+ * Splits an array into two groups based on a predicate. The first group
+ * contains items for which the predicate returns truthy; the second contains
+ * the rest. Order is preserved within each group.
+ *
+ * Supports a type-guard predicate (`(item) => item is U`) to narrow the
+ * resulting tuple to `[U[], Exclude<T, U>[]]`.
+ *
+ * @param params - The parameters object
+ * @param params.array - The array to partition
+ * @param params.predicate - Function called with `(item, index)` returning a boolean
+ * @returns A tuple `[matches, rest]`
+ *
+ * @example
+ * ```ts
+ * partition({ array: [1, 2, 3, 4, 5], predicate: (n) => n % 2 === 0 });
+ * // => [[2, 4], [1, 3, 5]]
+ *
+ * const users = [{ active: true }, { active: false }];
+ * const [active, inactive] = partition({ array: users, predicate: (u) => u.active });
+ * ```
+ *
+ * @keywords partition, split, divide, bifurcate, group, filter
+ *
+ * @throws Error if `array` is not an array
+ * @throws Error if `predicate` is not a function
+ */
+function partition<T, U extends T>(
+  params: PartitionTypeGuardParams<T, U>,
+): PartitionTypeGuardResult<T, U>;
+function partition<T>(params: PartitionParams<T>): PartitionResult<T>;
+function partition<T>({
+  array,
+  predicate,
+}: PartitionParams<T>): PartitionResult<T> {
+  if (!Array.isArray(array)) {
+    throw new Error("The 'array' parameter is not an array");
+  }
+
+  if (typeof predicate !== "function") {
+    throw new Error("The 'predicate' parameter must be a function");
+  }
+
+  const matches: T[] = [];
+  const rest: T[] = [];
+
+  for (let i = 0; i < array.length; i++) {
+    if (predicate(array[i], i)) {
+      matches.push(array[i]);
+    } else {
+      rest.push(array[i]);
+    }
+  }
+
+  return [matches, rest];
+}
+
+export { partition };

--- a/src/arrays/partition/index.ts
+++ b/src/arrays/partition/index.ts
@@ -13,6 +13,10 @@ import type {
  * Supports a type-guard predicate (`(item) => item is U`) to narrow the
  * resulting tuple to `[U[], Exclude<T, U>[]]`.
  *
+ * Iterates every index, including holes in sparse arrays (the predicate is
+ * invoked with `undefined`). This differs from `Array.prototype.filter`,
+ * which skips holes.
+ *
  * @param params - The parameters object
  * @param params.array - The array to partition
  * @param params.predicate - Function called with `(item, index)` returning a boolean

--- a/src/arrays/partition/types.ts
+++ b/src/arrays/partition/types.ts
@@ -1,0 +1,28 @@
+interface PartitionParams<T> {
+  array: T[];
+  predicate: (item: T, index: number) => boolean;
+}
+
+interface PartitionTypeGuardParams<T, U extends T> {
+  array: T[];
+  predicate: (item: T, index: number) => item is U;
+}
+
+type PartitionResult<T> = [T[], T[]];
+
+type PartitionTypeGuardResult<T, U extends T> = [U[], Exclude<T, U>[]];
+
+interface Partition {
+  <T, U extends T>(
+    params: PartitionTypeGuardParams<T, U>,
+  ): PartitionTypeGuardResult<T, U>;
+  <T>(params: PartitionParams<T>): PartitionResult<T>;
+}
+
+export type {
+  Partition,
+  PartitionParams,
+  PartitionResult,
+  PartitionTypeGuardParams,
+  PartitionTypeGuardResult,
+};

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -203,6 +203,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Transforms an object's values via an iteratee function. Compared against `lodash.mapValues` and a native `Object.fromEntries(Object.entries().map())` approach.",
   },
+  "partition (by role)": {
+    slug: "partition",
+    description:
+      "Splits an array into two groups based on a predicate. Compared against `lodash.partition`, a native two-`filter` approach, and a native single-pass loop.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { arrayToHash } from "./arrays/array-to-hash/index.js";
 export { chunk } from "./arrays/chunk/index.js";
 export { diff } from "./arrays/diff/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
+export { partition } from "./arrays/partition/index.js";
 export { range } from "./arrays/range/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
 export { times } from "./arrays/times/index.js";

--- a/website/src/content/docs/arrays/partition.mdx
+++ b/website/src/content/docs/arrays/partition.mdx
@@ -1,0 +1,94 @@
+---
+title: partition
+description: Split an array into two groups based on a predicate
+---
+
+Splits an array into two groups based on a predicate. The first group contains items for which the predicate returns truthy; the second contains the rest. Order is preserved within each group. Supports a type-guard predicate (`(item) => item is U`) to narrow the resulting tuple to `[U[], Exclude<T, U>[]]`.
+
+## Import
+
+```ts
+import { partition } from "1o1-utils";
+```
+
+```ts
+import { partition } from "1o1-utils/partition";
+```
+
+## Signature
+
+```ts
+function partition<T, U extends T>(
+  params: { array: T[]; predicate: (item: T, index: number) => item is U }
+): [U[], Exclude<T, U>[]];
+
+function partition<T>(
+  params: { array: T[]; predicate: (item: T, index: number) => boolean }
+): [T[], T[]];
+```
+
+## Parameters
+
+| Name      | Type                                       | Required | Description                                              |
+| --------- | ------------------------------------------ | -------- | -------------------------------------------------------- |
+| array     | `T[]`                                      | Yes      | The array to partition                                   |
+| predicate | `(item: T, index: number) => boolean`      | Yes      | Predicate called with `(item, index)` for every element |
+
+## Returns
+
+`[T[], T[]]` — A tuple where the first array contains items matching the predicate and the second contains the rest. With a type-guard predicate, the tuple narrows to `[U[], Exclude<T, U>[]]`.
+
+## Examples
+
+```ts
+partition({ array: [1, 2, 3, 4, 5], predicate: (n) => n % 2 === 0 });
+// => [[2, 4], [1, 3, 5]]
+
+const users = [
+  { name: "Alice", isActive: true },
+  { name: "Bob", isActive: false },
+  { name: "Carol", isActive: true },
+];
+const [active, inactive] = partition({
+  array: users,
+  predicate: (u) => u.isActive,
+});
+```
+
+Type-guard narrowing:
+
+```ts
+type Admin = { kind: "admin"; level: number };
+type User = { kind: "user"; name: string };
+
+const people: Array<Admin | User> = [
+  { kind: "admin", level: 1 },
+  { kind: "user", name: "Bob" },
+];
+
+const [admins, users] = partition({
+  array: people,
+  predicate: (p): p is Admin => p.kind === "admin",
+});
+// admins: Admin[]
+// users: User[]
+```
+
+## Edge Cases
+
+- Returns `[[], []]` for an empty input array.
+- Order is preserved within each group.
+- Does not mutate the input array.
+- The predicate receives `(item, index)`, mirroring `Array.prototype.filter`.
+- Throws if `array` is not an array.
+- Throws if `predicate` is not a function.
+
+## Also known as
+
+partition, split, divide, bifurcate, group, filter
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use partition to split an array into two groups based on a predicate.
+```

--- a/website/src/content/docs/arrays/partition.mdx
+++ b/website/src/content/docs/arrays/partition.mdx
@@ -79,7 +79,8 @@ const [admins, users] = partition({
 - Returns `[[], []]` for an empty input array.
 - Order is preserved within each group.
 - Does not mutate the input array.
-- The predicate receives `(item, index)`, mirroring `Array.prototype.filter`.
+- The predicate receives `(item, index)`, matching the signature of `Array.prototype.filter`.
+- Iterates every index, including holes in sparse arrays — the predicate is invoked with `undefined` for empty slots. This differs from `Array.prototype.filter`, which skips holes.
 - Throws if `array` is not an array.
 - Throws if `predicate` is not a function.
 


### PR DESCRIPTION
## Summary

Closes #92.

- Add `partition({ array, predicate })` to `arrays/` — splits an array into `[matches, rest]` in a single pass, preserves order, no input mutation.
- Type-guard overload narrows the result to `[U[], Exclude<T, U>[]]` when the predicate is a type guard.
- Predicate receives `(item, index)`, mirroring `Array.prototype.filter`.
- Throws on non-array `array` or non-function `predicate`.

## Benchmarks (median ops/s)

| Size | 1o1-utils | lodash.partition | native two-filter | native single-pass |
|------|-----------|------------------|-------------------|---------------------|
| n=100 | 3.0M | 1.0M | 1.0M | 3.4M |
| n=10k | 27K | 9.3K | 9.8K | 28K |
| n=100k | 1040 | 568 | 564 | 982 |
| n=1M | 108 | 59 | 61 | 112 |

~2× faster than `lodash.partition` and native two-filter; on par with native single-pass.

Bundle size: 180 B brotlied (limit 1 kB).

## Test plan

- [x] `pnpm test` — 15 new partition tests pass (659 total)
- [x] `pnpm test:coverage` — partition 100% lines/funcs, 88% branches
- [x] `pnpm build`
- [x] `pnpm size` — partition 180 B
- [x] `pnpm bench partition`
- [x] `pnpm check:fix` — no new warnings