### PR TITLE
feat(website): interactive playground + complete utility docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -149,7 +149,75 @@ Add the new utility to both files at the root of the repository:
 
 These files are symlinked into `website/public/` and served on the docs site for AI tool discoverability.
 
-### 7. Create a changeset
+### 7. Add a playground example
+
+The docs site ships an interactive playground (`/playground/`) plus a per-utility `## Try it` block embedded on every utility page. Both are powered by the same Sandpack-based component. Adding a new utility means contributing one example.
+
+#### 7a. Register the example
+
+Edit `website/src/content/examples/index.ts` and append an `Example` entry to the `EXAMPLES` array:
+
+```ts
+{
+  id: "my-util",          // kebab-case, must match the doc page slug
+  label: "myUtil",        // shown in the playground selector
+  category: "Arrays",     // Arrays | Objects | Numbers | Strings | Async | Validators | Comparisons | Functions
+  code: `import { myUtil } from "1o1-utils/my-util";
+
+const result = myUtil({ /* params */ });
+
+console.log(result);
+`,
+},
+```
+
+Guidelines for the snippet:
+
+- Use the **published API** (object-param form), not internals.
+- Keep it under ~15 lines so it fits the editor without scrolling.
+- Print output via `console.log` — the playground console panel renders it.
+- Avoid `import` from the bare `1o1-utils` entry; use the per-utility subpath (`1o1-utils/my-util`) so users see the tree-shakeable import.
+- Use `await` at the top level for async utilities (Sandpack's `vanilla-ts` template supports it).
+
+#### 7b. Embed the playground in the doc page
+
+Add the import + a `## Try it` section near the top of `website/src/content/docs/<category>/<my-util>.mdx`, right after the frontmatter and the one-line summary:
+
+```mdx
+---
+title: myUtil
+description: Brief description
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Brief one-paragraph summary of what the utility does.
+
+## Try it
+
+<Playground client:only="react" utilityId="my-util" />
+
+## Import
+...
+```
+
+The `utilityId` value **must** match the `id` in `EXAMPLES`. The path `../../../components/Playground.tsx` is correct for any `docs/<category>/<file>.mdx` page.
+
+#### 7c. Verify locally
+
+```bash
+pnpm docs:dev
+```
+
+Open `http://localhost:4321/1o1-utils/<category>/<my-util>/` and confirm the playground:
+
+1. Loads (Sandpack fetches `1o1-utils` from the CDN — first load takes a few seconds).
+2. Runs the snippet without throwing.
+3. Prints the expected output to the console panel.
+
+Also check `/playground/` — your example should appear in the selector under its category.
+
+### 8. Create a changeset
 
 ```bash
 pnpm changeset
@@ -239,6 +307,9 @@ Each utility must stay under its size limit (1-2 kB gzipped). Run `pnpm size` to
 - [ ] Export entry added to `package.json`
 - [ ] Size-limit entry added to `.size-limit.json`
 - [ ] Utility added to `llms.txt` and `llms-full.txt`
+- [ ] Playground example added to `website/src/content/examples/index.ts`
+- [ ] `## Try it` block with `<Playground utilityId="..." />` embedded in the docs page
+- [ ] Playground verified locally via `pnpm docs:dev`
 - [ ] `@keywords` added to JSDoc
 - [ ] `@see` RFC/standard reference added (if applicable)
 - [ ] "Also known as" section added to docs page

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center">
   <img src="https://raw.githubusercontent.com/pedrotroccoli/1o1-utils/main/website/public/logo.png" alt="1o1-utils logo" width="240">
   <h1 align="center">1o1-utils</h1>
-  <p align="center">Lightweight, fastest, tree-shakeable TypeScript utilities. 2 kB gzipped.</p>
+  <p align="center">Lightweight, tree-shakeable, zero-dependency TypeScript utilities. Pay only for what you import.</p>
 </p>
 
 <p align="center">
@@ -16,10 +16,12 @@
 
 ## Features
 
-- **Tree-shakeable** — import only what you use, each utility is independently importable
-- **Zero dependencies** — no bloat, no supply-chain risk
-- **TypeScript-first** — full type inference out of the box
-- **Benchmarked** — tested against lodash, radash, and native JS — up to 11× faster
+- **Tree-shakeable** — every utility ships from its own subpath; bundlers drop everything you don't import.
+- **Zero dependencies** — no transitive bloat, no supply-chain risk.
+- **TypeScript-first** — full type inference and strict null safety out of the box.
+- **Tiny per-utility footprint** — most utilities are **150–500 B brotlied**; the largest is ~1.2 kB.
+- **Benchmarked** — measured against lodash, radash, es-toolkit, and native JavaScript — up to 11× faster on the slowest competitor.
+- **Interactive playground** — every utility has a "Try it" block on its docs page that runs `1o1-utils` directly from npm.
 
 ## Install
 
@@ -58,35 +60,53 @@ import { pick } from "1o1-utils/pick";
 | --- | --- | --- |
 | `arrayToHash` | Convert an array to a keyed object | `1o1-utils/array-to-hash` |
 | `chunk` | Split an array into fixed-size chunks | `1o1-utils/chunk` |
+| `diff` | Elements in array A not in array B | `1o1-utils/diff` |
 | `groupBy` | Group array items by a key | `1o1-utils/group-by` |
+| `partition` | Split into `[matches, rest]` by predicate | `1o1-utils/partition` |
+| `range` | Generate a numeric range as an array | `1o1-utils/range` |
+| `replace` | Replace element(s) by predicate (immutable) | `1o1-utils/replace` |
+| `shuffle` | Fisher-Yates shuffle (non-mutating) | `1o1-utils/shuffle` |
 | `sortBy` | Sort an array by a key | `1o1-utils/sort-by` |
-| `unique` | Deduplicate an array by a key | `1o1-utils/unique` |
-
-### Objects
-
-| Utility | Description | Import |
-| --- | --- | --- |
-| `cloneDeep` | Deep clone objects, arrays, Maps, Sets, etc. | `1o1-utils/clone-deep` |
-| `deepMerge` | Recursively merge objects | `1o1-utils/deep-merge` |
-| `get` | Read a nested value via dot notation | `1o1-utils/get` |
-| `isEmpty` | Check if a value is empty | `1o1-utils/is-empty` |
-| `mapKeys` | Transform object keys via an iteratee | `1o1-utils/map-keys` |
-| `mapValues` | Transform object values via an iteratee | `1o1-utils/map-values` |
-| `omit` | Remove keys from an object | `1o1-utils/omit` |
-| `pick` | Extract keys from an object | `1o1-utils/pick` |
-| `set` | Set a nested value immutably via dot notation | `1o1-utils/set` |
+| `times` | Invoke `fn` N times and collect results | `1o1-utils/times` |
+| `unique` | Deduplicate an array (optionally by key) | `1o1-utils/unique` |
+| `unzip` | Split an array of tuples into separate arrays | `1o1-utils/unzip` |
+| `zip` | Combine arrays into tuples by index | `1o1-utils/zip` |
 
 ### Numbers
 
 | Utility | Description | Import |
 | --- | --- | --- |
-| `inRange` | Check if a number is within a range | `1o1-utils/in-range` |
+| `clamp` | Clamp a value to `[min, max]` | `1o1-utils/clamp` |
+| `inRange` | Check if a number is in a range | `1o1-utils/in-range` |
+| `randomInt` | CSPRNG random integer in a range | `1o1-utils/random-int` |
+
+### Objects
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `cloneDeep` | Deep clone (objects, arrays, Maps, Sets, etc.) | `1o1-utils/clone-deep` |
+| `compact` | Remove falsy values (with `keep` exceptions) | `1o1-utils/compact` |
+| `deepMerge` | Recursively merge objects | `1o1-utils/deep-merge` |
+| `defaults` | Fill `undefined` keys with defaults | `1o1-utils/defaults` |
+| `defaultsDeep` | Recursive `defaults` | `1o1-utils/defaults-deep` |
+| `get` | Read a nested value via dot notation | `1o1-utils/get` |
+| `isEmpty` | Check if a value is empty | `1o1-utils/is-empty` |
+| `mapKeys` | Transform object keys via an iteratee | `1o1-utils/map-keys` |
+| `mapValues` | Transform object values via an iteratee | `1o1-utils/map-values` |
+| `omit` | Remove keys from an object | `1o1-utils/omit` |
+| `omitBy` | Remove entries by predicate | `1o1-utils/omit-by` |
+| `pick` | Extract keys from an object | `1o1-utils/pick` |
+| `pickBy` | Keep entries by predicate | `1o1-utils/pick-by` |
+| `set` | Set a nested value immutably via dot notation | `1o1-utils/set` |
 
 ### Strings
 
 | Utility | Description | Import |
 | --- | --- | --- |
 | `capitalize` | Capitalize the first letter | `1o1-utils/capitalize` |
+| `deburr` | Strip diacritics (accent-fold) | `1o1-utils/deburr` |
+| `escapeRegExp` | Escape regex metacharacters | `1o1-utils/escape-reg-exp` |
+| `normalizeEmail` | Trim, lowercase, optional plus-strip | `1o1-utils/normalize-email` |
 | `slugify` | Convert to a URL-friendly slug | `1o1-utils/slugify` |
 | `transformCase` | Change string casing (camel, snake, etc.) | `1o1-utils/transform-case` |
 | `truncate` | Truncate a string with a suffix | `1o1-utils/truncate` |
@@ -96,20 +116,70 @@ import { pick } from "1o1-utils/pick";
 | Utility | Description | Import |
 | --- | --- | --- |
 | `debounce` | Debounce function calls | `1o1-utils/debounce` |
-| `retry` | Retry failed async operations | `1o1-utils/retry` |
-| `safely` | Wrap a function to return `[error, result]` instead of throwing | `1o1-utils/safely` |
+| `retry` | Retry failed async operations with backoff | `1o1-utils/retry` |
+| `safely` | Wrap a function to return `[error, result]` | `1o1-utils/safely` |
 | `sleep` | Promise-based delay | `1o1-utils/sleep` |
 | `throttle` | Throttle function calls | `1o1-utils/throttle` |
+| `waitForCondition` | Poll a predicate until truthy or timeout | `1o1-utils/wait-for-condition` |
+| `withTimeout` | Race a promise against a timeout | `1o1-utils/with-timeout` |
+
+### Comparisons
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `deepEqual` | Recursive structural equality | `1o1-utils/deep-equal` |
+| `isNil` | `null` or `undefined` check | `1o1-utils/is-nil` |
+| `shallowEqual` | Top-level entry equality | `1o1-utils/shallow-equal` |
+
+### Formatters
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `secondsToTimeFormat` | Format seconds as `MM:SS` / `H:MM:SS` | `1o1-utils/seconds-to-time-format` |
+| `timeFormatToSeconds` | Parse `MM:SS` / `H:MM:SS` into seconds | `1o1-utils/time-format-to-seconds` |
+
+### Functions
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `memo` | Memoize a function with optional TTL | `1o1-utils/memo` |
+| `once` | Run only once, cache the first result | `1o1-utils/once` |
+| `pipe` | Compose functions left-to-right | `1o1-utils/pipe` |
+
+### Validators
+
+| Utility | Description | Import |
+| --- | --- | --- |
+| `isValidEmail` | HTML5 + RFC 5321 email check | `1o1-utils/is-valid-email` |
+| `isValidPhone` | E.164 international phone check | `1o1-utils/is-valid-phone` |
+| `isValidUrl` | WHATWG `URL` parseable check | `1o1-utils/is-valid-url` |
 
 ### Browser
 
 | Utility | Description | Import |
 | --- | --- | --- |
-| `copyToClipboard` | Copy text to the clipboard with `execCommand` fallback | `1o1-utils/copy-to-clipboard` |
+| `bindKey` | Keyboard shortcuts (combos + sequences) | `1o1-utils/bind-key` |
+| `copyToClipboard` | Clipboard API + `execCommand` fallback | `1o1-utils/copy-to-clipboard` |
+
+## Bundle size
+
+Run `pnpm size` to see per-utility brotli sizes locally. Sample from the latest release:
+
+| Utility | Brotli size |
+| --- | --- |
+| `isNil` | 36 B |
+| `clamp` | 150 B |
+| `chunk` | 199 B |
+| `deepEqual` | 590 B |
+| `bindKey` | 1.05 kB |
+| `isValidPhone` | 1.19 kB |
+| **Whole library (all utilities)** | **~9.2 kB brotli / ~11 kB gzipped** |
+
+Tree-shaking removes everything you don't import — typical real-world bundles add a few hundred bytes per utility, not the whole 9 kB.
 
 ## Benchmarks
 
-All utilities are benchmarked against lodash, radash, and native JavaScript.
+All utilities are benchmarked against lodash, radash, es-toolkit, and native JavaScript.
 
 | Utility | vs lodash | vs radash | vs native |
 | --- | --- | --- | --- |
@@ -123,7 +193,9 @@ All utilities are benchmarked against lodash, radash, and native JavaScript.
 
 ## Documentation
 
-Full API reference and guides available at **[pedrotroccoli.github.io/1o1-utils](https://pedrotroccoli.github.io/1o1-utils)**.
+Full API reference, interactive playground, and migration guides at **[pedrotroccoli.github.io/1o1-utils](https://pedrotroccoli.github.io/1o1-utils)**.
+
+Every utility page includes a **Try it** block — Sandpack-powered, runs `1o1-utils` straight from npm in your browser. No install needed to experiment.
 
 ## Contributing
 

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
 import starlightTypeDoc from "starlight-typedoc";
+import react from "@astrojs/react";
 
 export default defineConfig({
   site: "https://pedrotroccoli.github.io",
@@ -9,6 +10,7 @@ export default defineConfig({
     prefetchAll: true,
   },
   integrations: [
+    react(),
     starlight({
       title: "1o1-utils",
       logo: {
@@ -50,6 +52,7 @@ export default defineConfig({
           items: [
             { label: "Why 1o1-utils", link: "/why-1o1-utils/" },
             { label: "Getting Started", link: "/getting-started/" },
+            { label: "Playground", link: "/playground/" },
             { label: "Benchmarks", link: "/benchmarks/" },
             { label: "Contributing", link: "/contributing/" },
           ],
@@ -82,6 +85,10 @@ export default defineConfig({
         {
           label: "Async",
           autogenerate: { directory: "async" },
+        },
+        {
+          label: "Browser",
+          autogenerate: { directory: "browser" },
         },
         {
           label: "Comparisons",

--- a/website/package.json
+++ b/website/package.json
@@ -8,11 +8,15 @@
     "preview": "astro preview"
   },
   "dependencies": {
+    "@astrojs/react": "^5.0.4",
     "@astrojs/starlight": "^0.38",
+    "@codesandbox/sandpack-react": "^2.20.0",
     "astro": "^6.1",
     "astro-og-canvas": "^0.11.0",
     "canvaskit-wasm": "^0.41.1",
     "iconoir": "^7.11.0",
+    "react": "^19.2.5",
+    "react-dom": "^19.2.5",
     "sharp": "^0.33",
     "starlight-typedoc": "^0.21",
     "typedoc": "^0.28",
@@ -23,5 +27,9 @@
       "esbuild",
       "sharp"
     ]
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.14",
+    "@types/react-dom": "^19.2.3"
   }
 }

--- a/website/pnpm-lock.yaml
+++ b/website/pnpm-lock.yaml
@@ -8,9 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@astrojs/react':
+        specifier: ^5.0.4
+        version: 5.0.4(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)
       '@astrojs/starlight':
         specifier: ^0.38
         version: 0.38.3(astro@6.1.6(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3))
+      '@codesandbox/sandpack-react':
+        specifier: ^2.20.0
+        version: 2.20.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       astro:
         specifier: ^6.1
         version: 6.1.6(@types/node@24.12.2)(rollup@4.60.1)(typescript@5.9.3)(yaml@2.8.3)
@@ -23,6 +29,12 @@ importers:
       iconoir:
         specifier: ^7.11.0
         version: 7.11.0
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.5
+        version: 19.2.5(react@19.2.5)
       sharp:
         specifier: ^0.33
         version: 0.33.5
@@ -35,6 +47,13 @@ importers:
       typedoc-plugin-markdown:
         specifier: ^4.6
         version: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
 
 packages:
 
@@ -43,6 +62,9 @@ packages:
 
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
+
+  '@astrojs/internal-helpers@0.9.0':
+    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
   '@astrojs/markdown-remark@7.1.0':
     resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
@@ -57,6 +79,15 @@ packages:
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
     engines: {node: '>=22.12.0'}
 
+  '@astrojs/react@5.0.4':
+    resolution: {integrity: sha512-yDNE4VnKOzCjH9dCBi7pT4F6kpI3M9TkS+uxnCB0sGIS6t5vKonOY+Hs/UUnSajJGT5jeBRfpI9IQp+r/n1fBA==}
+    engines: {node: '>=22.12.0'}
+    peerDependencies:
+      '@types/react': ^17.0.50 || ^18.0.21 || ^19.0.0
+      '@types/react-dom': ^17.0.17 || ^18.0.6 || ^19.0.0
+      react: ^17.0.2 || ^18.0.0 || ^19.0.0
+      react-dom: ^17.0.2 || ^18.0.0 || ^19.0.0
+
   '@astrojs/sitemap@3.7.2':
     resolution: {integrity: sha512-PqkzkcZTb5ICiyIR8VoKbIAP/laNRXi5tw616N1Ckk+40oNB8Can1AzVV56lrbC5GKSZFCyJYUVYqVivMisvpA==}
 
@@ -69,6 +100,44 @@ packages:
     resolution: {integrity: sha512-UFBgfeldP06qu6khs/yY+q1cDAaArM2/7AEIqQ9Cuvf7B1hNLq0xDrZkct+QoIGyjq56y8IaE2I3CTvG99mlhQ==}
     engines: {node: 18.20.8 || ^20.3.0 || >=22.0.0}
 
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.3':
+    resolution: {integrity: sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-string-parser@7.27.1':
     resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
     engines: {node: '>=6.9.0'}
@@ -77,13 +146,41 @@ packages:
     resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.29.2':
+    resolution: {integrity: sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/parser@7.29.2':
     resolution: {integrity: sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
   '@babel/runtime@7.29.2':
     resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/types@7.29.0':
@@ -99,6 +196,45 @@ packages:
 
   '@clack/prompts@1.2.0':
     resolution: {integrity: sha512-4jmztR9fMqPMjz6H/UZXj0zEmE43ha1euENwkckKKel4XpSfokExPo5AiVStdHSAlHekz4d0CA/r45Ok1E4D3w==}
+
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
+
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
+
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-html@6.4.11':
+    resolution: {integrity: sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==}
+
+  '@codemirror/lang-javascript@6.2.5':
+    resolution: {integrity: sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@codesandbox/nodebox@0.1.8':
+    resolution: {integrity: sha512-2VRS6JDSk+M+pg56GA6CryyUSGPjBEe8Pnae0QL3jJF1mJZJVMDKr93gJRtBbLkfZN6LD/DwMtf+2L0bpWrjqg==}
+
+  '@codesandbox/sandpack-client@2.19.8':
+    resolution: {integrity: sha512-CMV4nr1zgKzVpx4I3FYvGRM5YT0VaQhALMW9vy4wZRhEyWAtJITQIqZzrTGWqB1JvV7V72dVEUCUPLfYz5hgJQ==}
+
+  '@codesandbox/sandpack-react@2.20.0':
+    resolution: {integrity: sha512-takd1YpW/PMQ6KPQfvseWLHWklJovGY8QYj8MtWnskGKbjOGJ6uZfyZbcJ6aCFLQMpNyjTqz9AKNbvhCOZ1TUQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
+      react-dom: ^16.8.0 || ^17 || ^18 || ^19
 
   '@ctrl/tinycolor@4.2.0':
     resolution: {integrity: sha512-kzyuwOAQnXJNLS9PSyrk0CWk35nWJW/zl/6KvnTBMFK65gm7U1/Z5BqjxeapjZCIhQcM/DsrEmcbRwDyXyXK4A==}
@@ -520,11 +656,48 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/html@1.3.13':
+    resolution: {integrity: sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==}
+
+  '@lezer/javascript@1.5.4':
+    resolution: {integrity: sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
+
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -566,6 +739,19 @@ packages:
     resolution: {integrity: sha512-Fa2Iyw7kaDRzGMfNYNUXNW2zbL5FQVDgSOcbDHdzBrDEdpqOqg8TcZ68F22ol6NJ9IGzvUdmeyZypLW5dyhqsg==}
     cpu: [x64]
     os: [win32]
+
+  '@react-hook/intersection-observer@3.1.2':
+    resolution: {integrity: sha512-mWU3BMkmmzyYMSuhO9wu3eJVP21N8TcgYm9bZnTrMwuM818bEk+0NRM3hP+c/TqA9Ln5C7qE53p1H0QMtzYdvQ==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@react-hook/passive-layout-effect@1.2.1':
+    resolution: {integrity: sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==}
+    peerDependencies:
+      react: '>=16.8'
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
@@ -750,6 +936,21 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@stitches/core@1.2.8':
+    resolution: {integrity: sha512-Gfkvwk9o9kE9r9XNBmJRfV8zONvXThnm1tcuojL04Uy5uRyqg93DC83lDebl0rocZCfKSjUv+fWYtMQmEDJldg==}
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -780,6 +981,14 @@ packages:
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
   '@types/sax@1.2.7':
     resolution: {integrity: sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A==}
 
@@ -791,6 +1000,12 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+
+  '@vitejs/plugin-react@5.2.0':
+    resolution: {integrity: sha512-YmKkfhOAi3wsB1PhJq5Scj3GXMn3WvtQ/JC0xoopuHoXSdmtdStOpFrYaT1kie2YgFBcIe64ROzMYRjCrYOdYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
 
   '@webgpu/types@0.1.21':
     resolution: {integrity: sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==}
@@ -804,6 +1019,9 @@ packages:
     resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+
+  anser@2.3.5:
+    resolution: {integrity: sha512-vcZjxvvVoxTeR5XBNJB38oTu/7eDCZlwdz32N1eNgpyPF7j/Z7Idf+CUwQOkKKpJ7RJyjxgLHCM7vdIK0iCNMQ==}
 
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
@@ -855,6 +1073,14 @@ packages:
   base-64@1.0.0:
     resolution: {integrity: sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg==}
 
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+
+  baseline-browser-mapping@2.10.25:
+    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   bcp-47-match@2.0.3:
     resolution: {integrity: sha512-JtTezzbAibu8G0R9op9zb3vcWZd9JF6M0xOYGPn0fNCd7wOpRB1mU2mH9T8gaBGbAAyIIVgB2G7xG0GP98zMAQ==}
 
@@ -867,6 +1093,17 @@ packages:
   brace-expansion@5.0.5:
     resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
     engines: {node: 18 || 20 || >=22}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  caniuse-lite@1.0.30001791:
+    resolution: {integrity: sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==}
 
   canvaskit-wasm@0.41.1:
     resolution: {integrity: sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==}
@@ -893,6 +1130,9 @@ packages:
   ci-info@4.4.0:
     resolution: {integrity: sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==}
     engines: {node: '>=8'}
+
+  clean-set@1.1.2:
+    resolution: {integrity: sha512-cA8uCj0qSoG9e0kevyOWXwPaELRPVg5Pxp6WskLMwerx257Zfnh8Nl0JBH59d7wQzij2CK7qEfJQK3RjuKKIug==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -926,12 +1166,18 @@ packages:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
 
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
@@ -962,6 +1208,13 @@ packages:
   csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d@1.0.2:
+    resolution: {integrity: sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==}
+    engines: {node: '>=0.12'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1023,9 +1276,16 @@ packages:
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
   dset@3.1.4:
     resolution: {integrity: sha512-2QF/g9/zTaPDc3BjNcVTGoBbXBgYfMTTceLaYcFJ/W9kggFUkhxD/hMEeuLKbugyef9SqAx8cpgwlIP/jinUTA==}
     engines: {node: '>=4'}
+
+  electron-to-chromium@1.5.349:
+    resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -1042,6 +1302,17 @@ packages:
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
+  es5-ext@0.10.64:
+    resolution: {integrity: sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==}
+    engines: {node: '>=0.10'}
+
+  es6-iterator@2.0.3:
+    resolution: {integrity: sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==}
+
+  es6-symbol@3.1.4:
+    resolution: {integrity: sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==}
+    engines: {node: '>=0.12'}
+
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
 
@@ -1053,9 +1324,20 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-carriage@1.3.1:
+    resolution: {integrity: sha512-GwBr6yViW3ttx1kb7/Oh+gKQ1/TrhYwxKqVmg5gS+BK+Qe2KrOa/Vh7w3HPBvgGf0LfcDGoY9I6NHKoA5Hozhw==}
+
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
+
+  esniff@2.0.1:
+    resolution: {integrity: sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==}
+    engines: {node: '>=0.10'}
 
   estree-util-attach-comments@3.0.0:
     resolution: {integrity: sha512-cKUwm/HUcTDsYh/9FgnuFqpfquUbwIqwKM26BVCGDPVgvaCl/nDCCjUfiLlx6lsEZ3Z4RFxNbOQ60pkaEwFxGw==}
@@ -1081,11 +1363,17 @@ packages:
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
+  event-emitter@0.3.5:
+    resolution: {integrity: sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expressive-code@0.41.7:
     resolution: {integrity: sha512-2wZjC8OQ3TaVEMcBtYY4Va3lo6J+Ai9jf3d4dbhURMJcU4Pbqe6EcHe424MIZI0VHUA1bR6xdpoHYi3yxokWqA==}
+
+  ext@1.7.0:
+    resolution: {integrity: sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -1123,6 +1411,10 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -1208,8 +1500,15 @@ packages:
   iconoir@7.11.0:
     resolution: {integrity: sha512-F9T/E08aJBaQ+VOBjn+ChWKn3hFwsaK5VZ024OFMxdDaxKjLGDpU/OsU7MO9wXM+mDs4ZImypdXIn0fFZAXKmA==}
 
+  ieee754@1.2.1:
+    resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  intersection-observer@0.10.0:
+    resolution: {integrity: sha512-fn4bQ0Xq8FTej09YC/jqKZwtijpvARlRp6wxL5WTA6yPe2YWSJ5RJh7Nm79rK2qB0wr6iDQzH60XGq5V/7u8YQ==}
+    deprecated: The Intersection Observer polyfill is no longer needed and can safely be removed. Intersection Observer has been Baseline since 2019.
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -1247,8 +1546,21 @@ packages:
     resolution: {integrity: sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==}
     engines: {node: '>=16'}
 
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
     hasBin: true
 
   klona@2.0.6:
@@ -1265,8 +1577,15 @@ packages:
     resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
     engines: {node: 20 || >=22}
 
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
   lunr@2.3.9:
     resolution: {integrity: sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1456,6 +1775,10 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
     engines: {node: 18 || 20 || >=22}
@@ -1476,6 +1799,9 @@ packages:
     resolution: {integrity: sha512-Z4SmBUweYa09+o6pG+eASabEpP6QkQ70yHj351pQoEXIs8uHbaU2DWVmzBANKgflPa47A50PtB2+NgRpQvr7vA==}
     engines: {node: '>= 10'}
 
+  next-tick@1.1.0:
+    resolution: {integrity: sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==}
+
   nlcst-to-string@4.0.0:
     resolution: {integrity: sha512-YKLBCcUYKAg0FNlOBT6aI91qFmSiFKiluk655WzPF+DDMA02qIyy8uiRqI8QXtcFpEvll12LpL5MXqEmAZ+dcA==}
 
@@ -1484,6 +1810,9 @@ packages:
 
   node-mock-http@1.0.4:
     resolution: {integrity: sha512-8DY+kFsDkNXy1sJglUfuODx1/opAGJGyrTuFqEoN90oRc2Vk0ZbD4K2qmKXBBEhZQzdKHIVfEJpDU8Ak2NJEvQ==}
+
+  node-releases@2.0.38:
+    resolution: {integrity: sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -1506,6 +1835,9 @@ packages:
 
   oniguruma-to-es@4.3.5:
     resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
+
+  outvariant@1.4.0:
+    resolution: {integrity: sha512-AlWY719RF02ujitly7Kk/0QlV+pXGFDHrHf9O2OKqyqgBieaPOIeuSkL8sRK6j2WK+/ZAURq2kZsY0d8JapUiw==}
 
   p-limit@7.3.0:
     resolution: {integrity: sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw==}
@@ -1576,6 +1908,25 @@ packages:
 
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
+
+  react-devtools-inline@4.4.0:
+    resolution: {integrity: sha512-ES0GolSrKO8wsKbsEkVeiR/ZAaHQTY4zDh1UW8DImVmm8oaGLl3ijJDvSGe+qDRKPZdPRnDtWWnSvvrgxXdThQ==}
+
+  react-dom@19.2.5:
+    resolution: {integrity: sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==}
+    peerDependencies:
+      react: ^19.2.5
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.5:
+    resolution: {integrity: sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==}
+    engines: {node: '>=0.10.0'}
 
   readdirp@5.0.0:
     resolution: {integrity: sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==}
@@ -1668,6 +2019,13 @@ packages:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
     engines: {node: '>=11.0.0'}
 
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
   semver@7.7.4:
     resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
     engines: {node: '>=10'}
@@ -1722,11 +2080,20 @@ packages:
       typedoc: '>=0.28.0'
       typedoc-plugin-markdown: '>=4.6.0'
 
+  static-browser-server@1.0.3:
+    resolution: {integrity: sha512-ZUyfgGDdFRbZGGJQ1YhiM930Yczz5VlbJObrQLlk24+qNHVQx4OlLcYswEUo3bIyNAbQUIUR9Yr5/Hqjzqb4zA==}
+
   stream-replace-string@2.0.0:
     resolution: {integrity: sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==}
 
+  strict-event-emitter@0.4.6:
+    resolution: {integrity: sha512-12KWeb+wixJohmnwNFerbyiBrAlq5qJLwIt38etRtKtmmHyDSoGlIqFE9wx+4IwG0aDjI7GV8tc8ZccjWZZtTg==}
+
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   style-to-js@1.1.21:
     resolution: {integrity: sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==}
@@ -1772,6 +2139,9 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  type@2.7.3:
+    resolution: {integrity: sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==}
 
   typedoc-plugin-markdown@4.11.0:
     resolution: {integrity: sha512-2iunh2ALyfyh204OF7h2u0kuQ84xB3jFZtFyUr01nThJkLvR8oGGSSDlyt2gyO4kXhvUxDcVbO0y43+qX+wFbw==}
@@ -1904,6 +2274,12 @@ packages:
       uploadthing:
         optional: true
 
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -1964,6 +2340,9 @@ packages:
       vite:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   web-namespaces@2.0.1:
     resolution: {integrity: sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ==}
 
@@ -1973,6 +2352,9 @@ packages:
 
   xxhash-wasm@1.1.0:
     resolution: {integrity: sha512-147y/6YNh+tlp6nd/2pWq38i9h6mz/EuQ6njIrmW8D1BS5nCqs0P6DG+m6zTGnNz5I+uhZ0SHxBs9BsPrwcKDA==}
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yaml@2.8.3:
     resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
@@ -1998,6 +2380,10 @@ snapshots:
   '@astrojs/compiler@3.0.1': {}
 
   '@astrojs/internal-helpers@0.8.0':
+    dependencies:
+      picomatch: 4.0.4
+
+  '@astrojs/internal-helpers@0.9.0':
     dependencies:
       picomatch: 4.0.4
 
@@ -2049,6 +2435,31 @@ snapshots:
   '@astrojs/prism@4.0.1':
     dependencies:
       prismjs: 1.30.0
+
+  '@astrojs/react@5.0.4(@types/node@24.12.2)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(yaml@2.8.3)':
+    dependencies:
+      '@astrojs/internal-helpers': 0.9.0
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react': 5.2.0(vite@7.3.2(@types/node@24.12.2)(yaml@2.8.3))
+      devalue: 5.7.1
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      ultrahtml: 1.6.0
+      vite: 7.3.2(@types/node@24.12.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   '@astrojs/sitemap@3.7.2':
     dependencies:
@@ -2102,15 +2513,114 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.3': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.29.2
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.3
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.2
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
   '@babel/helper-string-parser@7.27.1': {}
 
   '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.29.2':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
 
   '@babel/parser@7.29.2':
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
   '@babel/runtime@7.29.2': {}
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.2
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/types@7.29.0':
     dependencies:
@@ -2132,6 +2642,114 @@ snapshots:
       fast-string-width: 1.1.0
       fast-wrap-ansi: 0.1.6
       sisteransi: 1.0.5
+
+  '@codemirror/autocomplete@6.20.1':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-html@6.4.11':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+      '@lezer/html': 1.3.13
+
+  '@codemirror/lang-javascript@6.2.5':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/javascript': 1.5.4
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@codesandbox/nodebox@0.1.8':
+    dependencies:
+      outvariant: 1.4.0
+      strict-event-emitter: 0.4.6
+
+  '@codesandbox/sandpack-client@2.19.8':
+    dependencies:
+      '@codesandbox/nodebox': 0.1.8
+      buffer: 6.0.3
+      dequal: 2.0.3
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+      static-browser-server: 1.0.3
+
+  '@codesandbox/sandpack-react@2.20.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/lang-css': 6.3.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/lang-javascript': 6.2.5
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@codesandbox/sandpack-client': 2.19.8
+      '@lezer/highlight': 1.2.3
+      '@react-hook/intersection-observer': 3.1.2(react@19.2.5)
+      '@stitches/core': 1.2.8
+      anser: 2.3.5
+      clean-set: 1.1.2
+      dequal: 2.0.3
+      escape-carriage: 1.3.1
+      lz-string: 1.5.0
+      react: 19.2.5
+      react-devtools-inline: 4.4.0
+      react-dom: 19.2.5(react@19.2.5)
+      react-is: 17.0.2
 
   '@ctrl/tinycolor@4.2.0': {}
 
@@ -2423,7 +3041,54 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/html@1.3.13':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/javascript@1.5.4':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.2': {}
 
   '@mdx-js/mdx@3.1.1':
     dependencies:
@@ -2455,6 +3120,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@open-draft/deferred-promise@2.2.0': {}
+
   '@oslojs/encoding@1.1.0': {}
 
   '@pagefind/darwin-arm64@1.5.2':
@@ -2479,6 +3146,18 @@ snapshots:
 
   '@pagefind/windows-x64@1.5.2':
     optional: true
+
+  '@react-hook/intersection-observer@3.1.2(react@19.2.5)':
+    dependencies:
+      '@react-hook/passive-layout-effect': 1.2.1(react@19.2.5)
+      intersection-observer: 0.10.0
+      react: 19.2.5
+
+  '@react-hook/passive-layout-effect@1.2.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/pluginutils@5.3.0(rollup@4.60.1)':
     dependencies:
@@ -2634,6 +3313,29 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@stitches/core@1.2.8': {}
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2666,6 +3368,14 @@ snapshots:
     dependencies:
       undici-types: 7.16.0
 
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
   '@types/sax@1.2.7':
     dependencies:
       '@types/node': 24.12.2
@@ -2676,6 +3386,18 @@ snapshots:
 
   '@ungap/structured-clone@1.3.0': {}
 
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.12.2)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.2(@types/node@24.12.2)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@webgpu/types@0.1.21': {}
 
   acorn-jsx@5.3.2(acorn@8.16.0):
@@ -2683,6 +3405,8 @@ snapshots:
       acorn: 8.16.0
 
   acorn@8.16.0: {}
+
+  anser@2.3.5: {}
 
   anymatch@3.1.3:
     dependencies:
@@ -2812,6 +3536,10 @@ snapshots:
 
   base-64@1.0.0: {}
 
+  base64-js@1.5.1: {}
+
+  baseline-browser-mapping@2.10.25: {}
+
   bcp-47-match@2.0.3: {}
 
   bcp-47@2.1.0:
@@ -2825,6 +3553,21 @@ snapshots:
   brace-expansion@5.0.5:
     dependencies:
       balanced-match: 4.0.4
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.25
+      caniuse-lite: 1.0.30001791
+      electron-to-chromium: 1.5.349
+      node-releases: 2.0.38
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
+  caniuse-lite@1.0.30001791: {}
 
   canvaskit-wasm@0.41.1:
     dependencies:
@@ -2845,6 +3588,8 @@ snapshots:
       readdirp: 5.0.0
 
   ci-info@4.4.0: {}
+
+  clean-set@1.1.2: {}
 
   clsx@2.1.1: {}
 
@@ -2872,9 +3617,13 @@ snapshots:
 
   common-ancestor-path@2.0.0: {}
 
+  convert-source-map@2.0.0: {}
+
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
+
+  crelt@1.0.6: {}
 
   crossws@0.3.5:
     dependencies:
@@ -2907,6 +3656,13 @@ snapshots:
   csso@5.0.5:
     dependencies:
       css-tree: 2.2.1
+
+  csstype@3.2.3: {}
+
+  d@1.0.2:
+    dependencies:
+      es5-ext: 0.10.64
+      type: 2.7.3
 
   debug@4.4.3:
     dependencies:
@@ -2958,7 +3714,11 @@ snapshots:
       domelementtype: 2.3.0
       domhandler: 5.0.3
 
+  dotenv@16.6.1: {}
+
   dset@3.1.4: {}
+
+  electron-to-chromium@1.5.349: {}
 
   entities@4.5.0: {}
 
@@ -2967,6 +3727,24 @@ snapshots:
   entities@8.0.0: {}
 
   es-module-lexer@2.0.0: {}
+
+  es5-ext@0.10.64:
+    dependencies:
+      es6-iterator: 2.0.3
+      es6-symbol: 3.1.4
+      esniff: 2.0.1
+      next-tick: 1.1.0
+
+  es6-iterator@2.0.3:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      es6-symbol: 3.1.4
+
+  es6-symbol@3.1.4:
+    dependencies:
+      d: 1.0.2
+      ext: 1.7.0
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -3011,7 +3789,18 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  escalade@3.2.0: {}
+
+  escape-carriage@1.3.1: {}
+
   escape-string-regexp@5.0.0: {}
+
+  esniff@2.0.1:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+      event-emitter: 0.3.5
+      type: 2.7.3
 
   estree-util-attach-comments@3.0.0:
     dependencies:
@@ -3048,6 +3837,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  event-emitter@0.3.5:
+    dependencies:
+      d: 1.0.2
+      es5-ext: 0.10.64
+
   eventemitter3@5.0.4: {}
 
   expressive-code@0.41.7:
@@ -3056,6 +3850,10 @@ snapshots:
       '@expressive-code/plugin-frames': 0.41.7
       '@expressive-code/plugin-shiki': 0.41.7
       '@expressive-code/plugin-text-markers': 0.41.7
+
+  ext@1.7.0:
+    dependencies:
+      type: 2.7.3
 
   extend@3.0.2: {}
 
@@ -3085,6 +3883,8 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  gensync@1.0.0-beta.2: {}
 
   github-slugger@2.0.0: {}
 
@@ -3303,7 +4103,11 @@ snapshots:
 
   iconoir@7.11.0: {}
 
+  ieee754@1.2.1: {}
+
   inline-style-parser@0.2.7: {}
+
+  intersection-observer@0.10.0: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -3332,9 +4136,15 @@ snapshots:
     dependencies:
       is-inside-container: 1.0.0
 
+  js-tokens@4.0.0: {}
+
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
 
   klona@2.0.6: {}
 
@@ -3346,7 +4156,13 @@ snapshots:
 
   lru-cache@11.3.5: {}
 
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
   lunr@2.3.9: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3834,6 +4650,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.54.0: {}
+
   minimatch@10.2.5:
     dependencies:
       brace-expansion: 5.0.5
@@ -3846,6 +4664,8 @@ snapshots:
 
   neotraverse@0.6.18: {}
 
+  next-tick@1.1.0: {}
+
   nlcst-to-string@4.0.0:
     dependencies:
       '@types/nlcst': 2.0.3
@@ -3853,6 +4673,8 @@ snapshots:
   node-fetch-native@1.6.7: {}
 
   node-mock-http@1.0.4: {}
+
+  node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
 
@@ -3877,6 +4699,8 @@ snapshots:
       oniguruma-parser: 0.12.1
       regex: 6.1.0
       regex-recursion: 6.0.2
+
+  outvariant@1.4.0: {}
 
   p-limit@7.3.0:
     dependencies:
@@ -3955,6 +4779,21 @@ snapshots:
   punycode.js@2.3.1: {}
 
   radix3@1.1.2: {}
+
+  react-devtools-inline@4.4.0:
+    dependencies:
+      es6-symbol: 3.1.4
+
+  react-dom@19.2.5(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+      scheduler: 0.27.0
+
+  react-is@17.0.2: {}
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.5: {}
 
   readdirp@5.0.0: {}
 
@@ -4154,6 +4993,10 @@ snapshots:
 
   sax@1.6.0: {}
 
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
   semver@7.7.4: {}
 
   sharp@0.33.5:
@@ -4264,12 +5107,23 @@ snapshots:
       typedoc: 0.28.19(typescript@5.9.3)
       typedoc-plugin-markdown: 4.11.0(typedoc@0.28.19(typescript@5.9.3))
 
+  static-browser-server@1.0.3:
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      dotenv: 16.6.1
+      mime-db: 1.54.0
+      outvariant: 1.4.0
+
   stream-replace-string@2.0.0: {}
+
+  strict-event-emitter@0.4.6: {}
 
   stringify-entities@4.0.4:
     dependencies:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
+
+  style-mod@4.1.3: {}
 
   style-to-js@1.1.21:
     dependencies:
@@ -4310,6 +5164,8 @@ snapshots:
 
   tslib@2.8.1:
     optional: true
+
+  type@2.7.3: {}
 
   typedoc-plugin-markdown@4.11.0(typedoc@0.28.19(typescript@5.9.3)):
     dependencies:
@@ -4409,6 +5265,12 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
 
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
   util-deprecate@1.0.2: {}
 
   vfile-location@5.0.3:
@@ -4443,11 +5305,15 @@ snapshots:
     optionalDependencies:
       vite: 7.3.2(@types/node@24.12.2)(yaml@2.8.3)
 
+  w3c-keyname@2.2.8: {}
+
   web-namespaces@2.0.1: {}
 
   which-pm-runs@1.1.0: {}
 
   xxhash-wasm@1.1.0: {}
+
+  yallist@3.1.1: {}
 
   yaml@2.8.3: {}
 

--- a/website/src/components/Playground.tsx
+++ b/website/src/components/Playground.tsx
@@ -1,0 +1,159 @@
+import { useMemo, useState } from "react";
+import {
+  SandpackProvider,
+  SandpackLayout,
+  SandpackCodeEditor,
+  SandpackConsole,
+  SandpackPreview,
+} from "@codesandbox/sandpack-react";
+import { EXAMPLES, EXAMPLES_BY_ID, type Example } from "../content/examples/index";
+
+const PKG_VERSION = "1.8.0";
+
+const indexHtml = `<!doctype html>
+<html>
+  <head><meta charset="utf-8" /><title>1o1-utils playground</title></head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./index.ts"></script>
+  </body>
+</html>`;
+
+type PlaygroundProps = {
+  /** Lock playground to a single example by id (no selector). */
+  utilityId?: string;
+  /** Initial example shown when selector is enabled. */
+  defaultId?: string;
+  /** Editor + console height in CSS units. */
+  height?: string;
+};
+
+function groupByCategory(examples: Example[]) {
+  const map = new Map<string, Example[]>();
+  for (const ex of examples) {
+    const list = map.get(ex.category) ?? [];
+    list.push(ex);
+    map.set(ex.category, list);
+  }
+  return [...map.entries()];
+}
+
+function Sandbox({ example, height }: { example: Example; height: string }) {
+  const showPreview = example.category === "Browser";
+
+  return (
+    <SandpackProvider
+      key={example.id}
+      template="vanilla-ts"
+      theme="dark"
+      customSetup={{
+        dependencies: {
+          "1o1-utils": PKG_VERSION,
+        },
+      }}
+      files={{
+        "/index.ts": { code: example.code, active: true },
+        "/index.html": { code: indexHtml, hidden: true },
+      }}
+      options={{
+        recompileMode: "delayed",
+        recompileDelay: 400,
+      }}
+    >
+      <SandpackLayout>
+        <SandpackCodeEditor
+          showTabs={false}
+          showLineNumbers
+          wrapContent
+          style={{ height }}
+        />
+        {showPreview ? (
+          <SandpackPreview style={{ height }} showRefreshButton showOpenInCodeSandbox={false} />
+        ) : (
+          <SandpackConsole
+            style={{ height }}
+            standalone={false}
+            showHeader
+            resetOnPreviewRestart
+          />
+        )}
+      </SandpackLayout>
+      {!showPreview ? (
+        <div style={{ display: "none" }}>
+          <SandpackPreview />
+        </div>
+      ) : null}
+    </SandpackProvider>
+  );
+}
+
+export default function Playground({
+  utilityId,
+  defaultId,
+  height = "360px",
+}: PlaygroundProps) {
+  const pinnedExample = utilityId ? EXAMPLES_BY_ID[utilityId] : undefined;
+
+  if (pinnedExample) {
+    return (
+      <div style={{ display: "flex", flexDirection: "column", gap: "0.5rem" }}>
+        <Sandbox example={pinnedExample} height={height} />
+        <p style={{ fontSize: "0.75rem", opacity: 0.7, margin: 0 }}>
+          Live — runs <code>1o1-utils@{PKG_VERSION}</code> in your browser.
+        </p>
+      </div>
+    );
+  }
+
+  const initial = defaultId && EXAMPLES_BY_ID[defaultId] ? defaultId : EXAMPLES[0].id;
+  const [exampleId, setExampleId] = useState(initial);
+  const example = useMemo(
+    () => EXAMPLES_BY_ID[exampleId] ?? EXAMPLES[0],
+    [exampleId]
+  );
+  const grouped = useMemo(() => groupByCategory(EXAMPLES), []);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
+      <label
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: "0.5rem",
+          fontSize: "0.875rem",
+        }}
+      >
+        <span style={{ fontWeight: 600 }}>Example:</span>
+        <select
+          value={exampleId}
+          onChange={(e) => setExampleId(e.target.value)}
+          style={{
+            padding: "0.35rem 0.6rem",
+            borderRadius: "6px",
+            border: "1px solid var(--sl-color-gray-5)",
+            background: "var(--sl-color-bg)",
+            color: "var(--sl-color-text)",
+            fontFamily: "inherit",
+          }}
+        >
+          {grouped.map(([category, items]) => (
+            <optgroup key={category} label={category}>
+              {items.map((it) => (
+                <option key={it.id} value={it.id}>
+                  {it.label}
+                </option>
+              ))}
+            </optgroup>
+          ))}
+        </select>
+      </label>
+
+      <Sandbox example={example} height={height} />
+
+      <p style={{ fontSize: "0.8rem", opacity: 0.75, margin: 0 }}>
+        Runs <code>1o1-utils@{PKG_VERSION}</code> from npm in your browser. Edit
+        the code — output appears in the console.
+      </p>
+    </div>
+  );
+}

--- a/website/src/components/Playground.tsx
+++ b/website/src/components/Playground.tsx
@@ -94,6 +94,14 @@ export default function Playground({
   height = "360px",
 }: PlaygroundProps) {
   const pinnedExample = utilityId ? EXAMPLES_BY_ID[utilityId] : undefined;
+  const initial =
+    defaultId && EXAMPLES_BY_ID[defaultId] ? defaultId : EXAMPLES[0].id;
+  const [exampleId, setExampleId] = useState(initial);
+  const example = useMemo(
+    () => EXAMPLES_BY_ID[exampleId] ?? EXAMPLES[0],
+    [exampleId]
+  );
+  const grouped = useMemo(() => groupByCategory(EXAMPLES), []);
 
   if (pinnedExample) {
     return (
@@ -105,14 +113,6 @@ export default function Playground({
       </div>
     );
   }
-
-  const initial = defaultId && EXAMPLES_BY_ID[defaultId] ? defaultId : EXAMPLES[0].id;
-  const [exampleId, setExampleId] = useState(initial);
-  const example = useMemo(
-    () => EXAMPLES_BY_ID[exampleId] ?? EXAMPLES[0],
-    [exampleId]
-  );
-  const grouped = useMemo(() => groupByCategory(EXAMPLES), []);
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: "0.75rem" }}>
@@ -133,7 +133,7 @@ export default function Playground({
             borderRadius: "6px",
             border: "1px solid var(--sl-color-gray-5)",
             background: "var(--sl-color-bg)",
-            color: "var(--sl-color-text)",
+            color: "var(--sl-color-white)",
             fontFamily: "inherit",
           }}
         >

--- a/website/src/components/Playground.tsx
+++ b/website/src/components/Playground.tsx
@@ -7,8 +7,9 @@ import {
   SandpackPreview,
 } from "@codesandbox/sandpack-react";
 import { EXAMPLES, EXAMPLES_BY_ID, type Example } from "../content/examples/index";
+import pkg from "../../../package.json" with { type: "json" };
 
-const PKG_VERSION = "1.8.0";
+const PKG_VERSION: string = pkg.version;
 
 const indexHtml = `<!doctype html>
 <html>

--- a/website/src/content/docs/arrays/array-to-hash.mdx
+++ b/website/src/content/docs/arrays/array-to-hash.mdx
@@ -3,7 +3,13 @@ title: arrayToHash
 description: Convert an array to a hash map keyed by a property
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Converts an array of objects into a hash map (plain object) keyed by a specified property. Useful for fast lookups by a unique identifier.
+
+## Try it
+
+<Playground client:only="react" utilityId="array-to-hash" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/chunk.mdx
+++ b/website/src/content/docs/arrays/chunk.mdx
@@ -3,7 +3,13 @@ title: chunk
 description: Split an array into groups of a given size
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Splits an array into smaller arrays (chunks) of a specified size. The last chunk may contain fewer elements if the array doesn't divide evenly.
+
+## Try it
+
+<Playground client:only="react" utilityId="chunk" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/diff.mdx
+++ b/website/src/content/docs/arrays/diff.mdx
@@ -3,7 +3,13 @@ title: diff
 description: Return elements in the first array not present in the second
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Returns a new array containing elements from the first array that are not present in the second. For arrays of objects, pass an `iteratee` function to derive an identity value used for comparison.
+
+## Try it
+
+<Playground client:only="react" utilityId="diff" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/group-by.mdx
+++ b/website/src/content/docs/arrays/group-by.mdx
@@ -3,7 +3,13 @@ title: groupBy
 description: Group array elements by a property value
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Groups the elements of an array into an object, keyed by the value of a specified property. Each key maps to an array of items that share that value.
+
+## Try it
+
+<Playground client:only="react" utilityId="group-by" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/partition.mdx
+++ b/website/src/content/docs/arrays/partition.mdx
@@ -3,7 +3,13 @@ title: partition
 description: Split an array into two groups based on a predicate
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Splits an array into two groups based on a predicate. The first group contains items for which the predicate returns truthy; the second contains the rest. Order is preserved within each group. Supports a type-guard predicate (`(item) => item is U`) to narrow the resulting tuple to `[U[], Exclude<T, U>[]]`.
+
+## Try it
+
+<Playground client:only="react" utilityId="partition" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/range.mdx
+++ b/website/src/content/docs/arrays/range.mdx
@@ -3,7 +3,13 @@ title: range
 description: Generate an array of numbers in a given range
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Generates an array of numbers from `start` (inclusive) to `end` (exclusive), incrementing by `step`. If `step` is omitted, it defaults to `1` when `start <= end` and `-1` when `start > end`.
+
+## Try it
+
+<Playground client:only="react" utilityId="range" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/replace.mdx
+++ b/website/src/content/docs/arrays/replace.mdx
@@ -3,7 +3,13 @@ title: replace
 description: Replace element(s) in an array by predicate, with optional updater function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Replaces element(s) in an array by predicate. Returns a new array — the input is never mutated. By default, only the first matching item is replaced; pass `all: true` to replace every match. `value` accepts either a static replacement or an updater function `(item, index) => newItem` that derives the new value from the matched item.
+
+## Try it
+
+<Playground client:only="react" utilityId="replace" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/shuffle.mdx
+++ b/website/src/content/docs/arrays/shuffle.mdx
@@ -3,7 +3,13 @@ title: shuffle
 description: Randomly reorder an array using Fisher-Yates
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Returns a new array with the elements of the input in random order, using the Fisher-Yates algorithm. The input is not mutated. Pass an optional `random` function to inject a deterministic or seeded random source.
+
+## Try it
+
+<Playground client:only="react" utilityId="shuffle" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/sort-by.mdx
+++ b/website/src/content/docs/arrays/sort-by.mdx
@@ -3,7 +3,13 @@ title: sortBy
 description: Sort an array of objects by a property
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Returns a new array sorted by a specified property. Supports ascending and descending order, as well as nested properties via dot notation.
+
+## Try it
+
+<Playground client:only="react" utilityId="sort-by" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/times.mdx
+++ b/website/src/content/docs/arrays/times.mdx
@@ -3,7 +3,13 @@ title: times
 description: Invoke a function N times and collect the results
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Invokes `fn` `count` times and returns an array of the results. The function receives the current index (0-based) on each call.
+
+## Try it
+
+<Playground client:only="react" utilityId="times" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/unique.mdx
+++ b/website/src/content/docs/arrays/unique.mdx
@@ -3,7 +3,13 @@ title: unique
 description: Remove duplicate elements from an array
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Returns a new array with duplicate elements removed. For arrays of objects, you can specify a property to determine uniqueness.
+
+## Try it
+
+<Playground client:only="react" utilityId="unique" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/unzip.mdx
+++ b/website/src/content/docs/arrays/unzip.mdx
@@ -3,7 +3,13 @@ title: unzip
 description: Split an array of tuples back into separate arrays
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Splits an array of grouped tuples back into separate arrays. The inverse of [zip](./zip.mdx).
+
+## Try it
+
+<Playground client:only="react" utilityId="unzip" />
 
 ## Import
 

--- a/website/src/content/docs/arrays/zip.mdx
+++ b/website/src/content/docs/arrays/zip.mdx
@@ -3,7 +3,13 @@ title: zip
 description: Combine arrays by index into tuples
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Combines multiple arrays by position into an array of tuples. The inverse of [unzip](./unzip.mdx).
+
+## Try it
+
+<Playground client:only="react" utilityId="zip" />
 
 ## Import
 

--- a/website/src/content/docs/async/debounce.mdx
+++ b/website/src/content/docs/async/debounce.mdx
@@ -3,7 +3,13 @@ title: debounce
 description: Create a debounced version of a function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a debounced version of a function that delays invocation until after a specified number of milliseconds have elapsed since the last call.
+
+## Try it
+
+<Playground client:only="react" utilityId="debounce" />
 
 ## Import
 

--- a/website/src/content/docs/async/retry.mdx
+++ b/website/src/content/docs/async/retry.mdx
@@ -3,7 +3,13 @@ title: retry
 description: Retry an async function with configurable backoff
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Retries an async (or sync) function up to a specified number of attempts, with configurable delay and backoff strategy.
+
+## Try it
+
+<Playground client:only="react" utilityId="retry" />
 
 ## Import
 

--- a/website/src/content/docs/async/safely.mdx
+++ b/website/src/content/docs/async/safely.mdx
@@ -3,7 +3,13 @@ title: safely
 description: Wrap a function so it returns a [error, result] tuple instead of throwing
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Wraps a function so it returns a `[error, result]` tuple instead of throwing. Auto-detects sync and async functions: sync calls return a tuple, async calls return a `Promise` of a tuple. Eliminates verbose `try/catch` blocks and anticipates the [TC39 Safe Assignment Operator](https://github.com/arthurfiorette/proposal-safe-assignment-operator) proposal.
+
+## Try it
+
+<Playground client:only="react" utilityId="safely" />
 
 On success the tuple is `[undefined, value]`. On error it is `[error, undefined]`.
 

--- a/website/src/content/docs/async/sleep.mdx
+++ b/website/src/content/docs/async/sleep.mdx
@@ -3,7 +3,13 @@ title: sleep
 description: Pause execution for a given duration
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Pauses execution for a given number of milliseconds by returning a promise that resolves after the specified delay.
+
+## Try it
+
+<Playground client:only="react" utilityId="sleep" />
 
 ## Import
 

--- a/website/src/content/docs/async/throttle.mdx
+++ b/website/src/content/docs/async/throttle.mdx
@@ -3,7 +3,13 @@ title: throttle
 description: Create a throttled version of a function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a throttled version of a function that only invokes the original at most once per specified interval.
+
+## Try it
+
+<Playground client:only="react" utilityId="throttle" />
 
 ## Import
 

--- a/website/src/content/docs/async/wait-for-condition.mdx
+++ b/website/src/content/docs/async/wait-for-condition.mdx
@@ -3,7 +3,13 @@ title: waitForCondition
 description: Poll a sync or async predicate until truthy, rejecting on timeout
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Polls a `condition` function at a given `interval` until it returns truthy or the `timeout` elapses. Supports synchronous and asynchronous predicates, an optional `AbortSignal`, and a custom timeout `message`. Rejects with `TimeoutError` (the same class exported by [`withTimeout`](/async/with-timeout)) on timeout, so a single `instanceof` check covers both utilities.
+
+## Try it
+
+<Playground client:only="react" utilityId="wait-for-condition" />
 
 ## Import
 

--- a/website/src/content/docs/async/with-timeout.mdx
+++ b/website/src/content/docs/async/with-timeout.mdx
@@ -3,7 +3,13 @@ title: withTimeout
 description: Race a promise against a timeout with AbortSignal support
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Wraps a promise with a timeout. Rejects with a `TimeoutError` if the promise does not settle within the given duration. Supports an optional `AbortSignal` to cancel externally.
+
+## Try it
+
+<Playground client:only="react" utilityId="with-timeout" />
 
 ## Import
 

--- a/website/src/content/docs/browser/bind-key.mdx
+++ b/website/src/content/docs/browser/bind-key.mdx
@@ -1,0 +1,100 @@
+---
+title: bindKey
+description: Bind a keyboard shortcut or key sequence to a handler with modifiers, sequences, and a per-element scope
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Binds a keyboard combo or sequence to a handler and returns an idempotent unbind function. Supports modifiers (`ctrl`, `alt`, `shift`, `meta`/`cmd`, `mod`), multi-step sequences (`g i`), per-element scoping, automatic input filtering, and configurable repeat / preventDefault behavior.
+
+Browser-only utility — does not work in Node.js or other non-DOM environments.
+
+## Try it
+
+<Playground client:only="react" utilityId="bind-key" />
+
+:::tip
+The Sandpack preview iframe needs focus. Click inside the preview pane (not the editor) before pressing the bound combo.
+:::
+
+## Import
+
+```ts
+import { bindKey } from "1o1-utils";
+```
+
+```ts
+import { bindKey } from "1o1-utils/bind-key";
+```
+
+## Signature
+
+```ts
+function bindKey(
+  combo: string,
+  handler: (event: KeyboardEvent) => void,
+  options?: BindKeyOptions,
+): () => void
+```
+
+## Parameters
+
+| Name                       | Type                                  | Required | Description                                                                                                                                                                                                  |
+| -------------------------- | ------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `combo`                    | `string`                              | Yes      | Key combo (e.g. `"ctrl+k"`) or sequence (e.g. `"g i"`). Case-insensitive. `mod` aliases `meta` on macOS, `ctrl` elsewhere.                                                                                   |
+| `handler`                  | `(event: KeyboardEvent) => void`      | Yes      | Called with the final `KeyboardEvent` when the combo or full sequence matches.                                                                                                                               |
+| `options.target`           | `EventTarget`                         | No       | Element or `Document`/`Window` to attach to. Defaults to `window`.                                                                                                                                           |
+| `options.filterInputs`     | `boolean`                             | No       | Skip handler when focus is on an input-like element (default `true`). Combos with a non-shift modifier always fire regardless.                                                                               |
+| `options.sequenceTimeout`  | `number`                              | No       | Idle ms after which a sequence buffer resets. Default `1000`.                                                                                                                                                |
+| `options.preventDefault`   | `boolean`                             | No       | Call `event.preventDefault()` on a full match. Default `false`.                                                                                                                                              |
+| `options.ignoreRepeat`     | `boolean`                             | No       | Ignore auto-repeat events (`event.repeat === true`). Default `true`.                                                                                                                                         |
+
+## Returns
+
+`() => void` — Idempotent unbind function. Safe to call multiple times.
+
+## Examples
+
+```ts
+import { bindKey } from "1o1-utils/bind-key";
+
+const unbindSearch = bindKey("ctrl+k", (e) => {
+  e.preventDefault();
+  openSearch();
+});
+
+const unbindGotoInbox = bindKey("g i", () => goToInbox());
+const unbindEsc = bindKey("escape", () => closeModal());
+const unbindArrows = bindKey("ctrl+arrowleft", () => prevTab());
+
+// Cleanup on teardown
+unbindSearch();
+unbindGotoInbox();
+unbindEsc();
+unbindArrows();
+```
+
+```ts
+// React effect
+useEffect(() => bindKey("mod+s", saveDocument, { preventDefault: true }), []);
+```
+
+## Edge Cases
+
+- Throws if `combo` is empty or malformed.
+- Throws if `handler` is not a function.
+- The `mod` alias resolves to `meta` on macOS (`navigator.platform`) and `ctrl` elsewhere — keep cross-platform shortcuts portable.
+- Sequences reset after `sequenceTimeout` ms of inactivity.
+- Inputs (`input`, `textarea`, `select`, `contenteditable`) skip the handler unless the combo includes a non-shift modifier.
+- Auto-repeat (`event.repeat`) is ignored by default — pass `ignoreRepeat: false` to fire on every repeat.
+- Returns a no-op unbinder if `window`/`document` are missing (e.g. SSR).
+
+## Also known as
+
+keyboard shortcut, hotkey, key binding, keypress, keymap, accelerator, shortcut, mousetrap
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use bindKey to wire ctrl+k to open a command palette in a React app.
+```

--- a/website/src/content/docs/browser/copy-to-clipboard.mdx
+++ b/website/src/content/docs/browser/copy-to-clipboard.mdx
@@ -1,0 +1,83 @@
+---
+title: copyToClipboard
+description: Copy a string to the system clipboard with Clipboard API + execCommand fallback
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Copies a string to the system clipboard. Uses the asynchronous Clipboard API when available in a secure context, and falls back to a hidden `<textarea>` plus `document.execCommand("copy")` for older browsers and edge cases (iOS Safari, document not focused).
+
+Browser-only utility — does not work in Node.js or other non-DOM environments.
+
+## Try it
+
+<Playground client:only="react" utilityId="copy-to-clipboard" />
+
+:::caution
+The Clipboard API requires a user gesture (click, keydown, etc.). Calling `copyToClipboard` outside a user-initiated handler may reject with `NotAllowedError`.
+:::
+
+## Import
+
+```ts
+import { copyToClipboard } from "1o1-utils";
+```
+
+```ts
+import { copyToClipboard } from "1o1-utils/copy-to-clipboard";
+```
+
+## Signature
+
+```ts
+async function copyToClipboard({ text }: CopyToClipboardParams): Promise<void>
+```
+
+## Parameters
+
+| Name   | Type     | Required | Description                       |
+| ------ | -------- | -------- | --------------------------------- |
+| `text` | `string` | Yes      | The string to copy to the clipboard |
+
+## Returns
+
+`Promise<void>` — Resolves once the text has been copied. Rejects when no clipboard mechanism is available or both Clipboard API and `execCommand` fallback fail.
+
+## Examples
+
+```ts
+import { copyToClipboard } from "1o1-utils/copy-to-clipboard";
+
+button.addEventListener("click", async () => {
+  await copyToClipboard({ text: "Hello world" });
+  toast.show("Copied!");
+});
+```
+
+```ts
+import { safely } from "1o1-utils/safely";
+import { copyToClipboard } from "1o1-utils/copy-to-clipboard";
+
+const [err] = await safely(() => copyToClipboard({ text: code }))();
+if (err) toast.show("Copy failed — please copy manually.");
+else toast.show("Copied!");
+```
+
+## Edge Cases
+
+- Throws if `text` is not a string.
+- The Clipboard API is only attempted when `globalThis.isSecureContext` is `true` (HTTPS or `localhost`).
+- The fallback inserts an off-screen, hidden `<textarea>`, copies via Range + Selection, and removes it. The user's existing selection is restored after the copy.
+- An empty string short-circuits — `execCommand("copy")` rejects empty selections in some browsers.
+- When both paths fail, the thrown error carries the original Clipboard API error in `cause`.
+- Throws `Clipboard not available in this environment` when neither API nor `document.body` is reachable (e.g. SSR, Node).
+
+## Also known as
+
+clipboard, copy, copy text, paste, navigator clipboard, execCommand
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use copyToClipboard to add a "Copy code" button to a code block.
+```

--- a/website/src/content/docs/comparisons/deep-equal.mdx
+++ b/website/src/content/docs/comparisons/deep-equal.mdx
@@ -3,7 +3,13 @@ title: deepEqual
 description: Recursively compare two values for structural equality across nested objects, arrays, and built-ins
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Recursively compares two values for structural equality. Handles primitives, plain objects, class instances (same prototype), arrays, `Date`, `RegExp`, `Map`, `Set`, `ArrayBuffer`, and typed arrays. Circular references are tracked with a `WeakMap` pair-cache; on cycle, the pair is assumed equal. Functions, `Error` instances, and other unsupported objects fall back to reference equality.
+
+## Try it
+
+<Playground client:only="react" utilityId="deep-equal" />
 
 ## Import
 

--- a/website/src/content/docs/comparisons/is-nil.mdx
+++ b/website/src/content/docs/comparisons/is-nil.mdx
@@ -3,7 +3,13 @@ title: isNil
 description: Check if a value is null or undefined
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Strict existence check for `null` or `undefined`. Distinct from `isEmpty`, which also treats empty strings, arrays, objects, Maps, and Sets as empty. `isNil` returns `true` only for the two nullish values.
+
+## Try it
+
+<Playground client:only="react" utilityId="is-nil" />
 
 ## Import
 

--- a/website/src/content/docs/comparisons/shallow-equal.mdx
+++ b/website/src/content/docs/comparisons/shallow-equal.mdx
@@ -3,7 +3,13 @@ title: shallowEqual
 description: Compare two values by their top-level entries using Object.is
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Compares two values by their top-level entries. Returns `true` when both values are strictly the same, or when they are arrays or plain objects with identical own-enumerable entries at the first level. Nested values are compared by reference, not structurally — use `deepEqual` for recursive comparison.
+
+## Try it
+
+<Playground client:only="react" utilityId="shallow-equal" />
 
 ## Import
 

--- a/website/src/content/docs/contributing.mdx
+++ b/website/src/content/docs/contributing.mdx
@@ -140,7 +140,75 @@ Add the new utility to both files at the root of the repository:
 
 These files are served on the docs site for AI tool discoverability.
 
-### 5. Create a changeset
+### 5. Add a playground example
+
+The docs site ships an interactive playground (`/playground/`) plus a per-utility `## Try it` block embedded on every utility page. Both are powered by the same Sandpack-based React component. Adding a new utility means contributing one example.
+
+#### 5a. Register the example
+
+Edit `website/src/content/examples/index.ts` and append an `Example` entry to the `EXAMPLES` array:
+
+```ts
+{
+  id: "my-util",          // kebab-case, must match the doc page slug
+  label: "myUtil",        // shown in the playground selector
+  category: "Arrays",     // Arrays | Objects | Numbers | Strings | Async | Validators | Comparisons | Functions
+  code: `import { myUtil } from "1o1-utils/my-util";
+
+const result = myUtil({ /* params */ });
+
+console.log(result);
+`,
+},
+```
+
+Snippet guidelines:
+
+- Use the **published API** (object-param form), not internals.
+- Keep it under ~15 lines so it fits the editor without scrolling.
+- Print output via `console.log` — the playground console panel renders it.
+- Import from the per-utility subpath (`1o1-utils/my-util`) to showcase tree-shaking.
+- Top-level `await` is supported (Sandpack `vanilla-ts` template).
+
+#### 5b. Embed the playground in the doc page
+
+Add the import + a `## Try it` section right after the frontmatter and the one-line summary in `website/src/content/docs/<category>/<my-util>.mdx`:
+
+```mdx
+---
+title: myUtil
+description: Brief description
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Brief one-paragraph summary.
+
+## Try it
+
+<Playground client:only="react" utilityId="my-util" />
+
+## Import
+...
+```
+
+`utilityId` **must** match the `id` in `EXAMPLES`. The `../../../components/Playground.tsx` path is correct for any `docs/<category>/<file>.mdx` page.
+
+#### 5c. Verify locally
+
+```bash
+pnpm docs:dev
+```
+
+Open `http://localhost:4321/1o1-utils/<category>/<my-util>/` and confirm the playground:
+
+1. Loads (Sandpack fetches `1o1-utils` from the CDN — first load takes a few seconds).
+2. Runs the snippet without throwing.
+3. Prints the expected output to the console panel.
+
+Also check `/playground/` — your example should appear in the selector under its category.
+
+### 6. Create a changeset
 
 ```bash
 pnpm changeset
@@ -229,6 +297,9 @@ Each utility must stay under its size limit (1-2 kB gzipped). The total library 
 - [ ] Export entry added to `package.json`
 - [ ] Size-limit entry added to `.size-limit.json`
 - [ ] Utility added to `llms.txt` and `llms-full.txt`
+- [ ] Playground example added to `website/src/content/examples/index.ts`
+- [ ] `## Try it` block with `<Playground utilityId="..." />` embedded in the docs page
+- [ ] Playground verified locally via `pnpm docs:dev`
 - [ ] `@keywords` added to JSDoc
 - [ ] `@see` RFC/standard reference added (if applicable)
 - [ ] "Also known as" section added to docs page

--- a/website/src/content/docs/formatters/seconds-to-time-format.mdx
+++ b/website/src/content/docs/formatters/seconds-to-time-format.mdx
@@ -3,7 +3,13 @@ title: secondsToTimeFormat
 description: Format seconds as a zero-padded MM:SS or H:MM:SS time string
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Converts a non-negative number of seconds into a zero-padded time-format string. Uses `MM:SS` when under one hour and `H:MM:SS` (or `HH:MM:SS` with `padHours: true`) otherwise. Hours are not capped at 24, and non-integer seconds are floored.
+
+## Try it
+
+<Playground client:only="react" utilityId="seconds-to-time-format" />
 
 ## Import
 

--- a/website/src/content/docs/formatters/time-format-to-seconds.mdx
+++ b/website/src/content/docs/formatters/time-format-to-seconds.mdx
@@ -3,7 +3,13 @@ title: timeFormatToSeconds
 description: Parse a MM:SS or H:MM:SS time string into seconds
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Parses a time-format string (`MM:SS` or `[H]H:MM:SS`) into a total number of seconds. Inverse of `secondsToTimeFormat`. Hours are not capped; minutes and seconds must be in `0..59`.
+
+## Try it
+
+<Playground client:only="react" utilityId="time-format-to-seconds" />
 
 ## Import
 

--- a/website/src/content/docs/functions/memo.mdx
+++ b/website/src/content/docs/functions/memo.mdx
@@ -3,7 +3,13 @@ title: memo
 description: Memoize a function with optional TTL and custom cache key
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Caches a function's return value per unique argument set so repeat calls skip the computation. Optionally expires entries after `ttl` milliseconds, and accepts a custom `key` resolver for control over cache identity.
+
+## Try it
+
+<Playground client:only="react" utilityId="memo" />
 
 ## Import
 

--- a/website/src/content/docs/functions/once.mdx
+++ b/website/src/content/docs/functions/once.mdx
@@ -3,7 +3,13 @@ title: once
 description: Create a function that runs only once and caches its result
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a version of a function that runs only once. Subsequent calls return the cached result from the first invocation and ignore any new arguments.
+
+## Try it
+
+<Playground client:only="react" utilityId="once" />
 
 ## Import
 

--- a/website/src/content/docs/functions/pipe.mdx
+++ b/website/src/content/docs/functions/pipe.mdx
@@ -3,7 +3,13 @@ title: pipe
 description: Compose functions left-to-right into a single function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Composes functions left-to-right. The first function receives the initial arguments; each subsequent function receives the previous function's return value. Aligned with the [TC39 pipe operator proposal](https://github.com/tc39/proposal-pipeline-operator).
+
+## Try it
+
+<Playground client:only="react" utilityId="pipe" />
 
 ## Import
 

--- a/website/src/content/docs/numbers/clamp.mdx
+++ b/website/src/content/docs/numbers/clamp.mdx
@@ -3,7 +3,13 @@ title: clamp
 description: Clamp a number to a given range
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Clamps a number to a given range. Returns `min` if `value` is below the range, `max` if above, otherwise `value`. If `min` is greater than `max`, the bounds are swapped automatically.
+
+## Try it
+
+<Playground client:only="react" utilityId="clamp" />
 
 ## Import
 

--- a/website/src/content/docs/numbers/in-range.mdx
+++ b/website/src/content/docs/numbers/in-range.mdx
@@ -3,7 +3,13 @@ title: inRange
 description: Check if a number falls within a given range
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Checks if a number falls within a given range. Start is inclusive, end is exclusive. If `start` is greater than `end`, the bounds are swapped automatically.
+
+## Try it
+
+<Playground client:only="react" utilityId="in-range" />
 
 ## Import
 

--- a/website/src/content/docs/numbers/random-int.mdx
+++ b/website/src/content/docs/numbers/random-int.mdx
@@ -3,7 +3,13 @@ title: randomInt
 description: Generate a cryptographically-secure random integer in a range
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Generates a cryptographically-secure random integer in the inclusive range `[min, max]`. Uses `crypto.getRandomValues` with rejection sampling — no modulo bias and no `Math.random`. If `min` is greater than `max`, the bounds are swapped automatically.
+
+## Try it
+
+<Playground client:only="react" utilityId="random-int" />
 
 ## Import
 

--- a/website/src/content/docs/objects/clone-deep.mdx
+++ b/website/src/content/docs/objects/clone-deep.mdx
@@ -3,7 +3,13 @@ title: cloneDeep
 description: Create a deep clone of a value
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a deep clone of any value. Handles plain objects, arrays, `Date`, `RegExp`, `Map`, `Set`, typed arrays, `ArrayBuffer`, `Error`, and circular references. Functions are copied by reference.
+
+## Try it
+
+<Playground client:only="react" utilityId="clone-deep" />
 
 Native `structuredClone` is a close alternative but throws on functions, class instances, and DOM nodes. `cloneDeep` covers those gaps and is 2–4× faster than `lodash.cloneDeep`.
 

--- a/website/src/content/docs/objects/compact.mdx
+++ b/website/src/content/docs/objects/compact.mdx
@@ -3,7 +3,13 @@ title: compact
 description: Remove falsy values from an object
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a new object with all falsy values removed. Pass `keep` to preserve specific falsy values that should survive.
+
+## Try it
+
+<Playground client:only="react" utilityId="compact" />
 
 Falsy values are `false`, `0`, `-0`, `0n`, `""`, `null`, `undefined`, and `NaN`. Matches in `keep` use `Object.is`, so `0` vs `-0` and `NaN` are handled exactly.
 

--- a/website/src/content/docs/objects/deep-merge.mdx
+++ b/website/src/content/docs/objects/deep-merge.mdx
@@ -3,7 +3,13 @@ title: deepMerge
 description: Recursively merge two objects
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Recursively merges two objects into a new object. Nested plain objects are merged deeply, while arrays and other types are overwritten by the source value.
+
+## Try it
+
+<Playground client:only="react" utilityId="deep-merge" />
 
 ## Import
 

--- a/website/src/content/docs/objects/defaults-deep.mdx
+++ b/website/src/content/docs/objects/defaults-deep.mdx
@@ -3,7 +3,13 @@ title: defaultsDeep
 description: Recursively fill undefined properties with defaults from another object
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Recursively assigns default values from `source` to `target`. For each property, if the target's value is `undefined` (or missing), the source's value is used. When both sides have plain objects at the same key, they are merged recursively. Existing `null`, `0`, `""`, `false`, and array values in the target are preserved.
+
+## Try it
+
+<Playground client:only="react" utilityId="defaults-deep" />
 
 ## Import
 

--- a/website/src/content/docs/objects/defaults.mdx
+++ b/website/src/content/docs/objects/defaults.mdx
@@ -3,7 +3,13 @@ title: defaults
 description: Fill undefined properties with defaults from another object
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Assigns default values from `source` to `target` for properties that are `undefined` or missing. Existing `null`, `0`, `""`, and `false` values in the target are preserved — only `undefined` triggers replacement.
+
+## Try it
+
+<Playground client:only="react" utilityId="defaults" />
 
 ## Import
 

--- a/website/src/content/docs/objects/get.mdx
+++ b/website/src/content/docs/objects/get.mdx
@@ -3,7 +3,13 @@ title: get
 description: Read a nested value from an object via dot notation with a default fallback
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Reads a nested value from an object using a dot-notation path. Returns `defaultValue` (or `undefined`) when the path does not resolve. Never throws.
+
+## Try it
+
+<Playground client:only="react" utilityId="get" />
 
 ## Import
 

--- a/website/src/content/docs/objects/is-empty.mdx
+++ b/website/src/content/docs/objects/is-empty.mdx
@@ -3,7 +3,13 @@ title: isEmpty
 description: Check if a value is empty
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Checks whether a given value is considered empty. Supports strings, arrays, plain objects, Maps, and Sets.
+
+## Try it
+
+<Playground client:only="react" utilityId="is-empty" />
 
 ## Import
 

--- a/website/src/content/docs/objects/map-keys.mdx
+++ b/website/src/content/docs/objects/map-keys.mdx
@@ -3,7 +3,13 @@ title: mapKeys
 description: Transform object keys via an iteratee function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a new object with the same values as `obj`, but with each key replaced by `String(iteratee(value, key, obj))`. Only own enumerable string keys are visited. Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) returned by the iteratee are silently skipped. When two keys collide, the last write wins.
+
+## Try it
+
+<Playground client:only="react" utilityId="map-keys" />
 
 ## Import
 

--- a/website/src/content/docs/objects/map-values.mdx
+++ b/website/src/content/docs/objects/map-values.mdx
@@ -3,7 +3,13 @@ title: mapValues
 description: Transform object values via an iteratee function
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a new object with the same keys as `obj`, but with each value replaced by `iteratee(value, key, obj)`. Only own enumerable string keys are visited. Useful for projecting an object through a pure transformation while preserving its shape.
+
+## Try it
+
+<Playground client:only="react" utilityId="map-values" />
 
 ## Import
 

--- a/website/src/content/docs/objects/omit-by.mdx
+++ b/website/src/content/docs/objects/omit-by.mdx
@@ -1,0 +1,72 @@
+---
+title: omitBy
+description: Create an object excluding the entries that match a predicate
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Creates a new object excluding the entries for which the predicate returns truthy. The predicate receives `(value, key)` for each own enumerable string property. Inverse of [`pickBy`](./pick-by/).
+
+## Try it
+
+<Playground client:only="react" utilityId="omit-by" />
+
+## Import
+
+```ts
+import { omitBy } from "1o1-utils";
+```
+
+```ts
+import { omitBy } from "1o1-utils/omit-by";
+```
+
+## Signature
+
+```ts
+function omitBy<T extends Record<string, unknown>>({
+  obj,
+  predicate,
+}: OmitByParams<T>): Partial<T>
+```
+
+## Parameters
+
+| Name        | Type                              | Required | Description                                                              |
+| ----------- | --------------------------------- | -------- | ------------------------------------------------------------------------ |
+| `obj`       | `Record<string, unknown>`         | Yes      | The source object                                                        |
+| `predicate` | `(value, key) => boolean`         | Yes      | Called per entry; the entry is removed when the function returns truthy  |
+
+## Returns
+
+`Partial<T>` — A new object without the entries the predicate matched.
+
+## Examples
+
+```ts
+omitBy({ obj: { a: 1, b: 2, c: 3 }, predicate: (v) => v > 1 });
+// => { a: 1 }
+
+omitBy({
+  obj: { id: 1, name: "Ada", password: "secret", token: "xyz" },
+  predicate: (_, key) => key === "password" || key === "token",
+});
+// => { id: 1, name: "Ada" }
+```
+
+## Edge Cases
+
+- Throws if `obj` is not an object or is `null`.
+- Throws if `predicate` is not a function.
+- Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are skipped.
+- Inherited keys are ignored — only own enumerable string keys are visited.
+
+## Also known as
+
+filter object, exclude by value, conditional omit, predicate omit, reject
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use omitBy to strip secret fields from an object before logging it.
+```

--- a/website/src/content/docs/objects/omit.mdx
+++ b/website/src/content/docs/objects/omit.mdx
@@ -3,7 +3,13 @@ title: omit
 description: Create an object with specified keys removed
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a new object with the specified keys removed. Supports dot notation for removing nested keys.
+
+## Try it
+
+<Playground client:only="react" utilityId="omit" />
 
 ## Import
 

--- a/website/src/content/docs/objects/pick-by.mdx
+++ b/website/src/content/docs/objects/pick-by.mdx
@@ -1,0 +1,72 @@
+---
+title: pickBy
+description: Create an object with only the entries that match a predicate
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Creates a new object containing only the entries for which the predicate returns truthy. The predicate receives `(value, key)` for each own enumerable string property.
+
+## Try it
+
+<Playground client:only="react" utilityId="pick-by" />
+
+## Import
+
+```ts
+import { pickBy } from "1o1-utils";
+```
+
+```ts
+import { pickBy } from "1o1-utils/pick-by";
+```
+
+## Signature
+
+```ts
+function pickBy<T extends Record<string, unknown>>({
+  obj,
+  predicate,
+}: PickByParams<T>): Partial<T>
+```
+
+## Parameters
+
+| Name        | Type                              | Required | Description                                                          |
+| ----------- | --------------------------------- | -------- | -------------------------------------------------------------------- |
+| `obj`       | `Record<string, unknown>`         | Yes      | The source object                                                    |
+| `predicate` | `(value, key) => boolean`         | Yes      | Called per entry; the entry is kept when the function returns truthy |
+
+## Returns
+
+`Partial<T>` — A new object with only the entries the predicate kept.
+
+## Examples
+
+```ts
+pickBy({ obj: { a: 1, b: null, c: 3 }, predicate: (v) => v !== null });
+// => { a: 1, c: 3 }
+
+pickBy({
+  obj: { name: "Ada", email: "", phone: "1234" },
+  predicate: (v) => typeof v === "string" && v.length > 0,
+});
+// => { name: "Ada", phone: "1234" }
+```
+
+## Edge Cases
+
+- Throws if `obj` is not an object or is `null`.
+- Throws if `predicate` is not a function.
+- Prototype-pollution keys (`__proto__`, `constructor`, `prototype`) are skipped.
+- Inherited keys are ignored — only own enumerable string keys are visited.
+
+## Also known as
+
+filter object, conditional pick, object filter, predicate pick
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use pickBy to drop nullable fields from an API response before saving to state.
+```

--- a/website/src/content/docs/objects/pick.mdx
+++ b/website/src/content/docs/objects/pick.mdx
@@ -3,7 +3,13 @@ title: pick
 description: Create an object with only the specified keys
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Creates a new object containing only the specified keys from the source object. Supports dot notation for selecting nested keys.
+
+## Try it
+
+<Playground client:only="react" utilityId="pick" />
 
 ## Import
 

--- a/website/src/content/docs/objects/set.mdx
+++ b/website/src/content/docs/objects/set.mdx
@@ -3,7 +3,13 @@ title: set
 description: Set a nested value via dot notation without mutating the input
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Sets a nested value on an object using a dot-notation path. Non-mutating: returns a new object with only the nodes on the path cloned (structural sharing).
+
+## Try it
+
+<Playground client:only="react" utilityId="set" />
 
 ## Import
 

--- a/website/src/content/docs/playground.mdx
+++ b/website/src/content/docs/playground.mdx
@@ -1,0 +1,18 @@
+---
+title: Playground
+description: Try 1o1-utils utilities live in your browser. No install needed.
+template: doc
+---
+
+import Playground from "../../components/Playground.tsx";
+
+Pick a utility, edit the code, see the output. Runs `1o1-utils` directly from
+npm — no install, no build step.
+
+<Playground client:only="react" />
+
+## Notes
+
+- The bundle is fetched on first load (~few seconds). Subsequent runs are cached.
+- Console output appears on the right. Errors include stack traces.
+- Want a utility that isn't here yet? [Open an issue](https://github.com/pedrotroccoli/1o1-utils/issues/new) or PR a new example.

--- a/website/src/content/docs/strings/capitalize.mdx
+++ b/website/src/content/docs/strings/capitalize.mdx
@@ -3,7 +3,13 @@ title: capitalize
 description: Capitalize the first character of a string
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Capitalizes the first character of a string, with an option to preserve or lowercase the remaining characters.
+
+## Try it
+
+<Playground client:only="react" utilityId="capitalize" />
 
 ## Import
 

--- a/website/src/content/docs/strings/deburr.mdx
+++ b/website/src/content/docs/strings/deburr.mdx
@@ -1,0 +1,65 @@
+---
+title: deburr
+description: Remove diacritics from a string while preserving case and non-accented characters
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Removes combining diacritical marks (accents, tildes, cedillas, etc.) from a string while preserving case and non-accented characters. Useful for search, comparison, deduplication, and slug generation in languages that use combining marks (Portuguese, Spanish, French, Vietnamese, etc.).
+
+## Try it
+
+<Playground client:only="react" utilityId="deburr" />
+
+## Import
+
+```ts
+import { deburr } from "1o1-utils";
+```
+
+```ts
+import { deburr } from "1o1-utils/deburr";
+```
+
+## Signature
+
+```ts
+function deburr({ str }: DeburrParams): string
+```
+
+## Parameters
+
+| Name  | Type     | Required | Description           |
+| ----- | -------- | -------- | --------------------- |
+| `str` | `string` | Yes      | The string to deburr  |
+
+## Returns
+
+`string` — The string with combining diacritical marks removed.
+
+## Examples
+
+```ts
+deburr({ str: "café" });           // => "cafe"
+deburr({ str: "São Paulo" });      // => "Sao Paulo"
+deburr({ str: "résumé" });         // => "resume"
+deburr({ str: "naïve façade" });   // => "naive facade"
+deburr({ str: "Tiếng Việt" });     // => "Tieng Viet"
+```
+
+## Edge Cases
+
+- Throws if `str` is not a string.
+- Returns the empty string for an empty string input.
+- Characters that do not decompose under NFD are left untouched (e.g. German `ß`, Turkish `ı`/`İ`, Polish `ł`). Pair with locale-aware transliteration if you need broader coverage.
+- Combining marks outside the U+0300–U+036F range are not stripped.
+
+## Also known as
+
+remove accents, strip accents, normalize, ascii fold, transliterate, latinize
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use deburr to make a search box accent-insensitive.
+```

--- a/website/src/content/docs/strings/escape-reg-exp.mdx
+++ b/website/src/content/docs/strings/escape-reg-exp.mdx
@@ -3,7 +3,13 @@ title: escapeRegExp
 description: Escape regex metacharacters so a string can be safely interpolated into a RegExp
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Escapes the 12 ECMAScript regex metacharacters (`. * + ? ^ $ { } ( ) | [ ] \`) so the string can be safely interpolated into a `RegExp`. Prevents regex injection when user input is used in a pattern.
+
+## Try it
+
+<Playground client:only="react" utilityId="escape-reg-exp" />
 
 ## Import
 

--- a/website/src/content/docs/strings/normalize-email.mdx
+++ b/website/src/content/docs/strings/normalize-email.mdx
@@ -3,7 +3,13 @@ title: normalizeEmail
 description: Normalize an email by trimming, lowercasing, and optionally stripping plus-addressing
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Normalizes an email address by trimming whitespace, lowercasing, and optionally stripping plus-addressing (`+alias`). Useful for deduplicating emails since most providers route `user+tag@example.com` to the same mailbox as `user@example.com`.
+
+## Try it
+
+<Playground client:only="react" utilityId="normalize-email" />
 
 ## Import
 

--- a/website/src/content/docs/strings/slugify.mdx
+++ b/website/src/content/docs/strings/slugify.mdx
@@ -3,7 +3,13 @@ title: slugify
 description: Convert a string to a URL-friendly slug
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Converts a string to a URL-friendly slug by lowercasing, stripping accents, and replacing non-alphanumeric characters with hyphens.
+
+## Try it
+
+<Playground client:only="react" utilityId="slugify" />
 
 ## Import
 

--- a/website/src/content/docs/strings/transform-case.mdx
+++ b/website/src/content/docs/strings/transform-case.mdx
@@ -3,7 +3,13 @@ title: transformCase
 description: Convert a string between case styles
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Converts a string between common case styles such as camelCase, kebab-case, snake_case, PascalCase, and Title Case.
+
+## Try it
+
+<Playground client:only="react" utilityId="transform-case" />
 
 ## Import
 

--- a/website/src/content/docs/strings/truncate.mdx
+++ b/website/src/content/docs/strings/truncate.mdx
@@ -3,7 +3,13 @@ title: truncate
 description: Truncate a string to a specified length
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Truncates a string to a specified length, appending a configurable suffix when the string exceeds the limit.
+
+## Try it
+
+<Playground client:only="react" utilityId="truncate" />
 
 ## Import
 

--- a/website/src/content/docs/validators/is-valid-email.mdx
+++ b/website/src/content/docs/validators/is-valid-email.mdx
@@ -3,7 +3,13 @@ title: isValidEmail
 description: Check if a string is a well-formed email address using the HTML5 living-standard pattern
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Validates whether a string is a well-formed email address. Uses the HTML5 living-standard email pattern (the same one browsers use for `<input type="email">`) plus RFC 5321 length limits (local part ≤64, total ≤254). Pragmatic over RFC 5322 strict — accepts the addresses people actually use.
+
+## Try it
+
+<Playground client:only="react" utilityId="is-valid-email" />
 
 ## Import
 

--- a/website/src/content/docs/validators/is-valid-phone.mdx
+++ b/website/src/content/docs/validators/is-valid-phone.mdx
@@ -3,7 +3,13 @@ title: isValidPhone
 description: Check if a string is a well-formed E.164 international phone number
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Validates whether a string is a well-formed E.164 international phone number. Requires a leading `+`, a non-zero country code, and 1–15 total digits. Common readability separators — spaces, hyphens, parentheses, and dots — are stripped before validation; any other character causes rejection.
+
+## Try it
+
+<Playground client:only="react" utilityId="is-valid-phone" />
 
 ## Import
 

--- a/website/src/content/docs/validators/is-valid-url.mdx
+++ b/website/src/content/docs/validators/is-valid-url.mdx
@@ -3,7 +3,13 @@ title: isValidUrl
 description: Check if a string is a parseable URL using the WHATWG URL API
 ---
 
+import Playground from "../../../components/Playground.tsx";
+
 Validates whether a value is a well-formed URL string. Delegates parsing to the WHATWG `URL` API — the same parser used by browsers and Node — so any scheme accepted by `new URL(input)` is considered valid (including `http`, `https`, `ftp`, `file`, and custom schemes).
+
+## Try it
+
+<Playground client:only="react" utilityId="is-valid-url" />
 
 ## Import
 

--- a/website/src/content/examples/index.ts
+++ b/website/src/content/examples/index.ts
@@ -1,0 +1,821 @@
+export type Example = {
+  id: string;
+  label: string;
+  category: string;
+  code: string;
+};
+
+export const EXAMPLES: Example[] = [
+  // ============ Arrays ============
+  {
+    id: "array-to-hash",
+    label: "arrayToHash",
+    category: "Arrays",
+    code: `import { arrayToHash } from "1o1-utils/array-to-hash";
+
+const users = [
+  { id: 1, name: "Ada" },
+  { id: 2, name: "Bob" },
+  { id: 3, name: "Cleo" },
+];
+
+console.log(arrayToHash({ array: users, key: "id" }));
+// { "1": { id: 1, name: "Ada" }, ... }
+`,
+  },
+  {
+    id: "chunk",
+    label: "chunk",
+    category: "Arrays",
+    code: `import { chunk } from "1o1-utils/chunk";
+
+console.log(chunk({ array: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3 }));
+// [[1,2,3],[4,5,6],[7,8,9],[10]]
+`,
+  },
+  {
+    id: "diff",
+    label: "diff",
+    category: "Arrays",
+    code: `import { diff } from "1o1-utils/diff";
+
+console.log(diff({ array: [1, 2, 3, 4], values: [2, 4] }));
+// [1, 3]
+
+const a = [{ id: 1 }, { id: 2 }, { id: 3 }];
+const b = [{ id: 2 }];
+console.log(diff({ array: a, values: b, iteratee: (x) => x.id }));
+`,
+  },
+  {
+    id: "group-by",
+    label: "groupBy",
+    category: "Arrays",
+    code: `import { groupBy } from "1o1-utils/group-by";
+
+const users = [
+  { id: 1, role: "admin", name: "Ada" },
+  { id: 2, role: "user", name: "Bob" },
+  { id: 3, role: "admin", name: "Cleo" },
+];
+
+console.log(groupBy({ array: users, key: "role" }));
+`,
+  },
+  {
+    id: "partition",
+    label: "partition",
+    category: "Arrays",
+    code: `import { partition } from "1o1-utils/partition";
+
+const [evens, odds] = partition({
+  array: [1, 2, 3, 4, 5, 6],
+  predicate: (n) => n % 2 === 0,
+});
+
+console.log({ evens, odds });
+`,
+  },
+  {
+    id: "range",
+    label: "range",
+    category: "Arrays",
+    code: `import { range } from "1o1-utils/range";
+
+console.log(range({ end: 5 }));
+// [0, 1, 2, 3, 4]
+
+console.log(range({ start: 1, end: 10, step: 2 }));
+// [1, 3, 5, 7, 9]
+`,
+  },
+  {
+    id: "replace",
+    label: "replace",
+    category: "Arrays",
+    code: `import { replace } from "1o1-utils/replace";
+
+const items = [
+  { id: 1, name: "Ada", role: "user" },
+  { id: 2, name: "Bob", role: "user" },
+  { id: 3, name: "Cleo", role: "user" },
+];
+
+console.log(
+  replace({
+    array: items,
+    predicate: (u) => u.id === 2,
+    value: { id: 2, name: "Bob", role: "admin" },
+  })
+);
+`,
+  },
+  {
+    id: "shuffle",
+    label: "shuffle",
+    category: "Arrays",
+    code: `import { shuffle } from "1o1-utils/shuffle";
+
+console.log(shuffle({ array: [1, 2, 3, 4, 5] }));
+`,
+  },
+  {
+    id: "sort-by",
+    label: "sortBy",
+    category: "Arrays",
+    code: `import { sortBy } from "1o1-utils/sort-by";
+
+const users = [
+  { name: "Bob", age: 30 },
+  { name: "Ada", age: 25 },
+  { name: "Cleo", age: 35 },
+];
+
+console.log(sortBy({ array: users, key: "age" }));
+console.log(sortBy({ array: users, key: "age", order: "desc" }));
+`,
+  },
+  {
+    id: "times",
+    label: "times",
+    category: "Arrays",
+    code: `import { times } from "1o1-utils/times";
+
+console.log(times({ count: 5, fn: (i) => i * i }));
+// [0, 1, 4, 9, 16]
+`,
+  },
+  {
+    id: "unique",
+    label: "unique",
+    category: "Arrays",
+    code: `import { unique } from "1o1-utils/unique";
+
+console.log(unique({ array: [1, 2, 2, 3, 3, 3, 4] }));
+
+const users = [
+  { id: 1, name: "Ada" },
+  { id: 1, name: "Ada (dup)" },
+  { id: 2, name: "Bob" },
+];
+console.log(unique({ array: users, key: "id" }));
+`,
+  },
+  {
+    id: "unzip",
+    label: "unzip",
+    category: "Arrays",
+    code: `import { unzip } from "1o1-utils/unzip";
+
+console.log(
+  unzip({
+    array: [
+      [1, "a", true],
+      [2, "b", false],
+      [3, "c", true],
+    ],
+  })
+);
+// [[1,2,3], ["a","b","c"], [true,false,true]]
+`,
+  },
+  {
+    id: "zip",
+    label: "zip",
+    category: "Arrays",
+    code: `import { zip } from "1o1-utils/zip";
+
+console.log(
+  zip({
+    arrays: [
+      [1, 2, 3],
+      ["a", "b", "c"],
+      [true, false, true],
+    ],
+  })
+);
+// [[1,"a",true],[2,"b",false],[3,"c",true]]
+`,
+  },
+
+  // ============ Numbers ============
+  {
+    id: "clamp",
+    label: "clamp",
+    category: "Numbers",
+    code: `import { clamp } from "1o1-utils/clamp";
+
+console.log(clamp({ value: 15, min: 0, max: 10 })); // 10
+console.log(clamp({ value: -5, min: 0, max: 10 })); // 0
+console.log(clamp({ value: 7, min: 0, max: 10 })); // 7
+`,
+  },
+  {
+    id: "in-range",
+    label: "inRange",
+    category: "Numbers",
+    code: `import { inRange } from "1o1-utils/in-range";
+
+console.log(inRange({ value: 5, start: 0, end: 10 })); // true
+console.log(inRange({ value: 10, start: 0, end: 10 })); // false (end exclusive)
+console.log(inRange({ value: -1, start: 0, end: 10 })); // false
+`,
+  },
+  {
+    id: "random-int",
+    label: "randomInt",
+    category: "Numbers",
+    code: `import { randomInt } from "1o1-utils/random-int";
+
+for (let i = 0; i < 5; i++) {
+  console.log(randomInt({ min: 1, max: 100 }));
+}
+`,
+  },
+
+  // ============ Objects ============
+  {
+    id: "clone-deep",
+    label: "cloneDeep",
+    category: "Objects",
+    code: `import { cloneDeep } from "1o1-utils/clone-deep";
+
+const original = {
+  user: { name: "Ada", tags: ["admin"] },
+  date: new Date(),
+};
+
+const copy = cloneDeep({ value: original });
+copy.user.tags.push("editor");
+
+console.log({ original: original.user.tags, copy: copy.user.tags });
+`,
+  },
+  {
+    id: "compact",
+    label: "compact",
+    category: "Objects",
+    code: `import { compact } from "1o1-utils/compact";
+
+const data = {
+  name: "Ada",
+  email: "",
+  age: 0,
+  bio: null,
+  active: true,
+};
+
+console.log(compact({ obj: data }));
+// removes falsy values by default
+`,
+  },
+  {
+    id: "deep-merge",
+    label: "deepMerge",
+    category: "Objects",
+    code: `import { deepMerge } from "1o1-utils/deep-merge";
+
+const target = { theme: { color: "blue", size: "md" }, debug: false };
+const source = { theme: { color: "red" }, debug: true };
+
+console.log(deepMerge({ target, source }));
+`,
+  },
+  {
+    id: "defaults",
+    label: "defaults",
+    category: "Objects",
+    code: `import { defaults } from "1o1-utils/defaults";
+
+const config = { port: 3000 };
+const defaults_ = { port: 8080, host: "localhost", debug: false };
+
+console.log(defaults({ target: config, source: defaults_ }));
+// { port: 3000, host: "localhost", debug: false }
+`,
+  },
+  {
+    id: "defaults-deep",
+    label: "defaultsDeep",
+    category: "Objects",
+    code: `import { defaultsDeep } from "1o1-utils/defaults-deep";
+
+const config = { server: { port: 3000 } };
+const defaults_ = { server: { port: 8080, host: "localhost" }, debug: false };
+
+console.log(defaultsDeep({ target: config, source: defaults_ }));
+`,
+  },
+  {
+    id: "get",
+    label: "get",
+    category: "Objects",
+    code: `import { get } from "1o1-utils/get";
+
+const data = { user: { profile: { name: "Ada" } } };
+
+console.log(get({ obj: data, path: "user.profile.name" }));
+console.log(get({ obj: data, path: "user.profile.missing", defaultValue: "fallback" }));
+`,
+  },
+  {
+    id: "is-empty",
+    label: "isEmpty",
+    category: "Objects",
+    code: `import { isEmpty } from "1o1-utils/is-empty";
+
+console.log(isEmpty({ value: "" })); // true
+console.log(isEmpty({ value: [] })); // true
+console.log(isEmpty({ value: {} })); // true
+console.log(isEmpty({ value: null })); // true
+console.log(isEmpty({ value: "hi" })); // false
+console.log(isEmpty({ value: [1] })); // false
+`,
+  },
+  {
+    id: "map-keys",
+    label: "mapKeys",
+    category: "Objects",
+    code: `import { mapKeys } from "1o1-utils/map-keys";
+
+const data = { firstName: "Ada", lastName: "Lovelace" };
+
+console.log(
+  mapKeys({
+    obj: data,
+    iteratee: (key) => key.toUpperCase(),
+  })
+);
+`,
+  },
+  {
+    id: "map-values",
+    label: "mapValues",
+    category: "Objects",
+    code: `import { mapValues } from "1o1-utils/map-values";
+
+const scores = { ada: 90, bob: 75, cleo: 88 };
+
+console.log(
+  mapValues({
+    obj: scores,
+    iteratee: (v) => \`\${v}%\`,
+  })
+);
+`,
+  },
+  {
+    id: "omit",
+    label: "omit",
+    category: "Objects",
+    code: `import { omit } from "1o1-utils/omit";
+
+const user = { id: 1, name: "Ada", password: "secret", token: "xyz" };
+
+console.log(omit({ obj: user, keys: ["password", "token"] }));
+`,
+  },
+  {
+    id: "omit-by",
+    label: "omitBy",
+    category: "Objects",
+    code: `import { omitBy } from "1o1-utils/omit-by";
+
+const data = { id: 1, name: "Ada", password: "secret", token: "xyz" };
+
+console.log(
+  omitBy({
+    obj: data,
+    predicate: (_, key) => key === "password" || key === "token",
+  })
+);
+`,
+  },
+  {
+    id: "pick-by",
+    label: "pickBy",
+    category: "Objects",
+    code: `import { pickBy } from "1o1-utils/pick-by";
+
+const data = { a: 1, b: null, c: 3, d: undefined };
+
+console.log(pickBy({ obj: data, predicate: (v) => v != null }));
+// { a: 1, c: 3 }
+`,
+  },
+  {
+    id: "pick",
+    label: "pick",
+    category: "Objects",
+    code: `import { pick } from "1o1-utils/pick";
+
+const user = { id: 1, name: "Ada", email: "ada@x.dev", role: "admin" };
+
+console.log(pick({ obj: user, keys: ["id", "name"] }));
+`,
+  },
+  {
+    id: "set",
+    label: "set",
+    category: "Objects",
+    code: `import { set } from "1o1-utils/set";
+
+const data = { user: { profile: { name: "Ada" } } };
+
+console.log(set({ obj: data, path: "user.profile.name", value: "Bob" }));
+console.log(set({ obj: data, path: "user.profile.email", value: "bob@x.dev" }));
+`,
+  },
+
+  // ============ Strings ============
+  {
+    id: "deburr",
+    label: "deburr",
+    category: "Strings",
+    code: `import { deburr } from "1o1-utils/deburr";
+
+console.log(deburr({ str: "São Paulo" }));   // "Sao Paulo"
+console.log(deburr({ str: "café résumé" })); // "cafe resume"
+console.log(deburr({ str: "Tiếng Việt" }));  // "Tieng Viet"
+`,
+  },
+  {
+    id: "capitalize",
+    label: "capitalize",
+    category: "Strings",
+    code: `import { capitalize } from "1o1-utils/capitalize";
+
+console.log(capitalize({ str: "hello world" })); // "Hello world"
+console.log(capitalize({ str: "HELLO", preserveRest: true })); // "HELLO"
+console.log(capitalize({ str: "HELLO" })); // "Hello"
+`,
+  },
+  {
+    id: "escape-reg-exp",
+    label: "escapeRegExp",
+    category: "Strings",
+    code: `import { escapeRegExp } from "1o1-utils/escape-reg-exp";
+
+const userInput = "1.5 + 2 * (3 - 1)";
+const escaped = escapeRegExp({ str: userInput });
+
+console.log(escaped);
+console.log(new RegExp(escaped).test(userInput));
+`,
+  },
+  {
+    id: "normalize-email",
+    label: "normalizeEmail",
+    category: "Strings",
+    code: `import { normalizeEmail } from "1o1-utils/normalize-email";
+
+console.log(normalizeEmail({ email: "  Foo.Bar@Gmail.COM  " }));
+console.log(normalizeEmail({ email: "user+spam@gmail.com", stripPlus: true }));
+`,
+  },
+  {
+    id: "slugify",
+    label: "slugify",
+    category: "Strings",
+    code: `import { slugify } from "1o1-utils/slugify";
+
+console.log(slugify({ str: "Olá Mundo! 1o1-utils é rápido" }));
+// ola-mundo-1o1-utils-e-rapido
+`,
+  },
+  {
+    id: "transform-case",
+    label: "transformCase",
+    category: "Strings",
+    code: `import { transformCase } from "1o1-utils/transform-case";
+
+console.log(transformCase({ str: "hello world", style: "camel" }));
+console.log(transformCase({ str: "hello world", style: "snake" }));
+console.log(transformCase({ str: "hello world", style: "kebab" }));
+console.log(transformCase({ str: "hello world", style: "pascal" }));
+`,
+  },
+  {
+    id: "truncate",
+    label: "truncate",
+    category: "Strings",
+    code: `import { truncate } from "1o1-utils/truncate";
+
+const text = "The quick brown fox jumps over the lazy dog";
+
+console.log(truncate({ str: text, length: 20 }));
+console.log(truncate({ str: text, length: 20, suffix: "…" }));
+`,
+  },
+
+  // ============ Async ============
+  {
+    id: "debounce",
+    label: "debounce",
+    category: "Async",
+    code: `import { debounce } from "1o1-utils/debounce";
+
+const search = debounce({
+  fn: (query) => console.log("searching:", query),
+  ms: 200,
+});
+
+search("a");
+search("ab");
+search("abc");
+
+// Only the last call fires after 200ms
+`,
+  },
+  {
+    id: "retry",
+    label: "retry",
+    category: "Async",
+    code: `import { retry } from "1o1-utils/retry";
+
+let attempt = 0;
+const flaky = async () => {
+  attempt++;
+  if (attempt < 3) throw new Error("fail " + attempt);
+  return "ok on attempt " + attempt;
+};
+
+console.log(await retry({ fn: flaky, attempts: 5, delay: 50 }));
+`,
+  },
+  {
+    id: "safely",
+    label: "safely",
+    category: "Async",
+    code: `import { safely } from "1o1-utils/safely";
+
+const safeParse = safely(JSON.parse);
+
+const [err1, val1] = safeParse("{invalid");
+console.log({ err1: err1?.message, val1 });
+
+const [err2, val2] = safeParse('{"ok":true}');
+console.log({ err2, val2 });
+`,
+  },
+  {
+    id: "sleep",
+    label: "sleep",
+    category: "Async",
+    code: `import { sleep } from "1o1-utils/sleep";
+
+console.log("start", new Date().toISOString());
+await sleep({ ms: 500 });
+console.log("end  ", new Date().toISOString());
+`,
+  },
+  {
+    id: "throttle",
+    label: "throttle",
+    category: "Async",
+    code: `import { throttle } from "1o1-utils/throttle";
+
+const log = throttle({
+  fn: (n) => console.log("call", n, "at", Date.now() % 10000),
+  ms: 100,
+});
+
+for (let i = 0; i < 5; i++) log(i);
+`,
+  },
+  {
+    id: "wait-for-condition",
+    label: "waitForCondition",
+    category: "Async",
+    code: `import { waitForCondition } from "1o1-utils/wait-for-condition";
+
+let ready = false;
+setTimeout(() => { ready = true; }, 300);
+
+await waitForCondition({
+  condition: () => ready,
+  interval: 50,
+  timeout: 2000,
+});
+
+console.log("ready!");
+`,
+  },
+  {
+    id: "with-timeout",
+    label: "withTimeout",
+    category: "Async",
+    code: `import { withTimeout } from "1o1-utils/with-timeout";
+import { safely } from "1o1-utils/safely";
+
+const slow = new Promise((resolve) => setTimeout(() => resolve("done"), 1000));
+
+const [err, result] = await safely(() =>
+  withTimeout({ promise: slow, ms: 200, message: "too slow!" })
+)();
+
+console.log({ err: err?.message, result });
+`,
+  },
+
+  // ============ Comparisons ============
+  {
+    id: "deep-equal",
+    label: "deepEqual",
+    category: "Comparisons",
+    code: `import { deepEqual } from "1o1-utils/deep-equal";
+
+console.log(
+  deepEqual({
+    a: { user: { tags: ["a", "b"] } },
+    b: { user: { tags: ["a", "b"] } },
+  })
+);
+
+console.log(
+  deepEqual({
+    a: new Map([["x", 1]]),
+    b: new Map([["x", 1]]),
+  })
+);
+`,
+  },
+  {
+    id: "is-nil",
+    label: "isNil",
+    category: "Comparisons",
+    code: `import { isNil } from "1o1-utils/is-nil";
+
+console.log(isNil({ value: null })); // true
+console.log(isNil({ value: undefined })); // true
+console.log(isNil({ value: 0 })); // false
+console.log(isNil({ value: "" })); // false
+`,
+  },
+  {
+    id: "shallow-equal",
+    label: "shallowEqual",
+    category: "Comparisons",
+    code: `import { shallowEqual } from "1o1-utils/shallow-equal";
+
+console.log(shallowEqual({ a: { x: 1, y: 2 }, b: { x: 1, y: 2 } })); // true
+console.log(shallowEqual({ a: [1, 2, 3], b: [1, 2, 3] })); // true
+console.log(shallowEqual({ a: { x: { n: 1 } }, b: { x: { n: 1 } } })); // false (nested)
+`,
+  },
+
+  // ============ Formatters ============
+  {
+    id: "seconds-to-time-format",
+    label: "secondsToTimeFormat",
+    category: "Formatters",
+    code: `import { secondsToTimeFormat } from "1o1-utils/seconds-to-time-format";
+
+console.log(secondsToTimeFormat({ seconds: 65 })); // "01:05"
+console.log(secondsToTimeFormat({ seconds: 3725 })); // "1:02:05"
+console.log(secondsToTimeFormat({ seconds: 3725, padHours: true })); // "01:02:05"
+`,
+  },
+  {
+    id: "time-format-to-seconds",
+    label: "timeFormatToSeconds",
+    category: "Formatters",
+    code: `import { timeFormatToSeconds } from "1o1-utils/time-format-to-seconds";
+
+console.log(timeFormatToSeconds({ time: "01:05" })); // 65
+console.log(timeFormatToSeconds({ time: "1:02:05" })); // 3725
+`,
+  },
+
+  // ============ Functions ============
+  {
+    id: "memo",
+    label: "memo",
+    category: "Functions",
+    code: `import { memo } from "1o1-utils/memo";
+
+let calls = 0;
+const slow = (n) => { calls++; return n * 2; };
+
+const fast = memo({ fn: slow });
+
+console.log(fast(5), fast(5), fast(5));
+console.log("calls:", calls); // 1
+`,
+  },
+  {
+    id: "once",
+    label: "once",
+    category: "Functions",
+    code: `import { once } from "1o1-utils/once";
+
+let setup = 0;
+const init = once(() => { setup++; return "ready"; });
+
+console.log(init(), init(), init());
+console.log("setup ran:", setup, "times"); // 1
+`,
+  },
+  {
+    id: "pipe",
+    label: "pipe",
+    category: "Functions",
+    code: `import { pipe } from "1o1-utils/pipe";
+
+const slug = pipe(
+  (s) => s.trim(),
+  (s) => s.toLowerCase(),
+  (s) => s.replace(/\\s+/g, "-")
+);
+
+console.log(slug("  Hello World  "));
+`,
+  },
+
+  // ============ Browser ============
+  {
+    id: "copy-to-clipboard",
+    label: "copyToClipboard",
+    category: "Browser",
+    code: `import { copyToClipboard } from "1o1-utils/copy-to-clipboard";
+import { safely } from "1o1-utils/safely";
+
+const root = document.getElementById("root");
+root.innerHTML = \`<button id="btn">Copy "1o1-utils"</button> <span id="msg"></span>\`;
+
+document.getElementById("btn").addEventListener("click", async () => {
+  const [err] = await safely(() =>
+    copyToClipboard({ text: "1o1-utils" })
+  )();
+  document.getElementById("msg").textContent = err
+    ? "failed: " + err.message
+    : "copied!";
+});
+
+console.log("Click the button in the preview to copy.");
+`,
+  },
+  {
+    id: "bind-key",
+    label: "bindKey",
+    category: "Browser",
+    code: `import { bindKey } from "1o1-utils/bind-key";
+
+const root = document.getElementById("root");
+root.innerHTML =
+  '<p style="font-family:system-ui">Click here, then press <b>g i</b> or <b>ctrl+k</b>.</p><pre id="log"></pre>';
+const log = document.getElementById("log");
+
+const append = (msg) => {
+  log.textContent = msg + "\\n" + log.textContent;
+};
+
+bindKey("g i", () => append("→ go to inbox (g i)"));
+bindKey("ctrl+k", (e) => {
+  e.preventDefault();
+  append("→ command palette (ctrl+k)");
+});
+
+console.log("Bound: 'g i' and 'ctrl+k'. Focus the preview to test.");
+`,
+  },
+
+  // ============ Validators ============
+  {
+    id: "is-valid-email",
+    label: "isValidEmail",
+    category: "Validators",
+    code: `import { isValidEmail } from "1o1-utils/is-valid-email";
+
+console.log(isValidEmail({ email: "ada@example.com" }));
+console.log(isValidEmail({ email: "not-an-email" }));
+console.log(isValidEmail({ email: "Ada <ada@example.com>", allowDisplayName: true }));
+`,
+  },
+  {
+    id: "is-valid-phone",
+    label: "isValidPhone",
+    category: "Validators",
+    code: `import { isValidPhone } from "1o1-utils/is-valid-phone";
+
+console.log(isValidPhone({ phone: "+1 415 555 0132" }));
+console.log(isValidPhone({ phone: "(11) 91234-5678", country: "BR" }));
+console.log(isValidPhone({ phone: "abc" }));
+`,
+  },
+  {
+    id: "is-valid-url",
+    label: "isValidUrl",
+    category: "Validators",
+    code: `import { isValidUrl } from "1o1-utils/is-valid-url";
+
+console.log(isValidUrl({ url: "https://example.com" }));
+console.log(isValidUrl({ url: "ftp://files.example.com" }));
+console.log(isValidUrl({ url: "ftp://files.example.com", protocols: ["http", "https"] }));
+`,
+  },
+];
+
+export const EXAMPLES_BY_ID: Record<string, Example> = Object.fromEntries(
+  EXAMPLES.map((e) => [e.id, e])
+);

--- a/website/src/content/examples/index.ts
+++ b/website/src/content/examples/index.ts
@@ -11,7 +11,7 @@ export const EXAMPLES: Example[] = [
     id: "array-to-hash",
     label: "arrayToHash",
     category: "Arrays",
-    code: `import { arrayToHash } from "1o1-utils/array-to-hash";
+    code: `import { arrayToHash } from "1o1-utils";
 
 const users = [
   { id: 1, name: "Ada" },
@@ -27,7 +27,7 @@ console.log(arrayToHash({ array: users, key: "id" }));
     id: "chunk",
     label: "chunk",
     category: "Arrays",
-    code: `import { chunk } from "1o1-utils/chunk";
+    code: `import { chunk } from "1o1-utils";
 
 console.log(chunk({ array: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3 }));
 // [[1,2,3],[4,5,6],[7,8,9],[10]]
@@ -37,7 +37,7 @@ console.log(chunk({ array: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10], size: 3 }));
     id: "diff",
     label: "diff",
     category: "Arrays",
-    code: `import { diff } from "1o1-utils/diff";
+    code: `import { diff } from "1o1-utils";
 
 console.log(diff({ array: [1, 2, 3, 4], values: [2, 4] }));
 // [1, 3]
@@ -51,7 +51,7 @@ console.log(diff({ array: a, values: b, iteratee: (x) => x.id }));
     id: "group-by",
     label: "groupBy",
     category: "Arrays",
-    code: `import { groupBy } from "1o1-utils/group-by";
+    code: `import { groupBy } from "1o1-utils";
 
 const users = [
   { id: 1, role: "admin", name: "Ada" },
@@ -66,7 +66,7 @@ console.log(groupBy({ array: users, key: "role" }));
     id: "partition",
     label: "partition",
     category: "Arrays",
-    code: `import { partition } from "1o1-utils/partition";
+    code: `import { partition } from "1o1-utils";
 
 const [evens, odds] = partition({
   array: [1, 2, 3, 4, 5, 6],
@@ -80,7 +80,7 @@ console.log({ evens, odds });
     id: "range",
     label: "range",
     category: "Arrays",
-    code: `import { range } from "1o1-utils/range";
+    code: `import { range } from "1o1-utils";
 
 console.log(range({ end: 5 }));
 // [0, 1, 2, 3, 4]
@@ -93,7 +93,7 @@ console.log(range({ start: 1, end: 10, step: 2 }));
     id: "replace",
     label: "replace",
     category: "Arrays",
-    code: `import { replace } from "1o1-utils/replace";
+    code: `import { replace } from "1o1-utils";
 
 const items = [
   { id: 1, name: "Ada", role: "user" },
@@ -114,7 +114,7 @@ console.log(
     id: "shuffle",
     label: "shuffle",
     category: "Arrays",
-    code: `import { shuffle } from "1o1-utils/shuffle";
+    code: `import { shuffle } from "1o1-utils";
 
 console.log(shuffle({ array: [1, 2, 3, 4, 5] }));
 `,
@@ -123,7 +123,7 @@ console.log(shuffle({ array: [1, 2, 3, 4, 5] }));
     id: "sort-by",
     label: "sortBy",
     category: "Arrays",
-    code: `import { sortBy } from "1o1-utils/sort-by";
+    code: `import { sortBy } from "1o1-utils";
 
 const users = [
   { name: "Bob", age: 30 },
@@ -139,7 +139,7 @@ console.log(sortBy({ array: users, key: "age", order: "desc" }));
     id: "times",
     label: "times",
     category: "Arrays",
-    code: `import { times } from "1o1-utils/times";
+    code: `import { times } from "1o1-utils";
 
 console.log(times({ count: 5, fn: (i) => i * i }));
 // [0, 1, 4, 9, 16]
@@ -149,7 +149,7 @@ console.log(times({ count: 5, fn: (i) => i * i }));
     id: "unique",
     label: "unique",
     category: "Arrays",
-    code: `import { unique } from "1o1-utils/unique";
+    code: `import { unique } from "1o1-utils";
 
 console.log(unique({ array: [1, 2, 2, 3, 3, 3, 4] }));
 
@@ -165,7 +165,7 @@ console.log(unique({ array: users, key: "id" }));
     id: "unzip",
     label: "unzip",
     category: "Arrays",
-    code: `import { unzip } from "1o1-utils/unzip";
+    code: `import { unzip } from "1o1-utils";
 
 console.log(
   unzip({
@@ -183,7 +183,7 @@ console.log(
     id: "zip",
     label: "zip",
     category: "Arrays",
-    code: `import { zip } from "1o1-utils/zip";
+    code: `import { zip } from "1o1-utils";
 
 console.log(
   zip({
@@ -203,7 +203,7 @@ console.log(
     id: "clamp",
     label: "clamp",
     category: "Numbers",
-    code: `import { clamp } from "1o1-utils/clamp";
+    code: `import { clamp } from "1o1-utils";
 
 console.log(clamp({ value: 15, min: 0, max: 10 })); // 10
 console.log(clamp({ value: -5, min: 0, max: 10 })); // 0
@@ -214,7 +214,7 @@ console.log(clamp({ value: 7, min: 0, max: 10 })); // 7
     id: "in-range",
     label: "inRange",
     category: "Numbers",
-    code: `import { inRange } from "1o1-utils/in-range";
+    code: `import { inRange } from "1o1-utils";
 
 console.log(inRange({ value: 5, start: 0, end: 10 })); // true
 console.log(inRange({ value: 10, start: 0, end: 10 })); // false (end exclusive)
@@ -225,7 +225,7 @@ console.log(inRange({ value: -1, start: 0, end: 10 })); // false
     id: "random-int",
     label: "randomInt",
     category: "Numbers",
-    code: `import { randomInt } from "1o1-utils/random-int";
+    code: `import { randomInt } from "1o1-utils";
 
 for (let i = 0; i < 5; i++) {
   console.log(randomInt({ min: 1, max: 100 }));
@@ -238,7 +238,7 @@ for (let i = 0; i < 5; i++) {
     id: "clone-deep",
     label: "cloneDeep",
     category: "Objects",
-    code: `import { cloneDeep } from "1o1-utils/clone-deep";
+    code: `import { cloneDeep } from "1o1-utils";
 
 const original = {
   user: { name: "Ada", tags: ["admin"] },
@@ -255,7 +255,7 @@ console.log({ original: original.user.tags, copy: copy.user.tags });
     id: "compact",
     label: "compact",
     category: "Objects",
-    code: `import { compact } from "1o1-utils/compact";
+    code: `import { compact } from "1o1-utils";
 
 const data = {
   name: "Ada",
@@ -273,7 +273,7 @@ console.log(compact({ obj: data }));
     id: "deep-merge",
     label: "deepMerge",
     category: "Objects",
-    code: `import { deepMerge } from "1o1-utils/deep-merge";
+    code: `import { deepMerge } from "1o1-utils";
 
 const target = { theme: { color: "blue", size: "md" }, debug: false };
 const source = { theme: { color: "red" }, debug: true };
@@ -285,7 +285,7 @@ console.log(deepMerge({ target, source }));
     id: "defaults",
     label: "defaults",
     category: "Objects",
-    code: `import { defaults } from "1o1-utils/defaults";
+    code: `import { defaults } from "1o1-utils";
 
 const config = { port: 3000 };
 const defaults_ = { port: 8080, host: "localhost", debug: false };
@@ -298,7 +298,7 @@ console.log(defaults({ target: config, source: defaults_ }));
     id: "defaults-deep",
     label: "defaultsDeep",
     category: "Objects",
-    code: `import { defaultsDeep } from "1o1-utils/defaults-deep";
+    code: `import { defaultsDeep } from "1o1-utils";
 
 const config = { server: { port: 3000 } };
 const defaults_ = { server: { port: 8080, host: "localhost" }, debug: false };
@@ -310,7 +310,7 @@ console.log(defaultsDeep({ target: config, source: defaults_ }));
     id: "get",
     label: "get",
     category: "Objects",
-    code: `import { get } from "1o1-utils/get";
+    code: `import { get } from "1o1-utils";
 
 const data = { user: { profile: { name: "Ada" } } };
 
@@ -322,7 +322,7 @@ console.log(get({ obj: data, path: "user.profile.missing", defaultValue: "fallba
     id: "is-empty",
     label: "isEmpty",
     category: "Objects",
-    code: `import { isEmpty } from "1o1-utils/is-empty";
+    code: `import { isEmpty } from "1o1-utils";
 
 console.log(isEmpty({ value: "" })); // true
 console.log(isEmpty({ value: [] })); // true
@@ -336,7 +336,7 @@ console.log(isEmpty({ value: [1] })); // false
     id: "map-keys",
     label: "mapKeys",
     category: "Objects",
-    code: `import { mapKeys } from "1o1-utils/map-keys";
+    code: `import { mapKeys } from "1o1-utils";
 
 const data = { firstName: "Ada", lastName: "Lovelace" };
 
@@ -352,7 +352,7 @@ console.log(
     id: "map-values",
     label: "mapValues",
     category: "Objects",
-    code: `import { mapValues } from "1o1-utils/map-values";
+    code: `import { mapValues } from "1o1-utils";
 
 const scores = { ada: 90, bob: 75, cleo: 88 };
 
@@ -368,7 +368,7 @@ console.log(
     id: "omit",
     label: "omit",
     category: "Objects",
-    code: `import { omit } from "1o1-utils/omit";
+    code: `import { omit } from "1o1-utils";
 
 const user = { id: 1, name: "Ada", password: "secret", token: "xyz" };
 
@@ -379,7 +379,7 @@ console.log(omit({ obj: user, keys: ["password", "token"] }));
     id: "omit-by",
     label: "omitBy",
     category: "Objects",
-    code: `import { omitBy } from "1o1-utils/omit-by";
+    code: `import { omitBy } from "1o1-utils";
 
 const data = { id: 1, name: "Ada", password: "secret", token: "xyz" };
 
@@ -395,7 +395,7 @@ console.log(
     id: "pick-by",
     label: "pickBy",
     category: "Objects",
-    code: `import { pickBy } from "1o1-utils/pick-by";
+    code: `import { pickBy } from "1o1-utils";
 
 const data = { a: 1, b: null, c: 3, d: undefined };
 
@@ -407,7 +407,7 @@ console.log(pickBy({ obj: data, predicate: (v) => v != null }));
     id: "pick",
     label: "pick",
     category: "Objects",
-    code: `import { pick } from "1o1-utils/pick";
+    code: `import { pick } from "1o1-utils";
 
 const user = { id: 1, name: "Ada", email: "ada@x.dev", role: "admin" };
 
@@ -418,7 +418,7 @@ console.log(pick({ obj: user, keys: ["id", "name"] }));
     id: "set",
     label: "set",
     category: "Objects",
-    code: `import { set } from "1o1-utils/set";
+    code: `import { set } from "1o1-utils";
 
 const data = { user: { profile: { name: "Ada" } } };
 
@@ -432,7 +432,7 @@ console.log(set({ obj: data, path: "user.profile.email", value: "bob@x.dev" }));
     id: "deburr",
     label: "deburr",
     category: "Strings",
-    code: `import { deburr } from "1o1-utils/deburr";
+    code: `import { deburr } from "1o1-utils";
 
 console.log(deburr({ str: "São Paulo" }));   // "Sao Paulo"
 console.log(deburr({ str: "café résumé" })); // "cafe resume"
@@ -443,7 +443,7 @@ console.log(deburr({ str: "Tiếng Việt" }));  // "Tieng Viet"
     id: "capitalize",
     label: "capitalize",
     category: "Strings",
-    code: `import { capitalize } from "1o1-utils/capitalize";
+    code: `import { capitalize } from "1o1-utils";
 
 console.log(capitalize({ str: "hello world" })); // "Hello world"
 console.log(capitalize({ str: "HELLO", preserveRest: true })); // "HELLO"
@@ -454,7 +454,7 @@ console.log(capitalize({ str: "HELLO" })); // "Hello"
     id: "escape-reg-exp",
     label: "escapeRegExp",
     category: "Strings",
-    code: `import { escapeRegExp } from "1o1-utils/escape-reg-exp";
+    code: `import { escapeRegExp } from "1o1-utils";
 
 const userInput = "1.5 + 2 * (3 - 1)";
 const escaped = escapeRegExp({ str: userInput });
@@ -467,7 +467,7 @@ console.log(new RegExp(escaped).test(userInput));
     id: "normalize-email",
     label: "normalizeEmail",
     category: "Strings",
-    code: `import { normalizeEmail } from "1o1-utils/normalize-email";
+    code: `import { normalizeEmail } from "1o1-utils";
 
 console.log(normalizeEmail({ email: "  Foo.Bar@Gmail.COM  " }));
 console.log(normalizeEmail({ email: "user+spam@gmail.com", stripPlus: true }));
@@ -477,7 +477,7 @@ console.log(normalizeEmail({ email: "user+spam@gmail.com", stripPlus: true }));
     id: "slugify",
     label: "slugify",
     category: "Strings",
-    code: `import { slugify } from "1o1-utils/slugify";
+    code: `import { slugify } from "1o1-utils";
 
 console.log(slugify({ str: "Olá Mundo! 1o1-utils é rápido" }));
 // ola-mundo-1o1-utils-e-rapido
@@ -487,7 +487,7 @@ console.log(slugify({ str: "Olá Mundo! 1o1-utils é rápido" }));
     id: "transform-case",
     label: "transformCase",
     category: "Strings",
-    code: `import { transformCase } from "1o1-utils/transform-case";
+    code: `import { transformCase } from "1o1-utils";
 
 console.log(transformCase({ str: "hello world", style: "camel" }));
 console.log(transformCase({ str: "hello world", style: "snake" }));
@@ -499,7 +499,7 @@ console.log(transformCase({ str: "hello world", style: "pascal" }));
     id: "truncate",
     label: "truncate",
     category: "Strings",
-    code: `import { truncate } from "1o1-utils/truncate";
+    code: `import { truncate } from "1o1-utils";
 
 const text = "The quick brown fox jumps over the lazy dog";
 
@@ -513,7 +513,7 @@ console.log(truncate({ str: text, length: 20, suffix: "…" }));
     id: "debounce",
     label: "debounce",
     category: "Async",
-    code: `import { debounce } from "1o1-utils/debounce";
+    code: `import { debounce } from "1o1-utils";
 
 const search = debounce({
   fn: (query) => console.log("searching:", query),
@@ -531,7 +531,7 @@ search("abc");
     id: "retry",
     label: "retry",
     category: "Async",
-    code: `import { retry } from "1o1-utils/retry";
+    code: `import { retry } from "1o1-utils";
 
 let attempt = 0;
 const flaky = async () => {
@@ -547,7 +547,7 @@ console.log(await retry({ fn: flaky, attempts: 5, delay: 50 }));
     id: "safely",
     label: "safely",
     category: "Async",
-    code: `import { safely } from "1o1-utils/safely";
+    code: `import { safely } from "1o1-utils";
 
 const safeParse = safely(JSON.parse);
 
@@ -562,7 +562,7 @@ console.log({ err2, val2 });
     id: "sleep",
     label: "sleep",
     category: "Async",
-    code: `import { sleep } from "1o1-utils/sleep";
+    code: `import { sleep } from "1o1-utils";
 
 console.log("start", new Date().toISOString());
 await sleep({ ms: 500 });
@@ -573,7 +573,7 @@ console.log("end  ", new Date().toISOString());
     id: "throttle",
     label: "throttle",
     category: "Async",
-    code: `import { throttle } from "1o1-utils/throttle";
+    code: `import { throttle } from "1o1-utils";
 
 const log = throttle({
   fn: (n) => console.log("call", n, "at", Date.now() % 10000),
@@ -587,7 +587,7 @@ for (let i = 0; i < 5; i++) log(i);
     id: "wait-for-condition",
     label: "waitForCondition",
     category: "Async",
-    code: `import { waitForCondition } from "1o1-utils/wait-for-condition";
+    code: `import { waitForCondition } from "1o1-utils";
 
 let ready = false;
 setTimeout(() => { ready = true; }, 300);
@@ -605,8 +605,8 @@ console.log("ready!");
     id: "with-timeout",
     label: "withTimeout",
     category: "Async",
-    code: `import { withTimeout } from "1o1-utils/with-timeout";
-import { safely } from "1o1-utils/safely";
+    code: `import { withTimeout } from "1o1-utils";
+import { safely } from "1o1-utils";
 
 const slow = new Promise((resolve) => setTimeout(() => resolve("done"), 1000));
 
@@ -623,7 +623,7 @@ console.log({ err: err?.message, result });
     id: "deep-equal",
     label: "deepEqual",
     category: "Comparisons",
-    code: `import { deepEqual } from "1o1-utils/deep-equal";
+    code: `import { deepEqual } from "1o1-utils";
 
 console.log(
   deepEqual({
@@ -644,7 +644,7 @@ console.log(
     id: "is-nil",
     label: "isNil",
     category: "Comparisons",
-    code: `import { isNil } from "1o1-utils/is-nil";
+    code: `import { isNil } from "1o1-utils";
 
 console.log(isNil({ value: null })); // true
 console.log(isNil({ value: undefined })); // true
@@ -656,7 +656,7 @@ console.log(isNil({ value: "" })); // false
     id: "shallow-equal",
     label: "shallowEqual",
     category: "Comparisons",
-    code: `import { shallowEqual } from "1o1-utils/shallow-equal";
+    code: `import { shallowEqual } from "1o1-utils";
 
 console.log(shallowEqual({ a: { x: 1, y: 2 }, b: { x: 1, y: 2 } })); // true
 console.log(shallowEqual({ a: [1, 2, 3], b: [1, 2, 3] })); // true
@@ -669,7 +669,7 @@ console.log(shallowEqual({ a: { x: { n: 1 } }, b: { x: { n: 1 } } })); // false 
     id: "seconds-to-time-format",
     label: "secondsToTimeFormat",
     category: "Formatters",
-    code: `import { secondsToTimeFormat } from "1o1-utils/seconds-to-time-format";
+    code: `import { secondsToTimeFormat } from "1o1-utils";
 
 console.log(secondsToTimeFormat({ seconds: 65 })); // "01:05"
 console.log(secondsToTimeFormat({ seconds: 3725 })); // "1:02:05"
@@ -680,7 +680,7 @@ console.log(secondsToTimeFormat({ seconds: 3725, padHours: true })); // "01:02:0
     id: "time-format-to-seconds",
     label: "timeFormatToSeconds",
     category: "Formatters",
-    code: `import { timeFormatToSeconds } from "1o1-utils/time-format-to-seconds";
+    code: `import { timeFormatToSeconds } from "1o1-utils";
 
 console.log(timeFormatToSeconds({ time: "01:05" })); // 65
 console.log(timeFormatToSeconds({ time: "1:02:05" })); // 3725
@@ -692,7 +692,7 @@ console.log(timeFormatToSeconds({ time: "1:02:05" })); // 3725
     id: "memo",
     label: "memo",
     category: "Functions",
-    code: `import { memo } from "1o1-utils/memo";
+    code: `import { memo } from "1o1-utils";
 
 let calls = 0;
 const slow = (n) => { calls++; return n * 2; };
@@ -707,7 +707,7 @@ console.log("calls:", calls); // 1
     id: "once",
     label: "once",
     category: "Functions",
-    code: `import { once } from "1o1-utils/once";
+    code: `import { once } from "1o1-utils";
 
 let setup = 0;
 const init = once(() => { setup++; return "ready"; });
@@ -720,7 +720,7 @@ console.log("setup ran:", setup, "times"); // 1
     id: "pipe",
     label: "pipe",
     category: "Functions",
-    code: `import { pipe } from "1o1-utils/pipe";
+    code: `import { pipe } from "1o1-utils";
 
 const slug = pipe(
   (s) => s.trim(),
@@ -737,8 +737,8 @@ console.log(slug("  Hello World  "));
     id: "copy-to-clipboard",
     label: "copyToClipboard",
     category: "Browser",
-    code: `import { copyToClipboard } from "1o1-utils/copy-to-clipboard";
-import { safely } from "1o1-utils/safely";
+    code: `import { copyToClipboard } from "1o1-utils";
+import { safely } from "1o1-utils";
 
 const root = document.getElementById("root");
 root.innerHTML = \`<button id="btn">Copy "1o1-utils"</button> <span id="msg"></span>\`;
@@ -759,7 +759,7 @@ console.log("Click the button in the preview to copy.");
     id: "bind-key",
     label: "bindKey",
     category: "Browser",
-    code: `import { bindKey } from "1o1-utils/bind-key";
+    code: `import { bindKey } from "1o1-utils";
 
 const root = document.getElementById("root");
 root.innerHTML =
@@ -785,7 +785,7 @@ console.log("Bound: 'g i' and 'ctrl+k'. Focus the preview to test.");
     id: "is-valid-email",
     label: "isValidEmail",
     category: "Validators",
-    code: `import { isValidEmail } from "1o1-utils/is-valid-email";
+    code: `import { isValidEmail } from "1o1-utils";
 
 console.log(isValidEmail({ email: "ada@example.com" }));
 console.log(isValidEmail({ email: "not-an-email" }));
@@ -796,7 +796,7 @@ console.log(isValidEmail({ email: "Ada <ada@example.com>", allowDisplayName: tru
     id: "is-valid-phone",
     label: "isValidPhone",
     category: "Validators",
-    code: `import { isValidPhone } from "1o1-utils/is-valid-phone";
+    code: `import { isValidPhone } from "1o1-utils";
 
 console.log(isValidPhone({ phone: "+1 415 555 0132" }));
 console.log(isValidPhone({ phone: "(11) 91234-5678", country: "BR" }));
@@ -807,7 +807,7 @@ console.log(isValidPhone({ phone: "abc" }));
     id: "is-valid-url",
     label: "isValidUrl",
     category: "Validators",
-    code: `import { isValidUrl } from "1o1-utils/is-valid-url";
+    code: `import { isValidUrl } from "1o1-utils";
 
 console.log(isValidUrl({ url: "https://example.com" }));
 console.log(isValidUrl({ url: "ftp://files.example.com" }));

--- a/website/src/content/examples/index.ts
+++ b/website/src/content/examples/index.ts
@@ -761,13 +761,15 @@ console.log("Click the button in the preview to copy.");
     category: "Browser",
     code: `import { bindKey } from "1o1-utils";
 
+const MAX_LINES = 20;
 const root = document.getElementById("root");
 root.innerHTML =
   '<p style="font-family:system-ui">Click here, then press <b>g i</b> or <b>ctrl+k</b>.</p><pre id="log"></pre>';
 const log = document.getElementById("log");
 
 const append = (msg) => {
-  log.textContent = msg + "\\n" + log.textContent;
+  const lines = [msg, ...log.textContent.split("\\n")].filter(Boolean);
+  log.textContent = lines.slice(0, MAX_LINES).join("\\n");
 };
 
 bindKey("g i", () => append("→ go to inbox (g i)"));

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -612,61 +612,61 @@ nav.sidebar a[href*="/contributing/"] > span::before {
 }
 
 /* Arrays — view-grid */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/arrays/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/arrays/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2'%3E%3Crect x='14' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='14' y='3' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='3' width='7' height='7' rx='.6'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2'%3E%3Crect x='14' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='14' y='3' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='3' width='7' height='7' rx='.6'/%3E%3C/svg%3E");
 }
 
 /* Numbers — calculator */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/numbers/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/numbers/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='2' width='16' height='20' rx='2'/%3E%3Cpath d='M8 6h8M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01M16 15h.01M8 19h.01M12 19h.01M16 19h.01'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='2' width='16' height='20' rx='2'/%3E%3Cpath d='M8 6h8M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01M16 15h.01M8 19h.01M12 19h.01M16 19h.01'/%3E%3C/svg%3E");
 }
 
 /* Objects — cube */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/objects/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/objects/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7.35v9.3a.5.5 0 0 1-.31.46l-8.4 4.67a.5.5 0 0 1-.58 0l-8.4-4.67A.5.5 0 0 1 3 16.65v-9.3a.5.5 0 0 1 .31-.46l8.4-4.67a.5.5 0 0 1 .58 0l8.4 4.67a.5.5 0 0 1 .31.46Z'/%3E%3Cpath d='M3.53 7.29l8.18 4.55a.5.5 0 0 0 .58 0L20.5 7.28M12 21V12'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7.35v9.3a.5.5 0 0 1-.31.46l-8.4 4.67a.5.5 0 0 1-.58 0l-8.4-4.67A.5.5 0 0 1 3 16.65v-9.3a.5.5 0 0 1 .31-.46l8.4-4.67a.5.5 0 0 1 .58 0l8.4 4.67a.5.5 0 0 1 .31.46Z'/%3E%3Cpath d='M3.53 7.29l8.18 4.55a.5.5 0 0 0 .58 0L20.5 7.28M12 21V12'/%3E%3C/svg%3E");
 }
 
 /* Strings — text */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/strings/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/strings/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M19 7V5H5v2M12 5v14m0 0h-2m2 0h2'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M19 7V5H5v2M12 5v14m0 0h-2m2 0h2'/%3E%3C/svg%3E");
 }
 
 /* Async — timer */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/async/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/async/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 2h6M12 10v4'/%3E%3Ccircle cx='12' cy='14' r='8'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 2h6M12 10v4'/%3E%3Ccircle cx='12' cy='14' r='8'/%3E%3C/svg%3E");
 }
 
 /* Browser — internet (globe) */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/browser/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/browser/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M2 12h20M12 2a14 14 0 0 1 0 20M12 2a14 14 0 0 0 0 20'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M2 12h20M12 2a14 14 0 0 1 0 20M12 2a14 14 0 0 0 0 20'/%3E%3C/svg%3E");
 }
 
 /* Comparisons — scale */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/comparisons/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/comparisons/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18M5 21h14M5 8l-3 5h6Zm14 0l3 5h-6ZM5 8h14M5 8l-1-3M19 8l1-3'/%3E%3Cpath d='M2 13a3 3 0 0 0 6 0M16 13a3 3 0 0 0 6 0'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18M5 21h14M5 8l-3 5h6Zm14 0l3 5h-6ZM5 8h14M5 8l-1-3M19 8l1-3'/%3E%3Cpath d='M2 13a3 3 0 0 0 6 0M16 13a3 3 0 0 0 6 0'/%3E%3C/svg%3E");
 }
 
 /* Formatters — magic-wand */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/formatters/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/formatters/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2 19 5M3 21l9-9M12.2 6.2 11 5'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2 19 5M3 21l9-9M12.2 6.2 11 5'/%3E%3C/svg%3E");
 }
 
 /* Functions — code-brackets */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/functions/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/functions/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 4H5a2 2 0 0 0-2 2v3.5a2 2 0 0 1-2 2v1a2 2 0 0 1 2 2V18a2 2 0 0 0 2 2h2'/%3E%3Cpath d='M17 4h2a2 2 0 0 1 2 2v3.5a2 2 0 0 0 2 2v1a2 2 0 0 0-2 2V18a2 2 0 0 1-2 2h-2'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 4H5a2 2 0 0 0-2 2v3.5a2 2 0 0 1-2 2v1a2 2 0 0 1 2 2V18a2 2 0 0 0 2 2h2'/%3E%3Cpath d='M17 4h2a2 2 0 0 1 2 2v3.5a2 2 0 0 0 2 2v1a2 2 0 0 0-2 2V18a2 2 0 0 1-2 2h-2'/%3E%3C/svg%3E");
 }
 
 /* Validators — shield-check */
-nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/validators/"]) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(a[href*="/validators/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z'/%3E%3Cpath d='m9 12 2 2 4-4'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z'/%3E%3Cpath d='m9 12 2 2 4-4'/%3E%3C/svg%3E");
 }

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -531,8 +531,8 @@ starlight-toc a[aria-current="true"] {
 
 /* ========================================
    SIDEBAR ICONS — iconoir via CSS masks
-   NOTE: Group icons use nth-child selectors tied to sidebar order in astro.config.mjs.
-   If sidebar sections are reordered or added, update the nth-child indices below.
+   Group icons use :has() selectors keyed off the directory autogenerate output,
+   so they survive sidebar reordering. Add a new block when adding a category.
    ======================================== */
 
 /* Base icon style for group labels */
@@ -553,6 +553,7 @@ nav.sidebar .top-level > li > details > summary .group-label::before {
 /* Base icon style for sidebar links */
 nav.sidebar a[href*="/getting-started/"] > span::before,
 nav.sidebar a[href*="/why-1o1-utils/"] > span::before,
+nav.sidebar a[href*="/playground/"] > span::before,
 nav.sidebar a[href*="/benchmarks/"] > span::before,
 nav.sidebar a[href*="/contributing/"] > span::before {
   content: "";
@@ -568,10 +569,16 @@ nav.sidebar a[href*="/contributing/"] > span::before {
   mask-repeat: no-repeat;
 }
 
-/* Start Here — triangle-flag */
-nav.sidebar .top-level > li:nth-child(1) > details > summary .group-label::before {
+/* Start Here — triangle-flag (matches Start Here group containing Why) */
+nav.sidebar .top-level > li:has(a[href*="/why-1o1-utils/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 21V16m0 0V3.577a.5.5 0 0 1 .916-.51l8.79 5.432a.5.5 0 0 1 .017.95L8 16Z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M8 21V16m0 0V3.577a.5.5 0 0 1 .916-.51l8.79 5.432a.5.5 0 0 1 .017.95L8 16Z'/%3E%3C/svg%3E");
+}
+
+/* Compare — git-fork */
+nav.sidebar .top-level > li:has(a[href*="/compare/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='6' cy='5' r='2'/%3E%3Ccircle cx='18' cy='5' r='2'/%3E%3Ccircle cx='12' cy='19' r='2'/%3E%3Cpath d='M6 7v3a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4V7M12 14v3'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='6' cy='5' r='2'/%3E%3Ccircle cx='18' cy='5' r='2'/%3E%3Ccircle cx='12' cy='19' r='2'/%3E%3Cpath d='M6 7v3a4 4 0 0 0 4 4h4a4 4 0 0 0 4-4V7M12 14v3'/%3E%3C/svg%3E");
 }
 
 /* Getting Started — rocket */
@@ -584,6 +591,12 @@ nav.sidebar a[href*="/getting-started/"] > span::before {
 nav.sidebar a[href*="/why-1o1-utils/"] > span::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 2l-1 1M3 2l1 1M21 16l-1-1M3 16l1-1M9 18h6M10 21h4'/%3E%3Cpath d='M12 3C8 3 5.95 4.95 6 8c.02 1.49.5 2.5 1.5 3.5S9 13 9 15h6c0-2 .5-2.5 1.5-3.5S18.05 9.49 18 8c.05-3.05-2-5-6-5Z'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 2l-1 1M3 2l1 1M21 16l-1-1M3 16l1-1M9 18h6M10 21h4'/%3E%3Cpath d='M12 3C8 3 5.95 4.95 6 8c.02 1.49.5 2.5 1.5 3.5S9 13 9 15h6c0-2 .5-2.5 1.5-3.5S18.05 9.49 18 8c.05-3.05-2-5-6-5Z'/%3E%3C/svg%3E");
+}
+
+/* Playground — code-brackets-square */
+nav.sidebar a[href*="/playground/"] > span::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='3' width='18' height='18' rx='3'/%3E%3Cpath d='M9 9l-2 3 2 3M15 9l2 3-2 3'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='3' y='3' width='18' height='18' rx='3'/%3E%3Cpath d='M9 9l-2 3 2 3M15 9l2 3-2 3'/%3E%3C/svg%3E");
 }
 
 /* Benchmarks — dashboard-speed */
@@ -599,27 +612,63 @@ nav.sidebar a[href*="/contributing/"] > span::before {
 }
 
 /* Arrays — view-grid */
-nav.sidebar .top-level > li:nth-child(2) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/arrays/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2'%3E%3Crect x='14' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='14' y='3' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='3' width='7' height='7' rx='.6'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2'%3E%3Crect x='14' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='14' width='7' height='7' rx='.6'/%3E%3Crect x='14' y='3' width='7' height='7' rx='.6'/%3E%3Crect x='3' y='3' width='7' height='7' rx='.6'/%3E%3C/svg%3E");
 }
 
+/* Numbers — calculator */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/numbers/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='2' width='16' height='20' rx='2'/%3E%3Cpath d='M8 6h8M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01M16 15h.01M8 19h.01M12 19h.01M16 19h.01'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='4' y='2' width='16' height='20' rx='2'/%3E%3Cpath d='M8 6h8M8 11h.01M12 11h.01M16 11h.01M8 15h.01M12 15h.01M16 15h.01M8 19h.01M12 19h.01M16 19h.01'/%3E%3C/svg%3E");
+}
+
 /* Objects — cube */
-nav.sidebar .top-level > li:nth-child(3) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/objects/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7.35v9.3a.5.5 0 0 1-.31.46l-8.4 4.67a.5.5 0 0 1-.58 0l-8.4-4.67A.5.5 0 0 1 3 16.65v-9.3a.5.5 0 0 1 .31-.46l8.4-4.67a.5.5 0 0 1 .58 0l8.4 4.67a.5.5 0 0 1 .31.46Z'/%3E%3Cpath d='M3.53 7.29l8.18 4.55a.5.5 0 0 0 .58 0L20.5 7.28M12 21V12'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M21 7.35v9.3a.5.5 0 0 1-.31.46l-8.4 4.67a.5.5 0 0 1-.58 0l-8.4-4.67A.5.5 0 0 1 3 16.65v-9.3a.5.5 0 0 1 .31-.46l8.4-4.67a.5.5 0 0 1 .58 0l8.4 4.67a.5.5 0 0 1 .31.46Z'/%3E%3Cpath d='M3.53 7.29l8.18 4.55a.5.5 0 0 0 .58 0L20.5 7.28M12 21V12'/%3E%3C/svg%3E");
 }
 
 /* Strings — text */
-nav.sidebar .top-level > li:nth-child(4) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/strings/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M19 7V5H5v2M12 5v14m0 0h-2m2 0h2'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M19 7V5H5v2M12 5v14m0 0h-2m2 0h2'/%3E%3C/svg%3E");
 }
 
 /* Async — timer */
-nav.sidebar .top-level > li:nth-child(5) > details > summary .group-label::before {
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/async/"]) > details > summary .group-label::before {
   -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 2h6M12 10v4'/%3E%3Ccircle cx='12' cy='14' r='8'/%3E%3C/svg%3E");
   mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M9 2h6M12 10v4'/%3E%3Ccircle cx='12' cy='14' r='8'/%3E%3C/svg%3E");
+}
+
+/* Browser — internet (globe) */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/browser/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M2 12h20M12 2a14 14 0 0 1 0 20M12 2a14 14 0 0 0 0 20'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Ccircle cx='12' cy='12' r='10'/%3E%3Cpath d='M2 12h20M12 2a14 14 0 0 1 0 20M12 2a14 14 0 0 0 0 20'/%3E%3C/svg%3E");
+}
+
+/* Comparisons — scale */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/comparisons/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18M5 21h14M5 8l-3 5h6Zm14 0l3 5h-6ZM5 8h14M5 8l-1-3M19 8l1-3'/%3E%3Cpath d='M2 13a3 3 0 0 0 6 0M16 13a3 3 0 0 0 6 0'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 3v18M5 21h14M5 8l-3 5h6Zm14 0l3 5h-6ZM5 8h14M5 8l-1-3M19 8l1-3'/%3E%3Cpath d='M2 13a3 3 0 0 0 6 0M16 13a3 3 0 0 0 6 0'/%3E%3C/svg%3E");
+}
+
+/* Formatters — magic-wand */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/formatters/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2 19 5M3 21l9-9M12.2 6.2 11 5'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M15 4V2M15 16v-2M8 9h2M20 9h2M17.8 11.8L19 13M17.8 6.2 19 5M3 21l9-9M12.2 6.2 11 5'/%3E%3C/svg%3E");
+}
+
+/* Functions — code-brackets */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/functions/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 4H5a2 2 0 0 0-2 2v3.5a2 2 0 0 1-2 2v1a2 2 0 0 1 2 2V18a2 2 0 0 0 2 2h2'/%3E%3Cpath d='M17 4h2a2 2 0 0 1 2 2v3.5a2 2 0 0 0 2 2v1a2 2 0 0 0-2 2V18a2 2 0 0 1-2 2h-2'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M7 4H5a2 2 0 0 0-2 2v3.5a2 2 0 0 1-2 2v1a2 2 0 0 1 2 2V18a2 2 0 0 0 2 2h2'/%3E%3Cpath d='M17 4h2a2 2 0 0 1 2 2v3.5a2 2 0 0 0 2 2v1a2 2 0 0 0-2 2V18a2 2 0 0 1-2 2h-2'/%3E%3C/svg%3E");
+}
+
+/* Validators — shield-check */
+nav.sidebar .top-level > li:has(> details > div > ul > li > a[href*="/validators/"]) > details > summary .group-label::before {
+  -webkit-mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z'/%3E%3Cpath d='m9 12 2 2 4-4'/%3E%3C/svg%3E");
+  mask-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' viewBox='0 0 24 24' fill='none' stroke='black' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10Z'/%3E%3Cpath d='m9 12 2 2 4-4'/%3E%3C/svg%3E");
 }
 
 /* ========================================

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -557,19 +557,23 @@ starlight-toc a[aria-current="true"] {
    so they survive sidebar reordering. Add a new block when adding a category.
    ======================================== */
 
-/* Base icon style for group labels */
-nav.sidebar .top-level > li > details > summary .group-label::before {
-  content: "";
-  display: inline-block;
-  width: 1em;
-  height: 1em;
-  margin-right: 0.5rem;             /* 8px */
-  vertical-align: -0.125rem;        /* 2px */
-  background-color: currentColor;
-  -webkit-mask-size: contain;
-  mask-size: contain;
-  -webkit-mask-repeat: no-repeat;
-  mask-repeat: no-repeat;
+/* Base icon style for group labels — only renders when :has() resolves a
+   matching mask-image rule below. Browsers without :has() support skip the
+   icon entirely instead of rendering a blank white square. */
+@supports selector(:has(*)) {
+  nav.sidebar .top-level > li > details > summary .group-label::before {
+    content: "";
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    margin-right: 0.5rem;             /* 8px */
+    vertical-align: -0.125rem;        /* 2px */
+    background-color: currentColor;
+    -webkit-mask-size: contain;
+    mask-size: contain;
+    -webkit-mask-repeat: no-repeat;
+    mask-repeat: no-repeat;
+  }
 }
 
 /* Base icon style for sidebar links */

--- a/website/src/styles/custom.css
+++ b/website/src/styles/custom.css
@@ -172,6 +172,28 @@ nav.sidebar ul ul li {
 }
 
 /* ========================================
+   SANDPACK — isolate from doc typography
+   Sandpack initializes CodeMirror after hydration; before init the raw
+   <pre> inherits the doc's --sl-line-height (1.8) and h2 margin rules,
+   which produced massive vertical gaps on first paint. Reset here.
+   ======================================== */
+.sl-markdown-content .sp-wrapper,
+.sl-markdown-content .sp-wrapper * {
+  line-height: 1.5;
+}
+
+.sl-markdown-content .sp-wrapper p,
+.sl-markdown-content .sp-wrapper pre,
+.sl-markdown-content .sp-wrapper code {
+  margin: 0;
+}
+
+.sl-markdown-content .sp-wrapper pre,
+.sl-markdown-content .sp-wrapper code {
+  font-family: var(--sl-font-mono);
+}
+
+/* ========================================
    CONTENT — GitBook spacing & typography
    ======================================== */
 


### PR DESCRIPTION
## Summary

- **Interactive playground** — Sandpack-based React island wired into Astro Starlight. Runs `1o1-utils` directly from npm in the browser, no install needed. Lives at `/playground/` and is also embedded as a **Try it** block at the top of every utility doc page (pinned via `utilityId`).
- **Five missing utility docs** — `pickBy`, `omitBy`, `deburr`, `copyToClipboard`, `bindKey` shipped without doc pages; each gets a full Starlight page (signature, parameters, examples, edge cases, prompt suggestion) plus the embedded playground. New **Browser** sidebar category for the two browser-only utilities.
- **Sidebar icons fix** — group icons (Async, Comparisons, Formatters, Functions, Validators) rendered as solid white boxes because the `nth-child` indices were stale and the strict `:has(> details > div > ul > li > a)` selectors didn't match Starlight's actual `<sl-sidebar-restore>` wrapper. Switched to descendant `:has(a[href*="/<cat>/"])` and added the missing icons.
- **README + CONTRIBUTING refresh** — dropped the stale "2 kB gzipped" claim, listed every utility (now 57 across 10 categories), added a real bundle-size table from `pnpm size`, and documented the new playground step in the contribution checklist.

## Notable fixes

- Sandpack bundler does not honor `package.json` `exports` subpaths, so example imports use the bare `1o1-utils` entry. Doc-page code blocks still showcase the tree-shakeable subpath form.
- Playground `PKG_VERSION` is read from the root `package.json` at build time, so future releases auto-pin without manual edits.
- Pre-CodeMirror render no longer inherits the doc page's `--sl-line-height: 1.8` and `<p>` margins, removing the massive line gaps on first paint.

## Test plan

- [ ] `pnpm docs:dev` → open `/1o1-utils/playground/` and run a few examples (chunk, retry, deepEqual)
- [ ] Open any utility page (e.g. `/arrays/chunk/`) and confirm the **Try it** block runs the pinned example
- [ ] Open `/browser/copy-to-clipboard/` and `/browser/bind-key/` — preview iframe variant, click/keypress works
- [ ] Sidebar shows an icon for every group (Start Here, Compare, Arrays, Numbers, Objects, Strings, Async, Browser, Comparisons, Formatters, Functions, Validators)
- [ ] `pnpm docs:build` succeeds (126 pages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)