### PR TITLE
fix(website): playground renders broken after page nav

### DIFF
--- a/website/src/components/Head.astro
+++ b/website/src/components/Head.astro
@@ -1,7 +1,5 @@
 ---
 import StarlightHead from "@astrojs/starlight/components/Head.astro";
-import { ClientRouter } from "astro:transitions";
 ---
 
 <StarlightHead {...Astro.props}><slot /></StarlightHead>
-<ClientRouter />


### PR DESCRIPTION
## Summary
- Remove Astro `<ClientRouter />` from `Head.astro`
- Sandpack CodeMirror measured container at 0 during view transition swap → editor mounted blank/misaligned on every nav between utility doc pages
- Falls back to native full-page nav (Starlight default); fixes playground rendering everywhere it's embedded (~60 utility pages + `/playground/`)

## Test plan
- [ ] `pnpm --filter website dev`
- [ ] Open `/playground/` — editor renders
- [ ] Sidebar → any utility (e.g. Arrays → Chunk) — editor renders
- [ ] Back to `/playground/` — still renders
- [ ] Switch examples via select — still renders
- [ ] Browser-category example (e.g. `copy-to-clipboard`) — preview iframe loads