### PR TITLE
feat(strings): add deburr utility

### DIFF
--- a/docs/benchmarks/README.md
+++ b/docs/benchmarks/README.md
@@ -9,14 +9,25 @@ Run `pnpm bench` to reproduce these results locally.
 ## Results
 
 - [arrayToHash / keyBy](./array-to-hash.md) — on par with lodash
-- [chunk](./chunk.md) — **1.4–11.4× faster** than lodash
-- [defaults](./defaults.md) — **1.5–1.8× faster** than lodash
-- [defaultsDeep](./defaults-deep.md) — **3.7–5.9× faster** than lodash
+- [chunk](./chunk.md) — **1.4–11.3× faster** than lodash
+- [cloneDeep](./clone-deep.md) — **2.6–4.1× faster** than lodash
+- [deburr](./deburr.md)
+- [defaultsDeep](./defaults-deep.md) — **3.6–5.9× faster** than lodash
+- [defaults](./defaults.md) — **1.5× faster** than lodash
 - [groupBy](./group-by.md) — **1.2× faster** than lodash
-- [mapKeys](./map-keys.md) — 1.2× slower than lodash, **1.6× faster** than native
-- [mapValues](./map-values.md) — on par with lodash, **3.0× faster** than native
-- [unique (by key)](./unique.md) — **2.7× faster** than lodash
+- [isEmpty](./is-empty.md) — on par with lodash
+- [mapKeys](./map-keys.md) — 1.2× slower than lodash
+- [mapValues](./map-values.md) — on par with lodash
+- [normalizeEmail](./normalize-email.md)
+- [omit](./omit.md) — **2.2–2.8× faster** than lodash
 - [pick](./pick.md) — **2.6–4.0× faster** than lodash
+- [retry](./retry.md)
+- [sleep](./sleep.md)
+- [sortBy](./sortby.md) — **1.7–2.3× faster** than lodash
+- [transformCase](./transform-case.md)
+- [unique (by key)](./unique.md) — **2.7× faster** than lodash
+- [unzip](./unzip.md) — **2.3–4.0× faster** than lodash
+- [zip](./zip.md) — on par with lodash
 
 ---
 
@@ -26,13 +37,24 @@ Run `pnpm bench` to reproduce these results locally.
 | ------- | --------- | --------- | --------- |
 | arrayToHash / keyBy | on par | on par | on par |
 | chunk | **4.9× faster** | on par | on par |
-| defaults | **1.6× faster** | — | **2.1× faster** |
+| cloneDeep | **3.2× faster** | 2.8× slower | — |
+| deburr | — | — | on par |
 | defaultsDeep | **4.8× faster** | — | — |
+| defaults | **1.6× faster** | — | **2.1× faster** |
 | groupBy | **1.3× faster** | on par | 1.1× slower |
-| mapKeys | 1.2× slower | — | **1.6× faster** |
-| mapValues | on par | — | **3.0× faster** |
-| unique (by key) | **2.7× faster** | **1.6× faster** | on par |
+| isEmpty | on par | **6.3× faster** | — |
+| mapKeys | 1.2× slower | — | **1.5× faster** |
+| mapValues | on par | — | **2.8× faster** |
+| normalizeEmail | — | — | on par |
+| omit | **2.5× faster** | 1.4× slower | — |
 | pick | **3.3× faster** | on par | — |
+| retry | — | **1.5× faster** | 1.3× slower |
+| sleep | — | on par | on par |
+| sortBy | **1.9× faster** | 1.5× slower | on par |
+| transformCase | — | — | — |
+| unique (by key) | **2.7× faster** | **1.6× faster** | on par |
+| unzip | **3.2× faster** | — | 1.6× slower |
+| zip | **1.5× faster** | **1.8× faster** | 1.2× slower |
 
 ---
 
@@ -42,5 +64,5 @@ Run `pnpm bench` to reproduce these results locally.
 - **Runtime**: Node.js v25.2.1
 - **OS**: darwin 24.3.0
 - **Benchmark tool**: tinybench v6
-- **Date**: 2026-04-09
+- **Date**: 2026-05-03
 - **Source**: [`src/**/*.bench.ts`](../src/)

--- a/docs/benchmarks/deburr.md
+++ b/docs/benchmarks/deburr.md
@@ -1,0 +1,20 @@
+# deburr
+
+[← Back to benchmarks](./README.md)
+
+Strips diacritics (accents) from a string via Unicode NFD normalization. Compared against a native inline `normalize('NFD').replace(...)` baseline.
+
+---
+
+| Size | 1o1-utils | native | Fastest |
+| ------ | ------ | ------ | ------ |
+| ascii | 125ns · 8.0M ops/s | 125ns · 8.0M ops/s | native |
+| short accented | 208ns · 4.8M ops/s | 208ns · 4.8M ops/s | native |
+| long accented | 2.5µs · 406.8K ops/s | 2.5µs · 406.8K ops/s | native |
+
+```mermaid
+xychart-beta horizontal
+  title "deburr — ops/s at long accented items"
+  x-axis ["native", "1o1-utils"]
+  bar [406835, 406835]
+```

