### PR TITLE
feat(strings): add normalizeEmail utility

### DIFF
--- a/.changeset/add-normalize-email.md
+++ b/.changeset/add-normalize-email.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `normalizeEmail` utility under the `strings` category. `normalizeEmail({ email })` trims whitespace and lowercases the address. Pass `stripPlus: true` to also drop plus-addressing (`user+tag@example.com` → `user@example.com`), useful for deduplicating emails since most providers route plus-tagged addresses to the same mailbox. Throws on non-string or empty input. Pair with `isValidEmail` for format validation.

--- a/docs/benchmarks/normalize-email.md
+++ b/docs/benchmarks/normalize-email.md
@@ -1,0 +1,20 @@
+# normalizeEmail
+
+[← Back to benchmarks](./README.md)
+
+Normalizes an email: trim, lowercase, and optionally strip plus-addressing (`user+tag@x.com` → `user@x.com`). Compared against a native `trim().toLowerCase()` baseline and a regex-based plus-stripper.
+
+---
+
+| Size | 1o1-utils | native | regex | Fastest |
+| ------ | ------ | ------ | ------ | ------ |
+| plain | 41ns · 24.4M ops/s | 41ns · 24.4M ops/s | — | native |
+| padded + plus | 125ns · 8.0M ops/s | 125ns · 8.0M ops/s | 125ns · 8.0M ops/s | regex |
+| longish | 208ns · 4.8M ops/s | 208ns · 4.8M ops/s | 250ns · 4.0M ops/s | native |
+
+```mermaid
+xychart-beta horizontal
+  title "normalizeEmail — ops/s at longish items"
+  x-axis ["1o1-utils", "native", "regex"]
+  bar [4807692, 4807692, 4000000]
+```

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -678,6 +678,33 @@ Escapes the 12 ECMAScript regex specials: . * + ? ^ $ { } ( ) | [ ] \
 
 ---
 
+### normalizeEmail
+
+Normalize an email address by trimming whitespace, lowercasing, and optionally stripping plus-addressing (`+alias`). Useful for deduplicating emails since most providers route `user+tag@example.com` to the same mailbox as `user@example.com`.
+
+Import: import { normalizeEmail } from "1o1-utils/normalize-email";
+
+Signature:
+function normalizeEmail({ email, stripPlus }: NormalizeEmailParams): string
+
+Parameters:
+- email (string, required): The email address to normalize
+- stripPlus (boolean, optional, default false): When true, drops everything from the first `+` in the local part up to (but excluding) the `@`.
+
+Returns: string
+
+Example:
+normalizeEmail({ email: "  User@Email.COM  " });                            // => "user@email.com"
+normalizeEmail({ email: "user+promotions@gmail.com", stripPlus: true });    // => "user@gmail.com"
+normalizeEmail({ email: "user+1@email.com" });                              // => "user+1@email.com"
+normalizeEmail({ email: "user+a+b@gmail.com", stripPlus: true });           // => "user@gmail.com"
+normalizeEmail({ email: "user@a+b.com", stripPlus: true });                 // => "user@a+b.com"
+
+Throws: Error if email is not a string. Error if email is empty after trimming.
+Lowercases both the local part and the domain. Plus-stripping only touches the local part — a `+` in the domain is left untouched. No format validation is performed; pair with `isValidEmail` for that.
+
+---
+
 ### slugify
 
 Convert a string to a URL-friendly slug by lowercasing, stripping accents, and replacing non-alphanumeric characters with hyphens.

