### PR TITLE
feat(arrays): add replace utility

### DIFF
--- a/.changeset/add-array-replace.md
+++ b/.changeset/add-array-replace.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": minor
+---
+
+Add `replace` utility for replacing element(s) in an array by predicate. Returns a new array (non-mutating). Replaces only the first match by default; pass `all: true` to replace every match. Accepts a static value or an updater function `(item, index) => newItem`.

--- a/.size-limit.json
+++ b/.size-limit.json
@@ -229,5 +229,10 @@
     "name": "partition",
     "path": "dist/arrays/partition/index.js",
     "limit": "1 kB"
+  },
+  {
+    "name": "replace",
+    "path": "dist/arrays/replace/index.js",
+    "limit": "1 kB"
   }
 ]

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -152,6 +152,35 @@ Throws: Error if array is not an array. Error if predicate is not a function.
 
 ---
 
+### replace
+
+Replace element(s) in an array by predicate. Returns a new array; the input is never mutated. Replaces only the first match by default; pass `all: true` to replace every match. `value` accepts a static value or an updater function `(item, index) => newItem`.
+
+Import: import { replace } from "1o1-utils/replace";
+
+Signature:
+function replace<T>({ array, predicate, value, all }: { array: T[]; predicate: (item: T, index: number) => boolean; value: T | ((item: T, index: number) => T); all?: boolean }): T[];
+
+Parameters:
+- array (T[], required): The source array
+- predicate ((item: T, index: number) => boolean, required): Function called for every element until a match (or for all elements when `all` is true)
+- value (T | (item: T, index: number) => T, required): Replacement value, or updater fn that derives the new value from the matched item
+- all (boolean, optional): When true, replace every match. Defaults to false (first match only).
+
+Returns: T[] — A new array with matched item(s) replaced.
+
+Example:
+const users = [{ id: 1, name: "Ana" }, { id: 2, name: "Bob" }];
+replace({ array: users, predicate: (u) => u.id === 2, value: { id: 2, name: "Bobby" } });
+// => [{ id: 1, name: "Ana" }, { id: 2, name: "Bobby" }]
+
+replace({ array: [1, 2, 3, 2], predicate: (n) => n === 2, value: (n) => n * 10, all: true });
+// => [1, 20, 3, 20]
+
+Throws: Error if array is not an array. Error if predicate is not a function. Error if value is undefined.
+
+---
+
 ### shuffle
 
 Randomly reorder an array using the Fisher-Yates algorithm. Returns a new array; the input is not mutated.

