### PR TITLE
feat(objects): add compact utility

### DIFF
--- a/.changeset/add-compact.md
+++ b/.changeset/add-compact.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `compact` utility for objects: removes falsy values (`false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, `NaN`) with an optional `keep` list to preserve specific falsy values via `Object.is`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -41,6 +41,11 @@
     "limit": "2 kB"
   },
   {
+    "name": "compact",
+    "path": "dist/objects/compact/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "deep-merge",
     "path": "dist/objects/deep-merge/index.js",
     "limit": "2 kB"

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -444,8 +444,8 @@ compact({ obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" } });
 compact({ obj: { a: 0, b: null, c: "" }, keep: [0] });
 // => { a: 0 }
 
-Throws: Error if obj is not an object. Error if keep is not an array.
-Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution. Does not mutate the input.
+Throws: Error if obj is not an object. Error if obj is an array (use `.filter(Boolean)` for arrays). Error if keep is not an array.
+Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution. Symbol-keyed properties are ignored. Truthy values in `keep` are no-ops. Does not mutate the input.
 
 ---
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -422,6 +422,33 @@ Primitives are returned as-is. Functions are copied by reference. Map values are
 
 ---
 
+### compact
+
+Remove all falsy values (`false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, `NaN`) from an object. Pass `keep` to preserve specific falsy values; matching uses `Object.is`, so `0` vs `-0` and `NaN` are handled exactly.
+
+Import: import { compact } from "1o1-utils/compact";
+
+Signature:
+function compact<T extends Record<string, unknown>>({ obj, keep }: CompactParams<T>): Partial<T>
+
+Parameters:
+- obj (T, required): The source object
+- keep (unknown[], optional): Falsy values to preserve
+
+Returns: Partial<T> — A new object without falsy entries (except those listed in `keep`).
+
+Example:
+compact({ obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" } });
+// => { a: 1, f: "ok" }
+
+compact({ obj: { a: 0, b: null, c: "" }, keep: [0] });
+// => { a: 0 }
+
+Throws: Error if obj is not an object. Error if keep is not an array.
+Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution. Does not mutate the input.
+
+---
+
 ### deepMerge
 
 Recursively merge two objects into a new object. Nested plain objects are merged deeply; arrays and other types are overwritten.

--- a/llms.txt
+++ b/llms.txt
@@ -34,6 +34,7 @@
 ## Objects
 
 - [cloneDeep](https://pedrotroccoli.github.io/1o1-utils/objects/clone-deep/): Deep clone any value — handles objects, arrays, Date, RegExp, Map, Set, typed arrays, and circular references
+- [compact](https://pedrotroccoli.github.io/1o1-utils/objects/compact/): Remove falsy values from an object, with an optional `keep` list to preserve specific falsy values
 - [deepMerge](https://pedrotroccoli.github.io/1o1-utils/objects/deep-merge/): Recursively merge two objects without mutation
 - [defaults](https://pedrotroccoli.github.io/1o1-utils/objects/defaults/): Fill `undefined` properties with defaults from another object
 - [defaultsDeep](https://pedrotroccoli.github.io/1o1-utils/objects/defaults-deep/): Recursively fill `undefined` properties with defaults from another object

--- a/package.json
+++ b/package.json
@@ -85,7 +85,10 @@
     "memo",
     "memoize",
     "cache",
-    "ttl-cache"
+    "ttl-cache",
+    "compact",
+    "remove-falsy",
+    "clean-object"
   ],
   "author": "Pedro Troccoli <contact@pedrotroccoli.com>",
   "license": "MIT",
@@ -127,6 +130,10 @@
     "./clone-deep": {
       "import": "./dist/objects/clone-deep/index.js",
       "types": "./dist/objects/clone-deep/index.d.ts"
+    },
+    "./compact": {
+      "import": "./dist/objects/compact/index.js",
+      "types": "./dist/objects/compact/index.d.ts"
     },
     "./deep-merge": {
       "import": "./dist/objects/deep-merge/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export { clamp } from "./numbers/clamp/index.js";
 export { inRange } from "./numbers/in-range/index.js";
 export { randomInt } from "./numbers/random-int/index.js";
 export { cloneDeep } from "./objects/clone-deep/index.js";
+export { compact } from "./objects/compact/index.js";
 export { deepMerge } from "./objects/deep-merge/index.js";
 export { defaults } from "./objects/defaults/index.js";
 export { defaultsDeep } from "./objects/defaults-deep/index.js";

--- a/src/objects/compact/index.bench.ts
+++ b/src/objects/compact/index.bench.ts
@@ -1,0 +1,35 @@
+import lodashOmitBy from "lodash/omitBy.js";
+import { shake as radashShake } from "radash";
+import { Bench } from "tinybench";
+import { compact } from "./index.js";
+
+const sampleObj = {
+  id: "usr_00000001",
+  name: "Alice",
+  age: 30,
+  role: "admin",
+  department: "engineering",
+  email: "alice@example.com",
+  inactive: null,
+  archived: null,
+  deletedAt: undefined,
+  notes: "",
+  loginCount: 0,
+};
+
+const isFalsy = (v: unknown) => !v;
+
+const bench = new Bench({ name: "compact", time: 1000 });
+
+bench
+  .add("1o1-utils", () => {
+    compact({ obj: sampleObj });
+  })
+  .add("lodash (omitBy isFalsy)", () => {
+    lodashOmitBy(sampleObj, isFalsy);
+  })
+  .add("radash (shake isFalsy)", () => {
+    radashShake(sampleObj, isFalsy);
+  });
+
+export { bench };

--- a/src/objects/compact/index.spec.ts
+++ b/src/objects/compact/index.spec.ts
@@ -1,0 +1,141 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { compact } from "./index.js";
+
+describe("compact", () => {
+  it("should remove all falsy values by default", () => {
+    const result = compact({
+      obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" },
+    });
+
+    expect(result).to.deep.equal({ a: 1, f: "ok" });
+  });
+
+  it("should remove undefined and NaN", () => {
+    const result = compact({
+      obj: { a: undefined, b: Number.NaN, c: 1 },
+    });
+
+    expect(result).to.deep.equal({ c: 1 });
+  });
+
+  it("should remove 0n (BigInt zero)", () => {
+    const result = compact({
+      obj: { a: 0n, b: 1n },
+    });
+
+    expect(result).to.deep.equal({ b: 1n });
+  });
+
+  it("should preserve falsy values listed in keep", () => {
+    const result = compact({
+      obj: { a: 0, b: null, c: "" },
+      keep: [0],
+    });
+
+    expect(result).to.deep.equal({ a: 0 });
+  });
+
+  it("should preserve multiple kept falsy values", () => {
+    const result = compact({
+      obj: { a: 0, b: false, c: "", d: null, e: 1 },
+      keep: [0, false, ""],
+    });
+
+    expect(result).to.deep.equal({ a: 0, b: false, c: "", e: 1 });
+  });
+
+  it("should match NaN in keep via Object.is", () => {
+    const result = compact({
+      obj: { a: Number.NaN, b: 1 },
+      keep: [Number.NaN],
+    });
+
+    expect(result).to.deep.equal({ a: Number.NaN, b: 1 });
+  });
+
+  it("should distinguish 0 from -0 via Object.is", () => {
+    const resultKeepZero = compact({
+      obj: { a: 0, b: -0 },
+      keep: [0],
+    });
+
+    expect(Object.is(resultKeepZero.a, 0)).to.equal(true);
+    expect(resultKeepZero).to.not.have.property("b");
+  });
+
+  it("should keep all truthy values regardless of keep", () => {
+    const result = compact({
+      obj: { a: 1, b: "x", c: true, d: {} },
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: "x", c: true, d: {} });
+  });
+
+  it("should return an empty object when all values are falsy and keep is empty", () => {
+    const result = compact({
+      obj: { a: null, b: undefined, c: 0 },
+    });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should return an empty object when source is empty", () => {
+    const result = compact({ obj: {} as Record<string, unknown> });
+
+    expect(result).to.deep.equal({});
+  });
+
+  it("should return a new object, not a reference to the original", () => {
+    const obj = { a: 1, b: 2 };
+    const result = compact({ obj });
+
+    expect(result).to.not.equal(obj);
+  });
+
+  it("should ignore keep when it is an empty array", () => {
+    const result = compact({
+      obj: { a: 0, b: null, c: 1 },
+      keep: [],
+    });
+
+    expect(result).to.deep.equal({ c: 1 });
+  });
+
+  it("should skip unsafe keys to prevent prototype pollution", () => {
+    const obj: Record<string, unknown> = {};
+    Object.defineProperty(obj, "__proto__", {
+      enumerable: true,
+      configurable: true,
+      writable: true,
+      value: { polluted: true },
+    });
+    obj.safe = 1;
+
+    const result = compact({ obj });
+
+    expect(result).to.deep.equal({ safe: 1 });
+    expect(({} as Record<string, unknown>).polluted).to.equal(undefined);
+  });
+
+  it("should throw an error if obj is not an object", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      compact({ obj: "not an object" }),
+    ).to.throw("The 'obj' parameter is not an object");
+  });
+
+  it("should throw an error if obj is null", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      compact({ obj: null }),
+    ).to.throw("The 'obj' parameter is not an object");
+  });
+
+  it("should throw an error if keep is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      compact({ obj: { a: 1 }, keep: "not an array" }),
+    ).to.throw("The 'keep' parameter is not an array");
+  });
+});

--- a/src/objects/compact/index.spec.ts
+++ b/src/objects/compact/index.spec.ts
@@ -138,4 +138,31 @@ describe("compact", () => {
       compact({ obj: { a: 1 }, keep: "not an array" }),
     ).to.throw("The 'keep' parameter is not an array");
   });
