### PR TITLE
feat(async): add parallel utility

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "Total (tree-shaken + gzipped)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "10 kB"
+    "limit": "11 kB"
   },
   {
     "name": "array-to-hash",
@@ -139,6 +139,11 @@
     "name": "retry",
     "path": "dist/async/retry/index.js",
     "limit": "2 kB"
+  },
+  {
+    "name": "parallel",
+    "path": "dist/async/parallel/index.js",
+    "limit": "1 kB"
   },
   {
     "name": "safely",

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1001,6 +1001,40 @@ Each call resets the delay timer. .cancel() clears any pending timeout.
 
 ---
 
+### parallel
+
+Run an async mapper over items with a concurrency cap (worker-pool semaphore). Results preserve input order and follow Promise.allSettled shape — fn errors are captured as rejected entries instead of rejecting the call.
+
+Import: import { parallel } from "1o1-utils/parallel";
+
+Signature:
+async function parallel<T, R>({ items, concurrency, fn, signal }: ParallelParams<T, R>): Promise<Array<{ status: "fulfilled"; value: R } | { status: "rejected"; reason: unknown }>>
+
+Parameters:
+- items (readonly T[], required): Items to process
+- concurrency (number, required): Max in-flight tasks (positive integer)
+- fn ((item: T, index: number) => Promise<R> | R, required): Mapper; may be sync or async
+- signal (AbortSignal, optional): Cancels pending work; in-flight tasks finish normally
+
+Returns: Promise<Array<{ status, value | reason }>> — entries in input order.
+
+Example:
+const results = await parallel({
+  items: urls,
+  concurrency: 3,
+  fn: async (url) => (await fetch(url)).json(),
+});
+
+for (const r of results) {
+  if (r.status === "fulfilled") console.log(r.value);
+  else console.error(r.reason);
+}
+
+Throws: Error if items is not an array. Error if concurrency is not a positive integer. Error if fn is not a function. Error if signal is not an AbortSignal. Throws signal.reason if signal is already aborted at call time.
+Empty items resolves to []. concurrency >= items.length runs everything in parallel. concurrency: 1 runs serially. When signal aborts mid-flight, unstarted indices resolve as rejected with signal.reason; in-flight tasks complete and their results are recorded.
+
+---
+
 ### retry
 
 Retry an async (or sync) function up to a specified number of attempts, with configurable delay and backoff strategy.

--- a/llms.txt
+++ b/llms.txt
@@ -62,6 +62,7 @@
 ## Async
 
 - [debounce](https://pedrotroccoli.github.io/1o1-utils/async/debounce/): Create a debounced function with cancel support
+- [parallel](https://pedrotroccoli.github.io/1o1-utils/async/parallel/): Run an async mapper over items with a concurrency cap (settle-all, AbortSignal-aware)
 - [retry](https://pedrotroccoli.github.io/1o1-utils/async/retry/): Retry async operations with fixed or exponential backoff
 - [safely](https://pedrotroccoli.github.io/1o1-utils/async/safely/): Wrap a function so it returns a [error, result] tuple instead of throwing
 - [sleep](https://pedrotroccoli.github.io/1o1-utils/async/sleep/): Promise-based delay

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
 		"truncate",
 		"retry",
 		"sleep",
+		"parallel",
+		"concurrency",
+		"semaphore",
 		"once",
 		"pipe",
 		"compose",
@@ -227,6 +230,10 @@
 		"./retry": {
 			"import": "./dist/async/retry/index.js",
 			"types": "./dist/async/retry/index.d.ts"
+		},
+		"./parallel": {
+			"import": "./dist/async/parallel/index.js",
+			"types": "./dist/async/parallel/index.d.ts"
 		},
 		"./safely": {
 			"import": "./dist/async/safely/index.js",

--- a/src/async/parallel/index.bench.ts
+++ b/src/async/parallel/index.bench.ts
@@ -1,0 +1,29 @@
+import { parallel as radashParallel } from "radash";
+import { Bench } from "tinybench";
+import { parallel } from "./index.js";
+
+const bench = new Bench({ name: "parallel", time: 1000 });
+
+const items = Array.from({ length: 50 }, (_, i) => i);
+const work = async (n: number) => {
+  await new Promise((r) => setTimeout(r, 0));
+  return n * 2;
+};
+
+bench
+  .add("1o1-utils (concurrency: 5, 50 items)", async () => {
+    await parallel({ items, concurrency: 5, fn: work });
+  })
+  .add("radash (concurrency: 5, 50 items)", async () => {
+    await radashParallel(5, items, work);
+  })
+  .add("native Promise.all (50 items, unbounded)", async () => {
+    await Promise.all(items.map(work));
+  })
+  .add("native serial loop (50 items)", async () => {
+    const out: number[] = [];
+    for (const n of items) out.push(await work(n));
+    return out;
+  });
+
+export { bench };

--- a/src/async/parallel/index.spec.ts
+++ b/src/async/parallel/index.spec.ts
@@ -1,0 +1,268 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { parallel } from "./index.js";
+
+const tick = (ms = 0) => new Promise((r) => setTimeout(r, ms));
+
+describe("parallel", () => {
+  it("should preserve input order in results", async () => {
+    const results = await parallel({
+      items: [10, 30, 5, 20],
+      concurrency: 2,
+      fn: async (n) => {
+        await tick(n);
+        return n * 2;
+      },
+    });
+
+    expect(results.map((r) => (r as { value: number }).value)).to.deep.equal([
+      20, 60, 10, 40,
+    ]);
+  });
+
+  it("should return Promise.allSettled-shaped entries", async () => {
+    const results = await parallel({
+      items: [1, 2, 3],
+      concurrency: 2,
+      fn: (n) => n * 10,
+    });
+
+    expect(results).to.deep.equal([
+      { status: "fulfilled", value: 10 },
+      { status: "fulfilled", value: 20 },
+      { status: "fulfilled", value: 30 },
+    ]);
+  });
+
+  it("should respect the concurrency cap", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = Array.from({ length: 10 }, (_, i) => i);
+
+    await parallel({
+      items,
+      concurrency: 3,
+      fn: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick(20);
+        inFlight--;
+      },
+    });
+
+    expect(peak).to.equal(3);
+  });
+
+  it("should run serially when concurrency is 1", async () => {
+    let inFlight = 0;
+    let peak = 0;
+
+    await parallel({
+      items: [1, 2, 3, 4],
+      concurrency: 1,
+      fn: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick(5);
+        inFlight--;
+      },
+    });
+
+    expect(peak).to.equal(1);
+  });
+
+  it("should run all in parallel when concurrency >= items.length", async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const items = [1, 2, 3];
+
+    await parallel({
+      items,
+      concurrency: 10,
+      fn: async () => {
+        inFlight++;
+        peak = Math.max(peak, inFlight);
+        await tick(15);
+        inFlight--;
+      },
+    });
+
+    expect(peak).to.equal(3);
+  });
+
+  it("should handle empty items array", async () => {
+    const results = await parallel({
+      items: [],
+      concurrency: 5,
+      fn: async () => "x",
+    });
+
+    expect(results).to.deep.equal([]);
+  });
+
+  it("should support sync fn", async () => {
+    const results = await parallel({
+      items: ["a", "b", "c"],
+      concurrency: 2,
+      fn: (s) => s.toUpperCase(),
+    });
+
+    expect(results).to.deep.equal([
+      { status: "fulfilled", value: "A" },
+      { status: "fulfilled", value: "B" },
+      { status: "fulfilled", value: "C" },
+    ]);
+  });
+
+  it("should pass index to fn", async () => {
+    const seen: Array<[string, number]> = [];
+    await parallel({
+      items: ["a", "b", "c"],
+      concurrency: 1,
+      fn: (item, i) => {
+        seen.push([item, i]);
+      },
+    });
+
+    expect(seen).to.deep.equal([
+      ["a", 0],
+      ["b", 1],
+      ["c", 2],
+    ]);
+  });
+
+  it("should capture rejections without rejecting the whole call", async () => {
+    const results = await parallel({
+      items: [1, 2, 3],
+      concurrency: 2,
+      fn: async (n) => {
+        if (n === 2) throw new Error("boom");
+        return n;
+      },
+    });
+
+    expect(results[0]).to.deep.equal({ status: "fulfilled", value: 1 });
+    expect(results[1]?.status).to.equal("rejected");
+    expect((results[1] as { reason: Error }).reason.message).to.equal("boom");
+    expect(results[2]).to.deep.equal({ status: "fulfilled", value: 3 });
+  });
+
+  it("should mix fulfilled and rejected results", async () => {
+    const results = await parallel({
+      items: [1, 2, 3, 4],
+      concurrency: 4,
+      fn: (n) => {
+        if (n % 2 === 0) throw new Error(`even:${n}`);
+        return n;
+      },
+    });
+
+    expect(results.map((r) => r.status)).to.deep.equal([
+      "fulfilled",
+      "rejected",
+      "fulfilled",
+      "rejected",
+    ]);
+  });
+
+  it("should reject pending items when signal aborts mid-flight", async () => {
+    const controller = new AbortController();
+    const items = Array.from({ length: 8 }, (_, i) => i);
+
+    setTimeout(() => controller.abort(new Error("stop")), 25);
+
+    const results = await parallel({
+      items,
+      concurrency: 2,
+      signal: controller.signal,
+      fn: async (n) => {
+        await tick(20);
+        return n;
+      },
+    });
+
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(rejected.length).to.be.greaterThan(0);
+    expect((rejected[0] as { reason: Error }).reason.message).to.equal("stop");
+  });
+
+  it("should throw if signal is already aborted", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("already"));
+
+    try {
+      await parallel({
+        items: [1, 2, 3],
+        concurrency: 2,
+        signal: controller.signal,
+        fn: (n) => n,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal("already");
+    }
+  });
+
+  it("should throw if items is not an array", async () => {
+    try {
+      await parallel({
+        items: "nope" as unknown as number[],
+        concurrency: 2,
+        fn: (n) => n,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'items' parameter must be an array",
+      );
+    }
+  });
+
+  it("should throw if concurrency is not a positive integer", async () => {
+    for (const bad of [0, -1, 1.5, Number.NaN]) {
+      try {
+        await parallel({
+          items: [1],
+          concurrency: bad,
+          fn: (n) => n,
+        });
+        expect.fail(`should have thrown for ${bad}`);
+      } catch (error) {
+        expect((error as Error).message).to.equal(
+          "The 'concurrency' parameter must be a positive integer",
+        );
+      }
+    }
+  });
+
+  it("should throw if fn is not a function", async () => {
+    try {
+      await parallel({
+        items: [1],
+        concurrency: 1,
+        fn: "nope" as unknown as (n: number) => number,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'fn' parameter must be a function",
+      );
+    }
+  });
+
+  it("should throw if signal is not an AbortSignal", async () => {
+    try {
+      await parallel({
+        items: [1],
+        concurrency: 1,
+        fn: (n) => n,
+        signal: "nope" as unknown as AbortSignal,
+      });
+      expect.fail("should have thrown");
+    } catch (error) {
+      expect((error as Error).message).to.equal(
+        "The 'signal' parameter must be an AbortSignal",
+      );
+    }
+  });
+});

--- a/src/async/parallel/index.spec.ts
+++ b/src/async/parallel/index.spec.ts
@@ -186,6 +186,29 @@ describe("parallel", () => {
     expect((rejected[0] as { reason: Error }).reason.message).to.equal("stop");
   });
 
+  it("should short-circuit pending indices on abort without iterating each", async () => {
+    const controller = new AbortController();
+    const items = Array.from({ length: 1000 }, (_, i) => i);
+    let fnCalls = 0;
+
+    setTimeout(() => controller.abort(new Error("stop")), 5);
+
+    const results = await parallel({
+      items,
+      concurrency: 2,
+      signal: controller.signal,
+      fn: async (n) => {
+        fnCalls++;
+        await tick(10);
+        return n;
+      },
+    });
+
+    expect(results).to.have.lengthOf(1000);
+    expect(results.every((r) => r !== undefined)).to.equal(true);
+    expect(fnCalls).to.be.lessThan(10);
+  });
+
   it("should throw if signal is already aborted", async () => {
     const controller = new AbortController();
     controller.abort(new Error("already"));

--- a/src/async/parallel/index.ts
+++ b/src/async/parallel/index.ts
@@ -66,7 +66,11 @@ async function parallel<T, R>({
       if (i >= items.length) return;
       if (signal?.aborted) {
         results[i] = { status: "rejected", reason: signal.reason };
-        continue;
+        while (next < items.length) {
+          const j = next++;
+          results[j] = { status: "rejected", reason: signal.reason };
+        }
+        return;
       }
       try {
         const value = await fn(items[i] as T, i);

--- a/src/async/parallel/index.ts
+++ b/src/async/parallel/index.ts
@@ -1,0 +1,85 @@
+import type { ParallelParams, ParallelSettledResult } from "./types.js";
+
+/**
+ * Runs an async mapper over `items` with a concurrency cap (worker-pool semaphore).
+ * Results preserve input order. Never rejects from `fn` errors — each item resolves
+ * to a Promise.allSettled-shaped entry. Optional `signal` stops dispatching new work;
+ * unstarted indices resolve as rejected with the signal's reason.
+ *
+ * @param params - The parameters object
+ * @param params.items - Items to process
+ * @param params.concurrency - Max in-flight tasks (positive integer)
+ * @param params.fn - Mapper invoked with `(item, index)`; may be sync or async
+ * @param params.signal - Optional AbortSignal to cancel pending work
+ * @returns Array of `{ status, value | reason }` in input order
+ *
+ * @example
+ * ```ts
+ * const results = await parallel({
+ *   items: urls,
+ *   concurrency: 3,
+ *   fn: async (url) => (await fetch(url)).json(),
+ * });
+ * // results[i] === { status: "fulfilled", value: ... } | { status: "rejected", reason: ... }
+ * ```
+ *
+ * @keywords concurrency limit, semaphore, worker pool, async map, throttle parallel
+ *
+ * @throws Error if validation fails or if `signal` is already aborted
+ */
+async function parallel<T, R>({
+  items,
+  concurrency,
+  fn,
+  signal,
+}: ParallelParams<T, R>): Promise<Array<ParallelSettledResult<R>>> {
+  if (!Array.isArray(items)) {
+    throw new Error("The 'items' parameter must be an array");
+  }
+
+  if (
+    typeof concurrency !== "number" ||
+    concurrency < 1 ||
+    !Number.isInteger(concurrency)
+  ) {
+    throw new Error("The 'concurrency' parameter must be a positive integer");
+  }
+
+  if (typeof fn !== "function") {
+    throw new Error("The 'fn' parameter must be a function");
+  }
+
+  if (signal !== undefined && !(signal instanceof AbortSignal)) {
+    throw new Error("The 'signal' parameter must be an AbortSignal");
+  }
+
+  if (signal?.aborted) {
+    throw signal.reason;
+  }
+
+  const results = new Array<ParallelSettledResult<R>>(items.length);
+  let next = 0;
+
+  const worker = async (): Promise<void> => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      if (signal?.aborted) {
+        results[i] = { status: "rejected", reason: signal.reason };
+        continue;
+      }
+      try {
+        const value = await fn(items[i] as T, i);
+        results[i] = { status: "fulfilled", value };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  };
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, worker));
+  return results;
+}
+
+export { parallel };

--- a/src/async/parallel/types.ts
+++ b/src/async/parallel/types.ts
@@ -1,0 +1,21 @@
+type ParallelSettledResult<R> =
+  | { status: "fulfilled"; value: R }
+  | { status: "rejected"; reason: unknown };
+
+interface ParallelParams<T, R> {
+  items: readonly T[];
+  concurrency: number;
+  fn: (item: T, index: number) => Promise<R> | R;
+  signal?: AbortSignal;
+}
+
+type ParallelResult<R> = Promise<Array<ParallelSettledResult<R>>>;
+
+type ParallelFn = <T, R>(params: ParallelParams<T, R>) => ParallelResult<R>;
+
+export type {
+  ParallelFn,
+  ParallelParams,
+  ParallelResult,
+  ParallelSettledResult,
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { unique } from "./arrays/unique/index.js";
 export { unzip } from "./arrays/unzip/index.js";
 export { zip } from "./arrays/zip/index.js";
 export { debounce } from "./async/debounce/index.js";
+export { parallel } from "./async/parallel/index.js";
 export { retry } from "./async/retry/index.js";
 export { safely } from "./async/safely/index.js";
 export { sleep } from "./async/sleep/index.js";

--- a/website/src/content/docs/async/parallel.mdx
+++ b/website/src/content/docs/async/parallel.mdx
@@ -1,0 +1,92 @@
+---
+title: parallel
+description: Run an async mapper over items with a concurrency cap
+---
+
+import Playground from "../../../components/Playground.tsx";
+
+Runs an async mapper over an array with a concurrency limit (worker-pool semaphore). Results preserve input order and follow the `Promise.allSettled` shape — `fn` errors never reject the call.
+
+## Try it
+
+<Playground client:only="react" utilityId="parallel" />
+
+## Import
+
+```ts
+import { parallel } from "1o1-utils";
+```
+
+```ts
+import { parallel } from "1o1-utils/parallel";
+```
+
+## Signature
+
+```ts
+async function parallel<T, R>({
+  items,
+  concurrency,
+  fn,
+  signal,
+}: ParallelParams<T, R>): Promise<Array<ParallelSettledResult<R>>>
+```
+
+## Parameters
+
+| Name        | Type                                       | Required | Description                                              |
+| ----------- | ------------------------------------------ | -------- | -------------------------------------------------------- |
+| items       | `readonly T[]`                             | Yes      | Items to process                                         |
+| concurrency | `number`                                   | Yes      | Max in-flight tasks (positive integer)                   |
+| fn          | `(item: T, index: number) => Promise<R> \| R` | Yes   | Mapper invoked per item; may be sync or async            |
+| signal      | `AbortSignal`                              | No       | Cancels pending work; in-flight tasks finish normally    |
+
+## Returns
+
+`Promise<Array<{ status: "fulfilled"; value: R } | { status: "rejected"; reason: unknown }>>` — entries in input order.
+
+## Examples
+
+```ts
+const results = await parallel({
+  items: urls,
+  concurrency: 3,
+  fn: async (url) => (await fetch(url)).json(),
+});
+
+for (const r of results) {
+  if (r.status === "fulfilled") console.log(r.value);
+  else console.error(r.reason);
+}
+
+// With AbortSignal
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5000);
+
+await parallel({
+  items,
+  concurrency: 5,
+  signal: controller.signal,
+  fn: doWork,
+});
+```
+
+## Edge Cases
+
+- Empty `items` resolves to `[]`.
+- `concurrency >= items.length` runs everything in parallel.
+- `concurrency: 1` runs serially.
+- Errors thrown by `fn` are captured as `{ status: "rejected", reason }` — the call itself never rejects from them.
+- Throws if `signal` is already aborted at call time.
+- Once `signal` aborts, unstarted indices resolve as rejected with `signal.reason`; in-flight tasks complete and their results are recorded.
+- Throws if `items` is not an array, `concurrency` is not a positive integer, `fn` is not a function, or `signal` is not an `AbortSignal`.
+
+## Also known as
+
+concurrency limit, semaphore, worker pool, async map, throttle parallel
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use parallel to fetch 100 URLs with a concurrency cap of 5
+```

--- a/website/src/content/examples/index.ts
+++ b/website/src/content/examples/index.ts
@@ -575,6 +575,27 @@ console.log(await retry({ fn: flaky, attempts: 5, delay: 50 }));
 `,
   },
   {
+    id: "parallel",
+    label: "parallel",
+    category: "Async",
+    code: `import { parallel } from "1o1-utils";
+
+const items = [1, 2, 3, 4, 5, 6, 7, 8];
+
+const results = await parallel({
+  items,
+  concurrency: 3,
+  fn: async (n) => {
+    await new Promise((r) => setTimeout(r, 100));
+    return n * 10;
+  },
+});
+
+console.log(results.map((r) => r.status === "fulfilled" ? r.value : r.reason));
+// [10, 20, 30, 40, 50, 60, 70, 80] — at most 3 in flight at a time
+`,
+  },
+  {
     id: "safely",
     label: "safely",
     category: "Async",


### PR DESCRIPTION
## Summary

- Add `parallel` async utility — worker-pool semaphore that runs an async mapper over items with a concurrency cap.
- Results preserve input order and follow `Promise.allSettled` shape — `fn` errors never reject the call.
- Supports `AbortSignal`: in-flight tasks finish, unstarted indices resolve as rejected with `signal.reason`.

```ts
const results = await parallel({
  items: urls,
  concurrency: 3,
  fn: async (url) => (await fetch(url)).json(),
});
```

## Benchmarks (50 items, concurrency: 5)

| Variant | Throughput med |
| ------- | -------------- |
| **1o1-utils** | 86 ops/s |
| radash | 85 ops/s (on par) |
| native `Promise.all` (unbounded) | 856 ops/s |
| native serial loop | 18 ops/s (~5× slower) |

## Size

- `parallel` standalone: 388 B (limit 1 kB)
- Total bundle: 10.16 kB (bumped limit 10 → 11 kB)

## Test plan

- [x] `pnpm build`
- [x] `pnpm test` — 16 new specs pass, 1075 total pass
- [x] `pnpm check` — biome clean
- [x] `pnpm size`
- [x] `pnpm bench parallel`

Closes #83