--- a/llms.txt
+++ b/llms.txt
@@ -18,6 +18,7 @@
 - [groupBy](https://pedrotroccoli.github.io/1o1-utils/arrays/group-by/): Group array elements by a property value
 - [partition](https://pedrotroccoli.github.io/1o1-utils/arrays/partition/): Split an array into two groups based on a predicate
 - [range](https://pedrotroccoli.github.io/1o1-utils/arrays/range/): Generate an array of numbers in a given range with optional start and step
+- [replace](https://pedrotroccoli.github.io/1o1-utils/arrays/replace/): Replace element(s) in an array by predicate, with optional updater function
 - [shuffle](https://pedrotroccoli.github.io/1o1-utils/arrays/shuffle/): Randomly reorder an array using Fisher-Yates, with an optional injectable random source
 - [sortBy](https://pedrotroccoli.github.io/1o1-utils/arrays/sort-by/): Sort an array of objects by a property with dot notation support
 - [times](https://pedrotroccoli.github.io/1o1-utils/arrays/times/): Invoke a function N times with the current index and collect the results

--- a/package.json
+++ b/package.json
@@ -88,7 +88,10 @@
     "ttl-cache",
     "compact",
     "remove-falsy",
-    "clean-object"
+    "clean-object",
+    "replace",
+    "swap",
+    "update-array"
   ],
   "author": "Pedro Troccoli <contact@pedrotroccoli.com>",
   "license": "MIT",
@@ -302,6 +305,10 @@
     "./memo": {
       "import": "./dist/functions/memo/index.js",
       "types": "./dist/functions/memo/index.d.ts"
+    },
+    "./replace": {
+      "import": "./dist/arrays/replace/index.js",
+      "types": "./dist/arrays/replace/index.d.ts"
     }
   },
   "scripts": {

--- a/src/arrays/replace/index.bench.ts
+++ b/src/arrays/replace/index.bench.ts
@@ -1,0 +1,45 @@
+import { Bench } from "tinybench";
+import { getDatasets, type User } from "../../benchmarks/helpers.js";
+import { replace } from "./index.js";
+
+const bench = new Bench({ name: "replace (by id)", time: 1000 });
+
+for (const { name, data: getData } of getDatasets()) {
+  const data = getData();
+  const targetId = data[Math.floor(data.length / 2)].id;
+  const isTarget = (u: User) => u.id === targetId;
+  const replacement: User = {
+    id: targetId,
+    name: "Replaced",
+    age: 99,
+    role: "admin",
+    department: "engineering",
+    email: "replaced@example.com",
+  };
+
+  bench
+    .add(`1o1-utils first (${name})`, () => {
+      replace({ array: data, predicate: isTarget, value: replacement });
+    })
+    .add(`1o1-utils all (${name})`, () => {
+      replace({
+        array: data,
+        predicate: isTarget,
+        value: replacement,
+        all: true,
+      });
+    })
+    // Native map ternary — calls predicate once per item, returns new array.
+    .add(`native map ternary (${name})`, () => {
+      data.map((u) => (isTarget(u) ? replacement : u));
+    })
+    // Native single-pass for loop — typical hand-written replace.
+    .add(`native single-pass (${name})`, () => {
+      const out: User[] = new Array(data.length);
+      for (let i = 0; i < data.length; i++) {
+        out[i] = isTarget(data[i]) ? replacement : data[i];
+      }
+    });
+}
+
+export { bench };

--- a/src/arrays/replace/index.spec.ts
+++ b/src/arrays/replace/index.spec.ts
@@ -1,0 +1,144 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { replace } from "./index.js";
+
+describe("replace", () => {
+  it("should replace the first matching item with a static value by default", () => {
+    const users = [
+      { id: 1, name: "Ana" },
+      { id: 2, name: "Bob" },
+    ];
+    expect(
+      replace({
+        array: users,
+        predicate: (u) => u.id === 2,
+        value: { id: 2, name: "Bobby" },
+      }),
+    ).to.deep.equal([
+      { id: 1, name: "Ana" },
+      { id: 2, name: "Bobby" },
+    ]);
+  });
+
+  it("should replace only the first match when multiple match and `all` is false", () => {
+    expect(
+      replace({
+        array: [1, 2, 3, 2, 4],
+        predicate: (n) => n === 2,
+        value: 99,
+      }),
+    ).to.deep.equal([1, 99, 3, 2, 4]);
+  });
+
+  it("should replace every match when `all` is true", () => {
+    expect(
+      replace({
+        array: [1, 2, 3, 2, 4],
+        predicate: (n) => n === 2,
+        value: 99,
+        all: true,
+      }),
+    ).to.deep.equal([1, 99, 3, 99, 4]);
+  });
+
+  it("should accept an updater function and pass (item, index)", () => {
+    const seen: Array<[unknown, number]> = [];
+    const result = replace({
+      array: [10, 20, 30, 20],
+      predicate: (n) => n === 20,
+      value: (item, index) => {
+        seen.push([item, index]);
+        return item + index;
+      },
+      all: true,
+    });
+    expect(result).to.deep.equal([10, 21, 30, 23]);
+    expect(seen).to.deep.equal([
+      [20, 1],
+      [20, 3],
+    ]);
+  });
+
+  it("should pass index to predicate", () => {
+    expect(
+      replace({
+        array: ["a", "b", "c", "d"],
+        predicate: (_, i) => i === 2,
+        value: "X",
+      }),
+    ).to.deep.equal(["a", "b", "X", "d"]);
+  });
+
+  it("should return a shallow copy when no item matches", () => {
+    const input = [1, 2, 3];
+    const out = replace({
+      array: input,
+      predicate: () => false,
+      value: 99,
+    });
+    expect(out).to.deep.equal([1, 2, 3]);
+    expect(out).to.not.equal(input);
+  });
+
+  it("should return an empty array for empty input", () => {
+    expect(
+      replace({ array: [], predicate: () => true, value: 1 }),
+    ).to.deep.equal([]);
+  });
+
+  it("should not mutate the input array", () => {
+    const input = [1, 2, 3];
+    const snapshot = [...input];
+    replace({
+      array: input,
+      predicate: (n) => n === 2,
+      value: 99,
+      all: true,
+    });
+    expect(input).to.deep.equal(snapshot);
+  });
+
+  it("should accept falsy static values like 0, '', null, false", () => {
+    expect(
+      replace({ array: [1, 2, 3], predicate: (n) => n === 2, value: 0 }),
+    ).to.deep.equal([1, 0, 3]);
+    expect(
+      replace({ array: [1, 2, 3], predicate: (n) => n === 2, value: null }),
+    ).to.deep.equal([1, null, 3]);
+  });
+
+  it("should throw an error if array is not an array", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      replace({ array: "abc", predicate: () => true, value: 1 }),
+    ).to.throw("The 'array' parameter is not an array");
+  });
+
+  it("should throw an error if array is null", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      replace({ array: null, predicate: () => true, value: 1 }),
+    ).to.throw("The 'array' parameter is not an array");
+  });
+
+  it("should throw an error if predicate is not a function", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      replace({ array: [1, 2, 3], predicate: "nope", value: 1 }),
+    ).to.throw("The 'predicate' parameter must be a function");
+  });
+
+  it("should throw an error if predicate is undefined", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      replace({ array: [1, 2, 3], value: 1 }),
+    ).to.throw("The 'predicate' parameter must be a function");
+  });
+
+  it("should throw an error if value is undefined", () => {
+    expect(() =>
+      // @ts-expect-error - we want to test the error case
+      replace({ array: [1, 2, 3], predicate: () => true }),
+    ).to.throw("The 'value' parameter is required");
+  });
+});

