### PR TITLE
feat(async): add waitForCondition utility (#76)

### DIFF
--- a/.changeset/add-wait-for-condition.md
+++ b/.changeset/add-wait-for-condition.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `waitForCondition` utility under the `async` category. `waitForCondition({ condition, interval, timeout, message?, signal? })` polls a sync or async predicate at the given `interval` (default 100ms) until it returns truthy, rejecting with `TimeoutError` after `timeout` ms (default 5000). Errors thrown or rejected by `condition` propagate immediately without further polling. Optional `AbortSignal` cancels externally; `message` is a string or lazy factory only invoked on timeout. Reuses `TimeoutError` from `withTimeout` so consumers can catch both with a single `instanceof` check. Closes #76.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -151,6 +151,11 @@
     "limit": "1 kB"
   },
   {
+    "name": "wait-for-condition",
+    "path": "dist/async/wait-for-condition/index.js",
+    "limit": "1 kB"
+  },
+  {
     "name": "once",
     "path": "dist/functions/once/index.js",
     "limit": "1 kB"

--- a/package.json
+++ b/package.json
@@ -227,6 +227,10 @@
       "import": "./dist/async/with-timeout/index.js",
       "types": "./dist/async/with-timeout/index.d.ts"
     },
+    "./wait-for-condition": {
+      "import": "./dist/async/wait-for-condition/index.js",
+      "types": "./dist/async/wait-for-condition/index.d.ts"
+    },
     "./once": {
       "import": "./dist/functions/once/index.js",
       "types": "./dist/functions/once/index.d.ts"

--- a/src/async/wait-for-condition/index.bench.ts
+++ b/src/async/wait-for-condition/index.bench.ts
@@ -1,0 +1,21 @@
+import { Bench } from "tinybench";
+import { waitForCondition } from "./index.js";
+
+const bench = new Bench({ name: "waitForCondition", time: 500 });
+
+bench
+  .add("1o1-utils (resolves immediately)", async () => {
+    await waitForCondition({
+      condition: () => true,
+      interval: 10,
+      timeout: 1000,
+    });
+  })
+  .add("naive while-sleep loop (resolves immediately)", async () => {
+    const cond = () => true;
+    while (!cond()) {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+  });
+
+export { bench };

--- a/src/async/wait-for-condition/index.spec.ts
+++ b/src/async/wait-for-condition/index.spec.ts
@@ -1,0 +1,313 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { TimeoutError } from "../with-timeout/index.js";
+import { waitForCondition } from "./index.js";
+
+describe("waitForCondition", () => {
+  it("should resolve immediately when condition is true on first call", async () => {
+    let calls = 0;
+    await waitForCondition({
+      condition: () => {
+        calls++;
+        return true;
+      },
+      interval: 10,
+      timeout: 100,
+    });
+    expect(calls).to.equal(1);
+  });
+
+  it("should resolve after the condition becomes true", async () => {
+    let calls = 0;
+    await waitForCondition({
+      condition: () => {
+        calls++;
+        return calls >= 3;
+      },
+      interval: 5,
+      timeout: 200,
+    });
+    expect(calls).to.equal(3);
+  });
+
+  it("should support async conditions", async () => {
+    let calls = 0;
+    await waitForCondition({
+      condition: async () => {
+        calls++;
+        return calls >= 2;
+      },
+      interval: 5,
+      timeout: 200,
+    });
+    expect(calls).to.equal(2);
+  });
+
+  it("should reject with TimeoutError when condition stays falsy", async () => {
+    try {
+      await waitForCondition({
+        condition: () => false,
+        interval: 5,
+        timeout: 20,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(TimeoutError);
+      expect(error).to.be.instanceOf(Error);
+      expect((error as TimeoutError).name).to.equal("TimeoutError");
+      expect((error as TimeoutError).message).to.equal(
+        "Condition not met within 20ms",
+      );
+    }
+  });
+
+  it("should use a custom string message on timeout", async () => {
+    try {
+      await waitForCondition({
+        condition: () => false,
+        interval: 5,
+        timeout: 10,
+        message: "element never appeared",
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as TimeoutError).message).to.equal(
+        "element never appeared",
+      );
+    }
+  });
+
+  it("should invoke a lazy message function only on timeout", async () => {
+    let calls = 0;
+    const factory = () => {
+      calls++;
+      return "lazy";
+    };
+
+    await waitForCondition({
+      condition: () => true,
+      interval: 5,
+      timeout: 50,
+      message: factory,
+    });
+    expect(calls).to.equal(0);
+
+    try {
+      await waitForCondition({
+        condition: () => false,
+        interval: 5,
+        timeout: 10,
+        message: factory,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(calls).to.equal(1);
+      expect((error as TimeoutError).message).to.equal("lazy");
+    }
+  });
+
+  it("should propagate a synchronous error from condition", async () => {
+    const original = new Error("boom");
+    let calls = 0;
+    try {
+      await waitForCondition({
+        condition: () => {
+          calls++;
+          throw original;
+        },
+        interval: 5,
+        timeout: 100,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.equal(original);
+      expect(calls).to.equal(1);
+    }
+  });
+
+  it("should propagate an async rejection from condition", async () => {
+    const original = new Error("async boom");
+    try {
+      await waitForCondition({
+        condition: async () => {
+          throw original;
+        },
+        interval: 5,
+        timeout: 100,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.equal(original);
+    }
+  });
+
+  it("should reject immediately if signal is already aborted", async () => {
+    const controller = new AbortController();
+    const reason = new Error("already aborted");
+    controller.abort(reason);
+
+    let calls = 0;
+    try {
+      await waitForCondition({
+        condition: () => {
+          calls++;
+          return false;
+        },
+        interval: 5,
+        timeout: 100,
+        signal: controller.signal,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.equal(reason);
+      expect(calls).to.equal(0);
+    }
+  });
+
+  it("should reject with signal.reason when aborted during polling", async () => {
+    const controller = new AbortController();
+    const reason = new Error("aborted mid-flight");
+
+    setTimeout(() => controller.abort(reason), 10);
+
+    try {
+      await waitForCondition({
+        condition: () => false,
+        interval: 5,
+        timeout: 200,
+        signal: controller.signal,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.equal(reason);
+    }
+  });
+
+  it("should reject if condition is not a function", async () => {
+    try {
+      // @ts-expect-error - testing invalid input
+      await waitForCondition({ condition: 42 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'condition' parameter must be a function",
+      );
+    }
+  });
+
+  it("should reject if interval is not a number", async () => {
+    try {
+      await waitForCondition({
+        condition: () => true,
+        // @ts-expect-error - testing invalid input
+        interval: "100",
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'interval' parameter must be a number",
+      );
+    }
+  });
+
+  it("should reject if interval is NaN", async () => {
+    try {
+      await waitForCondition({
+        condition: () => true,
+        interval: Number.NaN,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'interval' parameter must be a number",
+      );
+    }
+  });
+
+  it("should reject if interval is negative", async () => {
+    try {
+      await waitForCondition({ condition: () => true, interval: -1 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'interval' parameter must be a non-negative number",
+      );
+    }
+  });
+
+  it("should reject if timeout is not a number", async () => {
+    try {
+      await waitForCondition({
+        condition: () => true,
+        // @ts-expect-error - testing invalid input
+        timeout: "100",
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'timeout' parameter must be a number",
+      );
+    }
+  });
+
+  it("should reject if timeout is NaN", async () => {
+    try {
+      await waitForCondition({
+        condition: () => true,
+        timeout: Number.NaN,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'timeout' parameter must be a number",
+      );
+    }
+  });
+
+  it("should reject if timeout is negative", async () => {
+    try {
+      await waitForCondition({ condition: () => true, timeout: -1 });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'timeout' parameter must be a non-negative number",
+      );
+    }
+  });
+
+  it("should reject if signal is not an AbortSignal", async () => {
+    try {
+      await waitForCondition({
+        condition: () => true,
+        // @ts-expect-error - testing invalid input
+        signal: {},
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'signal' parameter must be an AbortSignal",
+      );
+    }
+  });
+
+  it("should resolve when timeout is 0 and initial check is truthy", async () => {
+    await waitForCondition({
+      condition: () => true,
+      interval: 5,
+      timeout: 0,
+    });
+  });
+
+  it("should reject with TimeoutError when timeout is 0 and initial check is falsy", async () => {
+    try {
+      await waitForCondition({
+        condition: () => false,
+        interval: 5,
+        timeout: 0,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(TimeoutError);
+    }
+  });
+});

--- a/src/async/wait-for-condition/index.spec.ts
+++ b/src/async/wait-for-condition/index.spec.ts
@@ -310,4 +310,29 @@ describe("waitForCondition", () => {
       expect(error).to.be.instanceOf(TimeoutError);
     }
   });
+
+  it("should not emit unhandledRejection when condition rejects after timeout wins", async () => {
+    const captured: unknown[] = [];
+    const listener = (reason: unknown) => captured.push(reason);
+    process.on("unhandledRejection", listener);
+
+    try {
+      await waitForCondition({
+        condition: () =>
+          new Promise((_, reject) =>
+            setTimeout(() => reject(new Error("late condition")), 50),
+          ),
+        interval: 100,
+        timeout: 10,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect(error).to.be.instanceOf(TimeoutError);
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    process.off("unhandledRejection", listener);
+
+    expect(captured).to.have.length(0);
+  });
 });

--- a/src/async/wait-for-condition/index.ts
+++ b/src/async/wait-for-condition/index.ts
@@ -1,0 +1,107 @@
+import { TimeoutError } from "../with-timeout/index.js";
+import type { WaitForConditionParams } from "./types.js";
+
+/**
+ * Polls a condition function at a given interval until it returns truthy or
+ * the timeout elapses. Supports sync and async predicates, and an optional
+ * AbortSignal for external cancellation.
+ *
+ * @param params - The parameters object
+ * @param params.condition - Sync or async function returning a boolean
+ * @param params.interval - Polling interval in milliseconds (default: 100)
+ * @param params.timeout - Maximum total wait in milliseconds (default: 5000)
+ * @param params.message - Error message or lazy factory (default: `Condition not met within {timeout}ms`)
+ * @param params.signal - Optional AbortSignal; rejects with `signal.reason` when aborted
+ * @returns A promise that resolves when the condition is truthy
+ *
+ * @example
+ * ```ts
+ * await waitForCondition({
+ *   condition: () => document.querySelector("#app") !== null,
+ *   interval: 100,
+ *   timeout: 5000,
+ * });
+ * ```
+ *
+ * @keywords poll, wait until, busy wait, await condition, retry until true
+ *
+ * @throws Error if `condition` is not a function
+ * @throws Error if `interval` is not a non-negative number
+ * @throws Error if `timeout` is not a non-negative number
+ * @throws Error if `signal` is not an AbortSignal
+ * @throws TimeoutError if `timeout` elapses before the condition is met
+ */
+async function waitForCondition({
+  condition,
+  interval = 100,
+  timeout = 5000,
+  message,
+  signal,
+}: WaitForConditionParams): Promise<void> {
+  if (typeof condition !== "function") {
+    throw new Error("The 'condition' parameter must be a function");
+  }
+
+  if (typeof interval !== "number" || Number.isNaN(interval)) {
+    throw new Error("The 'interval' parameter must be a number");
+  }
+
+  if (interval < 0) {
+    throw new Error("The 'interval' parameter must be a non-negative number");
+  }
+
+  if (typeof timeout !== "number" || Number.isNaN(timeout)) {
+    throw new Error("The 'timeout' parameter must be a number");
+  }
+
+  if (timeout < 0) {
+    throw new Error("The 'timeout' parameter must be a non-negative number");
+  }
+
+  if (signal !== undefined && !(signal instanceof AbortSignal)) {
+    throw new Error("The 'signal' parameter must be an AbortSignal");
+  }
+
+  if (signal?.aborted) {
+    throw signal.reason;
+  }
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onAbort: (() => void) | undefined;
+
+  const cancel = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => {
+      const msg =
+        typeof message === "function"
+          ? message()
+          : (message ?? `Condition not met within ${timeout}ms`);
+      reject(new TimeoutError(msg));
+    }, timeout);
+
+    if (signal) {
+      onAbort = () => reject(signal.reason);
+      signal.addEventListener("abort", onAbort, { once: true });
+    }
+  });
+
+  cancel.catch(() => {});
+
+  try {
+    while (true) {
+      const result = await Promise.race([
+        Promise.resolve().then(() => condition()),
+        cancel,
+      ]);
+      if (result) return;
+      await Promise.race([
+        new Promise<void>((resolve) => setTimeout(resolve, interval)),
+        cancel,
+      ]);
+    }
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+    if (signal && onAbort) signal.removeEventListener("abort", onAbort);
+  }
+}
+
+export { waitForCondition };

--- a/src/async/wait-for-condition/index.ts
+++ b/src/async/wait-for-condition/index.ts
@@ -84,17 +84,21 @@ async function waitForCondition({
     }
   });
 
-  cancel.catch(() => {});
+  const deadline = Date.now() + timeout;
 
   try {
     while (true) {
-      const result = await Promise.race([
-        Promise.resolve().then(() => condition()),
-        cancel,
-      ]);
+      const condPromise = Promise.resolve().then(() => condition());
+      condPromise.catch(() => {});
+      const result = await Promise.race([condPromise, cancel]);
       if (result) return;
+      const remaining = deadline - Date.now();
+      if (remaining <= 0) {
+        await cancel;
+      }
+      const wait = Math.min(interval, remaining);
       await Promise.race([
-        new Promise<void>((resolve) => setTimeout(resolve, interval)),
+        new Promise<void>((resolve) => setTimeout(resolve, wait)),
         cancel,
       ]);
     }

--- a/src/async/wait-for-condition/types.ts
+++ b/src/async/wait-for-condition/types.ts
@@ -1,0 +1,19 @@
+interface WaitForConditionParams {
+  condition: () => boolean | Promise<boolean>;
+  interval?: number;
+  timeout?: number;
+  message?: string | (() => string);
+  signal?: AbortSignal;
+}
+
+type WaitForConditionResult = Promise<void>;
+
+type WaitForConditionFn = (
+  params: WaitForConditionParams,
+) => WaitForConditionResult;
+
+export type {
+  WaitForConditionFn,
+  WaitForConditionParams,
+  WaitForConditionResult,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ export { retry } from "./async/retry/index.js";
 export { safely } from "./async/safely/index.js";
 export { sleep } from "./async/sleep/index.js";
 export { throttle } from "./async/throttle/index.js";
+export { waitForCondition } from "./async/wait-for-condition/index.js";
 export { withTimeout } from "./async/with-timeout/index.js";
 export { deepEqual } from "./comparisons/deep-equal/index.js";
 export { isNil } from "./comparisons/is-nil/index.js";

--- a/website/src/content/docs/async/wait-for-condition.mdx
+++ b/website/src/content/docs/async/wait-for-condition.mdx
@@ -1,0 +1,93 @@
+---
+title: waitForCondition
+description: Poll a sync or async predicate until truthy, rejecting on timeout
+---
+
+Polls a `condition` function at a given `interval` until it returns truthy or the `timeout` elapses. Supports synchronous and asynchronous predicates, an optional `AbortSignal`, and a custom timeout `message`. Rejects with `TimeoutError` (the same class exported by [`withTimeout`](/async/with-timeout)) on timeout, so a single `instanceof` check covers both utilities.
+
+## Import
+
+```ts
+import { waitForCondition } from "1o1-utils";
+```
+
+```ts
+import { waitForCondition } from "1o1-utils/wait-for-condition";
+import { TimeoutError } from "1o1-utils/with-timeout";
+```
+
+## Signature
+
+```ts
+function waitForCondition({
+  condition,
+  interval,
+  timeout,
+  message,
+  signal,
+}: WaitForConditionParams): Promise<void>
+```
+
+## Parameters
+
+| Name      | Type                                | Required | Description                                                                  |
+| --------- | ----------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| condition | `() => boolean \| Promise<boolean>` | Yes      | Predicate evaluated on each poll. Truthy return resolves; throws propagate. |
+| interval  | `number`                            | No       | Polling interval in milliseconds (default: `100`)                            |
+| timeout   | `number`                            | No       | Maximum total wait in milliseconds (default: `5000`)                         |
+| message   | `string \| (() => string)`          | No       | Error message or lazy factory. Default: `Condition not met within {timeout}ms` |
+| signal    | `AbortSignal`                       | No       | Rejects with `signal.reason` when aborted                                    |
+
+## Returns
+
+`Promise<void>` — resolves when the condition is truthy, rejects with `TimeoutError` on timeout, or with `signal.reason` if aborted.
+
+## Examples
+
+```ts
+await waitForCondition({
+  condition: () => document.querySelector("#app") !== null,
+  interval: 100,
+  timeout: 5000,
+});
+```
+
+```ts
+await waitForCondition({
+  condition: async () => {
+    const res = await fetch("/api/health");
+    return res.ok;
+  },
+  interval: 500,
+  timeout: 30_000,
+  message: "service never became healthy",
+});
+```
+
+```ts
+const controller = new AbortController();
+const task = waitForCondition({
+  condition: () => isReady(),
+  signal: controller.signal,
+});
+controller.abort(); // rejects with signal.reason
+```
+
+## Edge Cases
+
+- Rejects synchronously-thrown errors and async rejections from `condition` without further polling.
+- If `signal` is already aborted, rejects immediately with `signal.reason` and never calls `condition`.
+- The `message` factory is invoked lazily — only when the timeout fires.
+- Internal timer and abort listener are cleaned up after settle.
+- `timeout: 0` rejects unless the initial check is truthy.
+- Validation errors (non-function `condition`, NaN/negative `interval` or `timeout`, non-`AbortSignal` `signal`) reject the returned promise.
+
+## Also known as
+
+poll, wait until, busy wait, await condition, retry until true
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use waitForCondition to poll for a DOM element with a 5 second timeout.
+```


### PR DESCRIPTION
## Summary

- Adds `waitForCondition({ condition, interval?, timeout?, message?, signal? })` under `async/`. Polls a sync or async predicate at `interval` (default 100ms) until truthy, rejecting with `TimeoutError` after `timeout` ms (default 5000).
- Reuses `TimeoutError` from `withTimeout` so a single `instanceof` check covers both utilities. Errors thrown/rejected by `condition` propagate immediately. `AbortSignal` cancels externally; `message` supports a lazy factory invoked only on timeout.
- Standard utility wiring: subpath export `./wait-for-condition`, `.size-limit.json` entry (1 kB cap; current build 442 B), changeset (minor), Starlight doc page (sidebar auto-generated).

Closes #76.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 20 new specs + 874 total pass
- [x] `npm run size` — wait-for-condition 442 B / 1 kB
- [x] `npx biome check ./src/async/wait-for-condition` clean