--- a/package.json
+++ b/package.json
@@ -73,7 +73,11 @@
     "split",
     "bifurcate",
     "normalize-email",
-    "email"
+    "email",
+    "deburr",
+    "diacritic",
+    "accent",
+    "remove-accents"
   ],
   "author": "Pedro Troccoli <contact@pedrotroccoli.com>",
   "license": "MIT",
@@ -271,6 +275,10 @@
     "./normalize-email": {
       "import": "./dist/strings/normalize-email/index.js",
       "types": "./dist/strings/normalize-email/index.d.ts"
+    },
+    "./deburr": {
+      "import": "./dist/strings/deburr/index.js",
+      "types": "./dist/strings/deburr/index.d.ts"
     }
   },
   "scripts": {

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -193,6 +193,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Normalizes an email: trim, lowercase, and optionally strip plus-addressing (`user+tag@x.com` → `user@x.com`). Compared against a native `trim().toLowerCase()` baseline and a regex-based plus-stripper.",
   },
+  deburr: {
+    slug: "deburr",
+    description:
+      "Strips diacritics (accents) from a string via Unicode NFD normalization. Compared against a native inline `normalize('NFD').replace(...)` baseline.",
+  },
   zip: {
     slug: "zip",
     description:

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ export { omit } from "./objects/omit/index.js";
 export { pick } from "./objects/pick/index.js";
 export { set } from "./objects/set/index.js";
 export { capitalize } from "./strings/capitalize/index.js";
+export { deburr } from "./strings/deburr/index.js";
 export { escapeRegExp } from "./strings/escape-reg-exp/index.js";
 export { normalizeEmail } from "./strings/normalize-email/index.js";
 export { slugify } from "./strings/slugify/index.js";

--- a/src/strings/deburr/index.bench.ts
+++ b/src/strings/deburr/index.bench.ts
@@ -1,0 +1,38 @@
+import { Bench } from "tinybench";
+import { deburr } from "./index.js";
+
+function nativeDeburr(str: string): string {
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+const ascii = "hello world";
+const shortAccented = "São Paulo";
+const longAccented = `${"résumé ".repeat(20)}café ${"naïve ".repeat(20)}`;
+
+const bench = new Bench({ name: "deburr", time: 1000 });
+
+bench
+  .add("1o1-utils (ascii)", () => {
+    deburr({ str: ascii });
+  })
+  .add("native (ascii)", () => {
+    nativeDeburr(ascii);
+  });
+
+bench
+  .add("1o1-utils (short accented)", () => {
+    deburr({ str: shortAccented });
+  })
+  .add("native (short accented)", () => {
+    nativeDeburr(shortAccented);
+  });
+
+bench
+  .add("1o1-utils (long accented)", () => {
+    deburr({ str: longAccented });
+  })
+  .add("native (long accented)", () => {
+    nativeDeburr(longAccented);
+  });
+
+export { bench };

--- a/src/strings/deburr/index.spec.ts
+++ b/src/strings/deburr/index.spec.ts
@@ -1,0 +1,92 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { deburr } from "./index.js";
+
+describe("deburr", () => {
+  describe("removes diacritics", () => {
+    it("should strip a single accent", () => {
+      const result = deburr({ str: "café" });
+
+      expect(result).to.equal("cafe");
+    });
+
+    it("should strip accents while preserving case", () => {
+      const result = deburr({ str: "São Paulo" });
+
+      expect(result).to.equal("Sao Paulo");
+    });
+
+    it("should strip multiple accents in the same string", () => {
+      const result = deburr({ str: "résumé" });
+
+      expect(result).to.equal("resume");
+    });
+
+    it("should strip diaeresis", () => {
+      const result = deburr({ str: "naïve" });
+
+      expect(result).to.equal("naive");
+    });
+
+    it("should handle a wide range of Latin diacritics", () => {
+      const result = deburr({
+        str: "ÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÒÓÔÕÖÙÚÛÜÝàáâãäåçèéêëìíîïòóôõöùúûüýÿ",
+      });
+
+      expect(result).to.equal(
+        "AAAAAACEEEEIIIIOOOOOUUUUYaaaaaaceeeeiiiiooooouuuuyy",
+      );
+    });
+  });
+
+  describe("passthrough", () => {
+    it("should leave plain ASCII unchanged", () => {
+      const result = deburr({ str: "hello world" });
+
+      expect(result).to.equal("hello world");
+    });
+
+    it("should return an empty string for an empty input", () => {
+      const result = deburr({ str: "" });
+
+      expect(result).to.equal("");
+    });
+
+    it("should leave non-Latin scripts without combining marks unchanged", () => {
+      const result = deburr({ str: "你好 こんにちは" });
+
+      expect(result).to.equal("你好 こんにちは");
+    });
+
+    it("should leave characters that do not decompose unchanged", () => {
+      const result = deburr({ str: "straße łódź" });
+
+      expect(result).to.equal("straße łodz");
+    });
+  });
+
+  describe("idempotence", () => {
+    it("should produce the same result when applied twice", () => {
+      const once = deburr({ str: "São Paulo — résumé" });
+      const twice = deburr({ str: once });
+
+      expect(twice).to.equal(once);
+    });
+  });
+
+  describe("invalid inputs", () => {
+    it("should throw an error if str is not a string", () => {
+      // @ts-expect-error - we want to test the error case
+      expect(() => deburr({ str: 123 })).to.throw(
+        "The 'str' parameter must be a string",
+      );
+    });
+
+    it("should throw an error if str is undefined", () => {
+      // @ts-expect-error - we want to test the error case
+      expect(() => deburr({ str: undefined })).to.throw(
+        "The 'str' parameter must be a string",
+      );
+    });
+  });
+});

--- a/src/strings/deburr/index.ts
+++ b/src/strings/deburr/index.ts
@@ -1,0 +1,46 @@
+import type { DeburrParams, DeburrResult } from "./types.js";
+
+/**
+ * Removes diacritics (accents) from a string, preserving case and
+ * non-accented characters.
+ *
+ * Useful for search, comparison, deduplication, and slug generation in
+ * languages that use combining marks (Portuguese, Spanish, French,
+ * Vietnamese, etc.).
+ *
+ * @param params - The parameters object
+ * @param params.str - The string to deburr
+ * @returns The string with combining diacritical marks removed
+ *
+ * @example
+ * ```ts
+ * deburr({ str: "café" });
+ * // => "cafe"
+ *
+ * deburr({ str: "São Paulo" });
+ * // => "Sao Paulo"
+ *
+ * deburr({ str: "résumé" });
+ * // => "resume"
+ * ```
+ *
+ * @keywords deburr, accent, diacritic, unicode, normalize, remove accents, strip accents, ascii
+ *
+ * @remarks
+ * Uses Unicode NFD normalization to decompose accented characters into
+ * their base letter plus combining marks, then strips marks in the
+ * U+0300–U+036F range. Characters that do not decompose (e.g. German
+ * `ß`, Turkish `ı`/`İ`, Polish `ł`) are left untouched — pair with a
+ * locale-aware transliteration if you need broader coverage.
+ *
+ * @throws Error if `str` is not a string
+ */
+function deburr({ str }: DeburrParams): DeburrResult {
+  if (typeof str !== "string") {
+    throw new Error("The 'str' parameter must be a string");
+  }
+
+  return str.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
+
+export { deburr };

--- a/src/strings/deburr/types.ts
+++ b/src/strings/deburr/types.ts
@@ -1,0 +1,9 @@
+interface DeburrParams {
+  str: string;
+}
+
+type DeburrResult = string;
+
+type Deburr = (params: DeburrParams) => DeburrResult;
+
+export type { Deburr, DeburrParams, DeburrResult };

--- a/src/strings/slugify/index.ts
+++ b/src/strings/slugify/index.ts
@@ -1,3 +1,4 @@
+import { deburr } from "../deburr/index.js";
 import type { SlugifyParams, SlugifyResult } from "./types.js";
 
 /**
@@ -22,9 +23,7 @@ function slugify({ str }: SlugifyParams): SlugifyResult {
     throw new Error("The 'str' parameter must be a string");
   }
 
-  return str
-    .normalize("NFD")
-    .replace(/[\u0300-\u036f]/g, "")
+  return deburr({ str })
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");


### PR DESCRIPTION
## Summary
- Adds `deburr` — strips diacritics from a string via Unicode NFD normalization (`'café'` → `'cafe'`, `'São Paulo'` → `'Sao Paulo'`)
- Refactors `slugify` to call `deburr` internally, removing duplicated NFD strip
- Regenerates `docs/benchmarks/README.md` to include all 20 existing per-suite benchmarks (was stale, missing 11 utilities)

Closes #98

## Test plan
- [x] `npm test` — 745 passing (new `deburr` suite + existing `slugify` suite unchanged)
- [x] `npm run build` — `tsc` clean, `dist/strings/deburr/` emitted
- [x] `npm run bench -- deburr` — paridade com native em ASCII / curto acentuado / longo acentuado
- [x] Smoke check: `node -e "import('./dist/strings/deburr/index.js').then(m => console.log(m.deburr({str:'São Paulo'})))"` → `Sao Paulo`
- [x] Subpath export `1o1-utils/deburr` registered in `package.json` + barrel `src/index.ts`