--- a/src/arrays/replace/index.ts
+++ b/src/arrays/replace/index.ts
@@ -1,0 +1,87 @@
+import type { ReplaceParams, ReplaceResult } from "./types.js";
+
+/**
+ * Replaces element(s) in an array by predicate. Returns a new array; the
+ * input is never mutated. By default, only the first matching item is
+ * replaced; set `all: true` to replace every match.
+ *
+ * `value` accepts either a static replacement or an updater function
+ * `(item, index) => newItem` that derives the new value from the matched
+ * item. When no item matches, a shallow copy of the input is returned.
+ *
+ * @param params - The parameters object
+ * @param params.array - The source array
+ * @param params.predicate - Function called with `(item, index)` returning a boolean
+ * @param params.value - Replacement value, or updater fn `(item, index) => newItem`
+ * @param params.all - When `true`, replace every match; defaults to `false` (first only)
+ * @returns A new array with matched items replaced
+ *
+ * @example
+ * ```ts
+ * const users = [{ id: 1, name: "Ana" }, { id: 2, name: "Bob" }];
+ * replace({
+ *   array: users,
+ *   predicate: (u) => u.id === 2,
+ *   value: { id: 2, name: "Bobby" },
+ * });
+ * // => [{ id: 1, name: "Ana" }, { id: 2, name: "Bobby" }]
+ *
+ * // Updater fn — derive replacement from current item
+ * replace({
+ *   array: [1, 2, 3, 2],
+ *   predicate: (n) => n === 2,
+ *   value: (n) => n * 10,
+ *   all: true,
+ * });
+ * // => [1, 20, 3, 20]
+ * ```
+ *
+ * @keywords replace, set, update, swap, replace-by, splice
+ *
+ * @throws Error if `array` is not an array
+ * @throws Error if `predicate` is not a function
+ * @throws Error if `value` is `undefined`
+ *
+ * @remarks
+ * When `T` itself is a function type, `value` is detected as an updater via
+ * `typeof value === "function"`. Pass an updater that returns the desired
+ * function in that case.
+ */
+function replace<T>({
+  array,
+  predicate,
+  value,
+  all = false,
+}: ReplaceParams<T>): ReplaceResult<T> {
+  if (!Array.isArray(array)) {
+    throw new Error("The 'array' parameter is not an array");
+  }
+
+  if (typeof predicate !== "function") {
+    throw new Error("The 'predicate' parameter must be a function");
+  }
+
+  if (value === undefined) {
+    throw new Error("The 'value' parameter is required");
+  }
+
+  const isUpdater = typeof value === "function";
+  const result: T[] = new Array(array.length);
+  let replaced = false;
+
+  for (let i = 0; i < array.length; i++) {
+    const item = array[i];
+    if ((all || !replaced) && predicate(item, i)) {
+      result[i] = isUpdater
+        ? (value as (item: T, index: number) => T)(item, i)
+        : (value as T);
+      replaced = true;
+    } else {
+      result[i] = item;
+    }
+  }
+
+  return result;
+}
+
+export { replace };