--- a/llms.txt
+++ b/llms.txt
@@ -48,6 +48,7 @@
 
 - [capitalize](https://pedrotroccoli.github.io/1o1-utils/strings/capitalize/): Capitalize the first character of a string
 - [escapeRegExp](https://pedrotroccoli.github.io/1o1-utils/strings/escape-reg-exp/): Escape regex metacharacters so a string can be safely interpolated into a `RegExp`
+- [normalizeEmail](https://pedrotroccoli.github.io/1o1-utils/strings/normalize-email/): Normalize an email address by trimming, lowercasing, and optionally stripping plus-addressing (`+alias`)
 - [slugify](https://pedrotroccoli.github.io/1o1-utils/strings/slugify/): Convert a string to a URL-friendly slug with accent handling
 - [transformCase](https://pedrotroccoli.github.io/1o1-utils/strings/transform-case/): Convert between camelCase, kebab-case, snake_case, PascalCase, and Title Case with optional acronym preservation
 - [truncate](https://pedrotroccoli.github.io/1o1-utils/strings/truncate/): Truncate a string to a length with a configurable suffix

--- a/package.json
+++ b/package.json
@@ -68,7 +68,9 @@
     "regex-escape",
     "partition",
     "split",
-    "bifurcate"
+    "bifurcate",
+    "normalize-email",
+    "email"
   ],
   "author": "Pedro Troccoli <contact@pedrotroccoli.com>",
   "license": "MIT",
@@ -258,6 +260,10 @@
     "./partition": {
       "import": "./dist/arrays/partition/index.js",
       "types": "./dist/arrays/partition/index.d.ts"
+    },
+    "./normalize-email": {
+      "import": "./dist/strings/normalize-email/index.js",
+      "types": "./dist/strings/normalize-email/index.d.ts"
     }
   },
   "scripts": {

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -188,6 +188,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Validates a string against the HTML5 living-standard email pattern with RFC 5321 length limits. Compared against a simple regex and a native `indexOf`/`lastIndexOf` structural check.\n\n> **Note:** `simple regex` and `native string check` are coarse baselines — they do not validate hostname-label structure (hyphen rules, label length), so they accept many addresses 1o1-utils correctly rejects. Their numbers are shown for reference only and are not apples-to-apples.",
   },
+  normalizeEmail: {
+    slug: "normalize-email",
+    description:
+      "Normalizes an email: trim, lowercase, and optionally strip plus-addressing (`user+tag@x.com` → `user@x.com`). Compared against a native `trim().toLowerCase()` baseline and a regex-based plus-stripper.",
+  },
   zip: {
     slug: "zip",
     description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export { pick } from "./objects/pick/index.js";
 export { set } from "./objects/set/index.js";
 export { capitalize } from "./strings/capitalize/index.js";
 export { escapeRegExp } from "./strings/escape-reg-exp/index.js";
+export { normalizeEmail } from "./strings/normalize-email/index.js";
 export { slugify } from "./strings/slugify/index.js";
 export { transformCase } from "./strings/transform-case/index.js";
 export { truncate } from "./strings/truncate/index.js";

--- a/src/strings/normalize-email/index.bench.ts
+++ b/src/strings/normalize-email/index.bench.ts
@@ -1,0 +1,58 @@
+import { Bench } from "tinybench";
+import { normalizeEmail } from "./index.js";
+
+function nativeNormalize(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+function nativeNormalizeStripPlus(email: string): string {
+  const lower = email.trim().toLowerCase();
+  const at = lower.indexOf("@");
+  if (at < 0) return lower;
+  const plus = lower.indexOf("+");
+  if (plus < 0 || plus > at) return lower;
+  return lower.slice(0, plus) + lower.slice(at);
+}
+
+const REGEX_STRIP = /\+[^@]*(?=@)/;
+function regexNormalizeStripPlus(email: string): string {
+  return email.trim().toLowerCase().replace(REGEX_STRIP, "");
+}
+
+const plain = "User@Example.COM";
+const padded = "  User+Promotions@Gmail.COM  ";
+const longish = `  ${"a".repeat(40)}+tag-${"b".repeat(20)}@${"c".repeat(40)}.example.com  `;
+
+const bench = new Bench({ name: "normalizeEmail", time: 1000 });
+
+bench
+  .add("1o1-utils (plain)", () => {
+    normalizeEmail({ email: plain });
+  })
+  .add("native (plain)", () => {
+    nativeNormalize(plain);
+  });
+
+bench
+  .add("1o1-utils (padded + plus)", () => {
+    normalizeEmail({ email: padded, stripPlus: true });
+  })
+  .add("native (padded + plus)", () => {
+    nativeNormalizeStripPlus(padded);
+  })
+  .add("regex (padded + plus)", () => {
+    regexNormalizeStripPlus(padded);
+  });
+
+bench
+  .add("1o1-utils (longish)", () => {
+    normalizeEmail({ email: longish, stripPlus: true });
+  })
+  .add("native (longish)", () => {
+    nativeNormalizeStripPlus(longish);
+  })
+  .add("regex (longish)", () => {
+    regexNormalizeStripPlus(longish);
+  });
+
+export { bench };

--- a/src/strings/normalize-email/index.spec.ts
+++ b/src/strings/normalize-email/index.spec.ts
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { normalizeEmail } from "./index.js";
+
+describe("normalizeEmail", () => {
+  describe("trimming and casing", () => {
+    it("should trim leading and trailing whitespace", () => {
+      expect(normalizeEmail({ email: "  user@example.com  " })).to.equal(
+        "user@example.com",
+      );
+    });
+
+    it("should lowercase the local part", () => {
+      expect(normalizeEmail({ email: "User@example.com" })).to.equal(
+        "user@example.com",
+      );
+    });
+
+    it("should lowercase the domain", () => {
+      expect(normalizeEmail({ email: "user@Example.COM" })).to.equal(
+        "user@example.com",
+      );
+    });
+
+    it("should trim and lowercase together", () => {
+      expect(normalizeEmail({ email: "  User@Email.COM  " })).to.equal(
+        "user@email.com",
+      );
+    });
+
+    it("should be idempotent for already-normalized input", () => {
+      const input = "user@example.com";
+      expect(normalizeEmail({ email: input })).to.equal(input);
+      expect(
+        normalizeEmail({ email: normalizeEmail({ email: input }) }),
+      ).to.equal(input);
+    });
+  });
+
+  describe("plus-addressing (default stripPlus: false)", () => {
+    it("should preserve +tag by default", () => {
+      expect(normalizeEmail({ email: "user+promotions@gmail.com" })).to.equal(
+        "user+promotions@gmail.com",
+      );
+    });
+
+    it("should preserve +tag when stripPlus is explicitly false", () => {
+      expect(
+        normalizeEmail({ email: "user+1@email.com", stripPlus: false }),
+      ).to.equal("user+1@email.com");
+    });
+  });
+
+  describe("plus-addressing (stripPlus: true)", () => {
+    it("should strip +tag from the local part", () => {
+      expect(
+        normalizeEmail({
+          email: "user+promotions@gmail.com",
+          stripPlus: true,
+        }),
+      ).to.equal("user@gmail.com");
+    });
+
+    it("should be a no-op when there is no plus in the local part", () => {
+      expect(
+        normalizeEmail({ email: "user@gmail.com", stripPlus: true }),
+      ).to.equal("user@gmail.com");
+    });
+
+    it("should strip from the first plus through the @ when multiple pluses exist", () => {
+      expect(
+        normalizeEmail({
+          email: "user+a+b+c@gmail.com",
+          stripPlus: true,
+        }),
+      ).to.equal("user@gmail.com");
+    });
+
+    it("should leave a plus in the domain untouched", () => {
+      expect(
+        normalizeEmail({ email: "user@a+b.com", stripPlus: true }),
+      ).to.equal("user@a+b.com");
+    });
+
+    it("should still trim and lowercase when stripping", () => {
+      expect(
+        normalizeEmail({
+          email: "  User+Tag@Gmail.COM ",
+          stripPlus: true,
+        }),
+      ).to.equal("user@gmail.com");
+    });
+
+    it("should handle empty local segment before plus (e.g. +tag@)", () => {
+      expect(
+        normalizeEmail({ email: "+tag@example.com", stripPlus: true }),
+      ).to.equal("@example.com");
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("should throw for null", () => {
+      expect(() =>
+        // @ts-expect-error testing runtime guard
+        normalizeEmail({ email: null }),
+      ).to.throw(Error, "The 'email' parameter must be a string");
+    });
+
+    it("should throw for undefined", () => {
+      expect(() =>
+        // @ts-expect-error testing runtime guard
+        normalizeEmail({ email: undefined }),
+      ).to.throw(Error, "The 'email' parameter must be a string");
+    });
+
+    it("should throw for a number", () => {
+      expect(() =>
+        // @ts-expect-error testing runtime guard
+        normalizeEmail({ email: 42 }),
+      ).to.throw(Error, "The 'email' parameter must be a string");
+    });
+
+    it("should throw for an object", () => {
+      expect(() =>
+        // @ts-expect-error testing runtime guard
+        normalizeEmail({ email: {} }),
+      ).to.throw(Error, "The 'email' parameter must be a string");
+    });
+
+    it("should throw for an empty string", () => {
+      expect(() => normalizeEmail({ email: "" })).to.throw(
+        Error,
+        "The 'email' parameter must not be empty",
+      );
+    });
+
+    it("should throw for a whitespace-only string", () => {
+      expect(() => normalizeEmail({ email: "   " })).to.throw(
+        Error,
+        "The 'email' parameter must not be empty",
+      );
+    });
+  });
+});

--- a/src/strings/normalize-email/index.ts
+++ b/src/strings/normalize-email/index.ts
@@ -1,7 +1,4 @@
-import type {
-  NormalizeEmailParams,
-  NormalizeEmailResult,
-} from "./types.js";
+import type { NormalizeEmailParams, NormalizeEmailResult } from "./types.js";
 
 /**
  * Normalizes an email address: trim, lowercase, and optionally strip

--- a/src/strings/normalize-email/index.ts
+++ b/src/strings/normalize-email/index.ts
@@ -42,7 +42,8 @@ import type {
  *
  * Plus-stripping only touches the local part: a `+` that appears in the
  * domain is left untouched. When multiple `+` characters exist in the
- * local part, everything from the first `+` through the `@` is removed.
+ * local part, everything from the first `+` up to (but excluding) the
+ * `@` is removed; the `@` and domain are preserved.
  *
  * No format validation is performed — pair with `isValidEmail` for that.
  *

--- a/src/strings/normalize-email/index.ts
+++ b/src/strings/normalize-email/index.ts
@@ -1,0 +1,81 @@
+import type {
+  NormalizeEmailParams,
+  NormalizeEmailResult,
+} from "./types.js";
+
+/**
+ * Normalizes an email address: trim, lowercase, and optionally strip
+ * plus-addressing (`+alias`).
+ *
+ * Plus-addressing (`user+tag@example.com`) resolves to the same mailbox
+ * as `user@example.com` in most providers. Pass `stripPlus: true` to
+ * collapse plus-tagged addresses to their base form, useful for
+ * deduplicating emails.
+ *
+ * @param params - The parameters object
+ * @param params.email - The email address to normalize
+ * @param params.stripPlus - When `true`, drops everything from the first
+ *   `+` in the local part up to the `@`. Default `false`.
+ * @returns The normalized email address
+ *
+ * @example
+ * ```ts
+ * normalizeEmail({ email: "  User@Email.COM  " });
+ * // => "user@email.com"
+ *
+ * normalizeEmail({
+ *   email: "user+promotions@gmail.com",
+ *   stripPlus: true,
+ * });
+ * // => "user@gmail.com"
+ *
+ * normalizeEmail({ email: "user+1@email.com" });
+ * // => "user+1@email.com"
+ * ```
+ *
+ * @keywords normalize email, email, lowercase email, dedupe email, plus addressing, strip plus
+ *
+ * @remarks
+ * Lowercases both the local part and the domain. Per RFC 5321 the local
+ * part is technically case-sensitive, but virtually every mail provider
+ * treats it case-insensitively, so lowercasing is the practical default.
+ *
+ * Plus-stripping only touches the local part: a `+` that appears in the
+ * domain is left untouched. When multiple `+` characters exist in the
+ * local part, everything from the first `+` through the `@` is removed.
+ *
+ * No format validation is performed — pair with `isValidEmail` for that.
+ *
+ * @throws Error if `email` is not a string
+ * @throws Error if `email` is empty after trimming
+ */
+function normalizeEmail({
+  email,
+  stripPlus = false,
+}: NormalizeEmailParams): NormalizeEmailResult {
+  if (typeof email !== "string") {
+    throw new Error("The 'email' parameter must be a string");
+  }
+
+  const trimmed = email.trim();
+  if (trimmed.length === 0) {
+    throw new Error("The 'email' parameter must not be empty");
+  }
+
+  const lower = trimmed.toLowerCase();
+
+  if (!stripPlus) return lower;
+
+  const atIndex = lower.indexOf("@");
+  if (atIndex < 0) return lower;
+
+  const local = lower.slice(0, atIndex);
+  const domain = lower.slice(atIndex);
+
+  const plusIndex = local.indexOf("+");
+  if (plusIndex < 0) return lower;
+
+  return local.slice(0, plusIndex) + domain;
+}
+
+export { normalizeEmail };

--- a/src/strings/normalize-email/types.ts
+++ b/src/strings/normalize-email/types.ts
@@ -1,0 +1,14 @@
+interface NormalizeEmailParams {
+  email: string;
+  stripPlus?: boolean;
+}
+
+type NormalizeEmailResult = string;
+
+type NormalizeEmailFn = (params: NormalizeEmailParams) => NormalizeEmailResult;
+
+export type {
+  NormalizeEmailFn,
+  NormalizeEmailParams,
+  NormalizeEmailResult,
+};

--- a/src/strings/normalize-email/types.ts
+++ b/src/strings/normalize-email/types.ts
@@ -7,8 +7,4 @@ type NormalizeEmailResult = string;
 
 type NormalizeEmailFn = (params: NormalizeEmailParams) => NormalizeEmailResult;
 
-export type {
-  NormalizeEmailFn,
-  NormalizeEmailParams,
-  NormalizeEmailResult,
-};
+export type { NormalizeEmailFn, NormalizeEmailParams, NormalizeEmailResult };

--- a/website/src/content/docs/strings/normalize-email.mdx
+++ b/website/src/content/docs/strings/normalize-email.mdx
@@ -1,0 +1,70 @@
+---
+title: normalizeEmail
+description: Normalize an email by trimming, lowercasing, and optionally stripping plus-addressing
+---
+
+Normalizes an email address by trimming whitespace, lowercasing, and optionally stripping plus-addressing (`+alias`). Useful for deduplicating emails since most providers route `user+tag@example.com` to the same mailbox as `user@example.com`.
+
+## Import
+
+```ts
+import { normalizeEmail } from "1o1-utils";
+```
+
+```ts
+import { normalizeEmail } from "1o1-utils/normalize-email";
+```
+
+## Signature
+
+```ts
+function normalizeEmail({ email, stripPlus }: NormalizeEmailParams): string
+```
+
+## Parameters
+
+| Name      | Type      | Required | Description                                                                                                       |
+| --------- | --------- | -------- | ----------------------------------------------------------------------------------------------------------------- |
+| email     | `string`  | Yes      | The email address to normalize                                                                                    |
+| stripPlus | `boolean` | No       | When `true`, drops everything from the first `+` in the local part up to (but excluding) the `@`. Default `false` |
+
+## Returns
+
+`string`
+
+## Examples
+
+```ts
+normalizeEmail({ email: "  User@Email.COM  " });
+// => "user@email.com"
+
+normalizeEmail({ email: "user+promotions@gmail.com", stripPlus: true });
+// => "user@gmail.com"
+
+normalizeEmail({ email: "user+1@email.com" });
+// => "user+1@email.com" — default keeps plus-addressing
+
+normalizeEmail({ email: "user+a+b@gmail.com", stripPlus: true });
+// => "user@gmail.com" — strips from first plus
+
+normalizeEmail({ email: "user@a+b.com", stripPlus: true });
+// => "user@a+b.com" — plus in domain is preserved
+```
+
+## Edge Cases
+
+- Throws if `email` is not a string.
+- Throws if `email` is empty after trimming.
+- Lowercases both the local part and the domain.
+- `stripPlus` only touches the local part — a `+` that appears in the domain is preserved.
+- No format validation is performed. Pair with [`isValidEmail`](/1o1-utils/validators/is-valid-email/) for that.
+
+## Also known as
+
+normalize email, lowercase email, dedupe email, plus addressing, strip plus
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use normalizeEmail with stripPlus to deduplicate user signups by email.
+```


### PR DESCRIPTION
## Summary

- New `normalizeEmail` utility under `strings/`. Trims, lowercases, and optionally strips plus-addressing (`user+tag@x.com` → `user@x.com` with `stripPlus: true`).
- Throws on non-string or empty input. No format validation — pair with `isValidEmail`.
- Benchmark added: on par with native `trim().toLowerCase()` baseline; faster than regex on long inputs.

Closes #56

## API

\`\`\`ts
normalizeEmail({ email: "  User@Email.COM  " });
// => "user@email.com"

normalizeEmail({ email: "user+promotions@gmail.com", stripPlus: true });
// => "user@gmail.com"

normalizeEmail({ email: "user+1@email.com" });
// => "user+1@email.com"  (default stripPlus: false)
\`\`\`

## Test plan

- [x] \`npm run build\` — clean
- [x] \`npm test\` — 19 new tests pass (722 total)
- [x] \`npm run lint\` — no new warnings
- [x] \`npm run bench -- normalize-email\` — on par with native baseline
- [x] Smoke test built output via dynamic import