+
+  it("should throw an error if obj is an array", () => {
+    expect(() =>
+      // @ts-expect-error - testing invalid input
+      compact({ obj: [1, null, 2] }),
+    ).to.throw("The 'obj' parameter must not be an array");
+  });
+
+  it("should ignore truthy values listed in keep (no-op)", () => {
+    const result = compact({
+      obj: { a: 1, b: 0, c: null },
+      keep: ["truthy-no-op", 42, 0],
+    });
+
+    expect(result).to.deep.equal({ a: 1, b: 0 });
+  });
+
+  it("should ignore symbol-keyed properties", () => {
+    const sym = Symbol("hidden");
+    const obj: Record<string | symbol, unknown> = { a: 1 };
+    obj[sym] = "secret";
+
+    const result = compact({ obj: obj as Record<string, unknown> });
+
+    expect(result).to.deep.equal({ a: 1 });
+    expect(Object.getOwnPropertySymbols(result)).to.have.lengthOf(0);
+  });
 });

--- a/src/objects/compact/index.ts
+++ b/src/objects/compact/index.ts
@@ -1,0 +1,61 @@
+import type { CompactParams } from "./types.js";
+
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+/**
+ * Creates a new object with all falsy values removed.
+ * Falsy values are `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`.
+ * Pass `keep` to preserve specific falsy values (matched via `Object.is`).
+ *
+ * @param params - The parameters object
+ * @param params.obj - The source object
+ * @param params.keep - Optional array of falsy values to preserve
+ * @returns A new object without falsy entries (except those in `keep`)
+ *
+ * @example
+ * ```ts
+ * compact({ obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" } });
+ * // => { a: 1, f: "ok" }
+ *
+ * compact({ obj: { a: 0, b: null, c: "" }, keep: [0] });
+ * // => { a: 0 }
+ * ```
+ *
+ * @keywords remove falsy, clean object, drop empty, prune null, compact object
+ *
+ * @throws Error if `obj` is not an object
+ * @throws Error if `keep` is not an array
+ */
+function compact<T extends Record<string, unknown>>({
+  obj,
+  keep,
+}: CompactParams<T>): Partial<T> {
+  if (typeof obj !== "object" || obj === null) {
+    throw new Error("The 'obj' parameter is not an object");
+  }
+
+  if (keep !== undefined && !Array.isArray(keep)) {
+    throw new Error("The 'keep' parameter is not an array");
+  }
+
+  const result: Partial<T> = {};
+  const keys = Object.keys(obj) as (keyof T & string)[];
+  const hasKeep = keep !== undefined && keep.length > 0;
+
+  for (let i = 0; i < keys.length; i++) {
+    const key = keys[i];
+    if (UNSAFE_KEYS.has(key)) continue;
+    const value = obj[key];
+    if (value) {
+      result[key] = value;
+      continue;
+    }
+    if (hasKeep && keep.some((k) => Object.is(k, value))) {
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+export { compact };

--- a/src/objects/compact/index.ts
+++ b/src/objects/compact/index.ts
@@ -6,9 +6,13 @@ const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
  * Creates a new object with all falsy values removed.
  * Falsy values are `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`.
  * Pass `keep` to preserve specific falsy values (matched via `Object.is`).
+ * Truthy values inside `keep` are no-ops (truthy entries are always preserved).
+ *
+ * Only string-keyed enumerable own properties are considered.
+ * Symbol-keyed properties are ignored (use `Reflect.ownKeys` if needed).
  *
  * @param params - The parameters object
- * @param params.obj - The source object
+ * @param params.obj - The source object (must be a plain object, not an array)
  * @param params.keep - Optional array of falsy values to preserve
  * @returns A new object without falsy entries (except those in `keep`)
  *
@@ -24,6 +28,7 @@ const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
  * @keywords remove falsy, clean object, drop empty, prune null, compact object
  *
  * @throws Error if `obj` is not an object
+ * @throws Error if `obj` is an array
  * @throws Error if `keep` is not an array
  */
 function compact<T extends Record<string, unknown>>({
@@ -32,6 +37,10 @@ function compact<T extends Record<string, unknown>>({
 }: CompactParams<T>): Partial<T> {
   if (typeof obj !== "object" || obj === null) {
     throw new Error("The 'obj' parameter is not an object");
+  }
+
+  if (Array.isArray(obj)) {
+    throw new Error("The 'obj' parameter must not be an array");
   }
 
   if (keep !== undefined && !Array.isArray(keep)) {

--- a/src/objects/compact/types.ts
+++ b/src/objects/compact/types.ts
@@ -1,0 +1,10 @@
+interface CompactParams<T extends Record<string, unknown>> {
+  obj: T;
+  keep?: unknown[];
+}
+
+type CompactFn<T extends Record<string, unknown>> = (
+  params: CompactParams<T>,
+) => Partial<T>;
+
+export type { CompactFn, CompactParams };

--- a/website/src/content/docs/objects/compact.mdx
+++ b/website/src/content/docs/objects/compact.mdx
@@ -52,8 +52,11 @@ compact({ obj: { a: NaN, b: 1 }, keep: [NaN] });
 ## Edge Cases
 
 - Throws if `obj` is not an object.
+- Throws if `obj` is an array (use `.filter(Boolean)` instead).
 - Throws if `keep` is provided but not an array.
 - Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution.
+- Symbol-keyed properties are ignored (only string-keyed enumerable own properties are processed).
+- Truthy values inside `keep` are no-ops — `keep` is only useful for falsy values you want to preserve.
 - Distinguishes `0` from `-0` via `Object.is`.
 - Does not mutate the original object.
 

--- a/website/src/content/docs/objects/compact.mdx
+++ b/website/src/content/docs/objects/compact.mdx
@@ -1,0 +1,68 @@
+---
+title: compact
+description: Remove falsy values from an object
+---
+
+Creates a new object with all falsy values removed. Pass `keep` to preserve specific falsy values that should survive.
+
+Falsy values are `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`. Matches in `keep` use `Object.is`, so `0` vs `-0` and `NaN` are handled exactly.
+
+## Import
+
+```ts
+import { compact } from "1o1-utils";
+```
+
+```ts
+import { compact } from "1o1-utils/compact";
+```
+
+## Signature
+
+```ts
+function compact<T extends Record<string, unknown>>({ obj, keep }: CompactParams<T>): Partial<T>
+```
+
+## Parameters
+
+| Name   | Type        | Required | Description                                          |
+| ------ | ----------- | -------- | ---------------------------------------------------- |
+| `obj`  | `T`         | Yes      | The source object                                    |
+| `keep` | `unknown[]` | No       | Falsy values to preserve (matched via `Object.is`)   |
+
+## Returns
+
+`Partial<T>` — A new object without falsy entries (except those listed in `keep`).
+
+## Examples
+
+```ts
+compact({ obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" } });
+// => { a: 1, f: "ok" }
+
+// Preserve specific falsy values
+compact({ obj: { a: 0, b: null, c: "" }, keep: [0] });
+// => { a: 0 }
+
+// Match NaN exactly
+compact({ obj: { a: NaN, b: 1 }, keep: [NaN] });
+// => { a: NaN, b: 1 }
+```
+
+## Edge Cases
+
+- Throws if `obj` is not an object.
+- Throws if `keep` is provided but not an array.
+- Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution.
+- Distinguishes `0` from `-0` via `Object.is`.
+- Does not mutate the original object.
+
+## Also known as
+
+remove falsy, clean object, drop empty, prune null
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use compact to strip null/undefined fields from an object before serializing.
+```


### PR DESCRIPTION
## Summary
- Adds `compact` utility under `src/objects/compact/` that removes falsy values (`false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, `NaN`) from an object.
- Optional `keep` array preserves specific falsy values, matched via `Object.is` (handles `0` vs `-0` and `NaN` exactly).
- Skips unsafe keys (`__proto__`, `constructor`, `prototype`) to prevent prototype pollution.
- Closes #81.

## API
```ts
compact({ obj: { a: 1, b: null, c: "", d: 0, e: false, f: "ok" } });
// => { a: 1, f: "ok" }

compact({ obj: { a: 0, b: null, c: "" }, keep: [0] });
// => { a: 0 }
```

## Benchmark (10-key sample object)
| Lib | Latency med | Throughput |
|---|---|---|
| **1o1-utils** | 250 ns | **3.92M ops/s** |
| radash shake | 250 ns | 4.28M ops/s |
| lodash omitBy | 792 ns | 1.25M ops/s |

~3× lodash, paridade com radash. Pequeno overhead vs radash vem do guard de prototype pollution + validação de input + ramo `keep`.

## Size
255 B (limit 1 kB). Total bundle 5.87 / 6 kB.

## Test plan
- [x] `pnpm test --grep compact` — 16/16 passing
- [x] `pnpm test` — 771/771 passing
- [x] `pnpm build`
- [x] `pnpm size` — 255 B
- [x] `pnpm bench compact`