--- a/src/arrays/replace/types.ts
+++ b/src/arrays/replace/types.ts
@@ -1,0 +1,14 @@
+type ReplaceUpdater<T> = (item: T, index: number) => T;
+
+interface ReplaceParams<T> {
+  array: T[];
+  predicate: (item: T, index: number) => boolean;
+  value: T | ReplaceUpdater<T>;
+  all?: boolean;
+}
+
+type ReplaceResult<T> = T[];
+
+type Replace = <T>(params: ReplaceParams<T>) => ReplaceResult<T>;
+
+export type { Replace, ReplaceParams, ReplaceResult, ReplaceUpdater };

--- a/src/benchmarks/run.ts
+++ b/src/benchmarks/run.ts
@@ -233,6 +233,11 @@ const SUITE_META: Record<string, { slug: string; description: string }> = {
     description:
       "Splits an array into two groups based on a predicate. Compared against `lodash.partition`, a native two-`filter` approach, and a native single-pass loop.",
   },
+  "replace (by id)": {
+    slug: "replace",
+    description:
+      "Replaces element(s) in an array by predicate, returning a new array. Compared against a native `map` ternary and a native single-pass `for` loop. Both first-match (default) and `all: true` modes are benchmarked.",
+  },
 };
 
 function getSizes(rows: TaskRow[]): string[] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ export { diff } from "./arrays/diff/index.js";
 export { groupBy } from "./arrays/group-by/index.js";
 export { partition } from "./arrays/partition/index.js";
 export { range } from "./arrays/range/index.js";
+export { replace } from "./arrays/replace/index.js";
 export { shuffle } from "./arrays/shuffle/index.js";
 export { sortBy } from "./arrays/sort-by/index.js";
 export { times } from "./arrays/times/index.js";

--- a/website/src/content/docs/arrays/replace.mdx
+++ b/website/src/content/docs/arrays/replace.mdx
@@ -1,0 +1,101 @@
+---
+title: replace
+description: Replace element(s) in an array by predicate, with optional updater function
+---
+
+Replaces element(s) in an array by predicate. Returns a new array — the input is never mutated. By default, only the first matching item is replaced; pass `all: true` to replace every match. `value` accepts either a static replacement or an updater function `(item, index) => newItem` that derives the new value from the matched item.
+
+## Import
+
+```ts
+import { replace } from "1o1-utils";
+```
+
+```ts
+import { replace } from "1o1-utils/replace";
+```
+
+## Signature
+
+```ts
+function replace<T>(params: {
+  array: T[];
+  predicate: (item: T, index: number) => boolean;
+  value: T | ((item: T, index: number) => T);
+  all?: boolean;
+}): T[];
+```
+
+## Parameters
+
+| Name      | Type                                            | Required | Description                                                                  |
+| --------- | ----------------------------------------------- | -------- | ---------------------------------------------------------------------------- |
+| array     | `T[]`                                           | Yes      | The source array                                                             |
+| predicate | `(item: T, index: number) => boolean`           | Yes      | Predicate called with `(item, index)` to identify matches                    |
+| value     | `T \| ((item: T, index: number) => T)`          | Yes      | Static replacement, or updater fn that derives the new value from the match  |
+| all       | `boolean`                                       | No       | When `true`, replace every match. Defaults to `false` (first match only).    |
+
+## Returns
+
+`T[]` — A new array with matched item(s) replaced. When no item matches, a shallow copy of the input is returned.
+
+## Examples
+
+```ts
+const users = [
+  { id: 1, name: "Ana" },
+  { id: 2, name: "Bob" },
+];
+
+replace({
+  array: users,
+  predicate: (u) => u.id === 2,
+  value: { id: 2, name: "Bobby" },
+});
+// => [{ id: 1, name: "Ana" }, { id: 2, name: "Bobby" }]
+```
+
+Replace every match with `all: true`:
+
+```ts
+replace({
+  array: [1, 2, 3, 2, 4],
+  predicate: (n) => n === 2,
+  value: 99,
+  all: true,
+});
+// => [1, 99, 3, 99, 4]
+```
+
+Updater function — derive the new value from the matched item:
+
+```ts
+replace({
+  array: [10, 20, 30, 20],
+  predicate: (n) => n === 20,
+  value: (item, index) => item + index,
+  all: true,
+});
+// => [10, 21, 30, 23]
+```
+
+## Edge Cases
+
+- Returns a shallow copy when no item matches the predicate.
+- Returns `[]` for an empty input array.
+- Does not mutate the input array.
+- The predicate receives `(item, index)`, matching the signature of `Array.prototype.filter`.
+- When `T` itself is a function type, `value` is detected as an updater via `typeof value === "function"`. Use an updater that returns the desired function in that case.
+- Throws if `array` is not an array.
+- Throws if `predicate` is not a function.
+- Throws if `value` is `undefined`.
+
+## Also known as
+
+replace, set, update, swap, replace-by, splice
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use replace to replace an element in an array by predicate.
+```


### PR DESCRIPTION
## Summary

- Add `replace` utility in `arrays/` — replaces element(s) in array by predicate, returns new array (non-mutating).
- Default replaces only first match; `all: true` replaces every match.
- `value` accepts static value OR updater fn `(item, index) => newItem`.

## API

```ts
replace<T>({
  array: T[],
  predicate: (item: T, index: number) => boolean,
  value: T | ((item: T, index: number) => T),
  all?: boolean, // default false
}): T[]
```

## Performance

`first` mode 1.5-2× faster than native `map` ternary across all dataset sizes (n=100 to n=10M); short-circuit after first match. `all` mode on par with hand-rolled single-pass loop.

Bundle size: 234 B brotlied (limit 1 kB).

## Test plan

- [x] `pnpm check:fix`
- [x] `pnpm test` — 14 specs covering first-match default, `all: true`, updater fn, no-match returns copy, no mutation, empty array, falsy values, all error paths
- [x] `pnpm build`
- [x] `pnpm size`
- [x] `pnpm bench replace` (full, n=100 → n=10M)

Closes #80