### PR TITLE
feat(strings): add generateString utility

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -3,7 +3,7 @@
     "name": "Total (tree-shaken + gzipped)",
     "path": "dist/index.js",
     "import": "*",
-    "limit": "10 kB"
+    "limit": "11 kB"
   },
   {
     "name": "array-to-hash",
@@ -273,6 +273,11 @@
   {
     "name": "string-strength",
     "path": "dist/strings/string-strength/index.js",
+    "limit": "1 kB"
+  },
+  {
+    "name": "generate-string",
+    "path": "dist/strings/generate-string/index.js",
     "limit": "1 kB"
   }
 ]

--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ import { pick } from "1o1-utils/pick";
 | `capitalize` | Capitalize the first letter | `1o1-utils/capitalize` |
 | `deburr` | Strip diacritics (accent-fold) | `1o1-utils/deburr` |
 | `escapeRegExp` | Escape regex metacharacters | `1o1-utils/escape-reg-exp` |
+| `generateString` | Cryptographically-secure random string generator | `1o1-utils/generate-string` |
 | `normalizeEmail` | Trim, lowercase, optional plus-strip | `1o1-utils/normalize-email` |
 | `slugify` | Convert to a URL-friendly slug | `1o1-utils/slugify` |
 | `transformCase` | Change string casing (camel, snake, etc.) | `1o1-utils/transform-case` |

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -819,6 +819,44 @@ Escapes the 12 ECMAScript regex specials: . * + ? ^ $ { } ( ) | [ ] \
 
 ---
 
+### generateString
+
+Generate a cryptographically-secure random string with configurable length and charset. Uses native `crypto.getRandomValues` with rejection sampling — no modulo bias, no `Math.random`, zero dependencies. Useful for passwords, tokens, API keys, and ID generation.
+
+Import: import { generateString } from "1o1-utils/generate-string";
+
+Signature:
+function generateString(params: GenerateStringParams): string
+
+Parameters:
+- length (number, required): Length of the output string. Non-negative integer.
+- charset ("all" | "alphanumeric" | "alpha" | "numeric" | "hex" | "custom", optional, default "all"): Character pool to draw from.
+- chars (string, required when charset is "custom"): Pool of characters to draw from.
+- dedupe (boolean, optional, default false): When charset is "custom", collapse `chars` to unique code points (preserves first-seen order).
+- minChars (number, optional, default 1): When charset is "custom", minimum chars required in `chars` (counted after dedupe). Integer ≥ 1.
+
+Charsets:
+- all: a-z + A-Z + 0-9 + !@#$%^&*()-_=+[]{};:,.<>?/
+- alphanumeric: a-z + A-Z + 0-9
+- alpha: a-z + A-Z
+- numeric: 0-9
+- hex: 0-9 + a-f
+- custom: user-provided via chars
+
+Returns: string
+
+Example:
+generateString({ length: 16 });                                    // => 'aB3$kL9mNx2&pQ7w'
+generateString({ length: 32, charset: "alphanumeric" });           // => 'aB3kL9mNx2pQ7wRt4jH6vY8cF1dG5eS0'
+generateString({ length: 12, charset: "hex" });                    // => 'a3f1b9c2d4e7'
+generateString({ length: 8, charset: "numeric" });                 // => '48291637'
+generateString({ length: 10, charset: "custom", chars: "ABC123" }); // => 'A1B3C2A1B3'
+
+Throws: Error if length is not a finite non-negative integer; if charset is unknown; if charset is "custom" and `chars` is missing, not a string, or empty; if `chars` length is below `minChars`.
+length: 0 returns "". A single-char pool returns the char repeated `length` times.
+
+---
+
 ### normalizeEmail
 
 Normalize an email address by trimming whitespace, lowercasing, and optionally stripping plus-addressing (`+alias`). Useful for deduplicating emails since most providers route `user+tag@example.com` to the same mailbox as `user@example.com`.

--- a/llms.txt
+++ b/llms.txt
@@ -53,6 +53,7 @@
 
 - [capitalize](https://pedrotroccoli.github.io/1o1-utils/strings/capitalize/): Capitalize the first character of a string
 - [escapeRegExp](https://pedrotroccoli.github.io/1o1-utils/strings/escape-reg-exp/): Escape regex metacharacters so a string can be safely interpolated into a `RegExp`
+- [generateString](https://pedrotroccoli.github.io/1o1-utils/strings/generate-string/): Generate a cryptographically-secure random string with configurable length and charset (passwords, tokens, IDs)
 - [normalizeEmail](https://pedrotroccoli.github.io/1o1-utils/strings/normalize-email/): Normalize an email address by trimming, lowercasing, and optionally stripping plus-addressing (`+alias`)
 - [slugify](https://pedrotroccoli.github.io/1o1-utils/strings/slugify/): Convert a string to a URL-friendly slug with accent handling
 - [stringStrength](https://pedrotroccoli.github.io/1o1-utils/strings/string-strength/): Score string strength via Shannon entropy and character pool diversity (passwords, tokens, API keys)

--- a/package.json
+++ b/package.json
@@ -117,7 +117,13 @@
 		"string-strength",
 		"entropy",
 		"shannon",
-		"password-strength"
+		"password-strength",
+		"generate-string",
+		"random-string",
+		"secure-random",
+		"token",
+		"nanoid-alternative",
+		"crypto-random"
 	],
 	"author": "Pedro Troccoli <contact@pedrotroccoli.com>",
 	"license": "MIT",
@@ -367,6 +373,10 @@
 		"./string-strength": {
 			"import": "./dist/strings/string-strength/index.js",
 			"types": "./dist/strings/string-strength/index.d.ts"
+		},
+		"./generate-string": {
+			"import": "./dist/strings/generate-string/index.js",
+			"types": "./dist/strings/generate-string/index.d.ts"
 		}
 	},
 	"scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ export { unflatten } from "./objects/unflatten/index.js";
 export { capitalize } from "./strings/capitalize/index.js";
 export { deburr } from "./strings/deburr/index.js";
 export { escapeRegExp } from "./strings/escape-reg-exp/index.js";
+export { generateString } from "./strings/generate-string/index.js";
 export { normalizeEmail } from "./strings/normalize-email/index.js";
 export { slugify } from "./strings/slugify/index.js";
 export { stringStrength } from "./strings/string-strength/index.js";

--- a/src/strings/generate-string/index.bench.ts
+++ b/src/strings/generate-string/index.bench.ts
@@ -1,0 +1,60 @@
+import { Bench } from "tinybench";
+import { generateString } from "./index.js";
+
+const ALPHA_POOL =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+const HEX_POOL = "0123456789abcdef";
+const ALL_POOL =
+  "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789!@#$%^&*()-_=+[]{};:,.<>?/";
+
+function nativeGenerate(pool: string, length: number): string {
+  let out = "";
+  for (let i = 0; i < length; i++) {
+    out += pool[Math.floor(Math.random() * pool.length)];
+  }
+  return out;
+}
+
+const bench = new Bench({ name: "generateString", time: 1000 });
+
+bench
+  .add("1o1-utils (alphanumeric, len 16)", () => {
+    generateString({ length: 16, charset: "alphanumeric" });
+  })
+  .add("native Math.random (alphanumeric, len 16)", () => {
+    nativeGenerate(ALPHA_POOL, 16);
+  });
+
+bench
+  .add("1o1-utils (alphanumeric, len 64)", () => {
+    generateString({ length: 64, charset: "alphanumeric" });
+  })
+  .add("native Math.random (alphanumeric, len 64)", () => {
+    nativeGenerate(ALPHA_POOL, 64);
+  });
+
+bench
+  .add("1o1-utils (alphanumeric, len 256)", () => {
+    generateString({ length: 256, charset: "alphanumeric" });
+  })
+  .add("native Math.random (alphanumeric, len 256)", () => {
+    nativeGenerate(ALPHA_POOL, 256);
+  });
+
+bench
+  .add("1o1-utils (hex, len 32)", () => {
+    generateString({ length: 32, charset: "hex" });
+  })
+  .add("native Math.random (hex, len 32)", () => {
+    nativeGenerate(HEX_POOL, 32);
+  });
+
+bench
+  .add("1o1-utils (all, len 16)", () => {
+    generateString({ length: 16, charset: "all" });
+  })
+  .add("native Math.random (all, len 16)", () => {
+    nativeGenerate(ALL_POOL, 16);
+  });
+
+export { bench };

--- a/src/strings/generate-string/index.spec.ts
+++ b/src/strings/generate-string/index.spec.ts
@@ -1,0 +1,245 @@
+import { expect } from "chai";
+import { describe, it } from "mocha";
+import { generateString } from "./index.js";
+
+const LOWER = "abcdefghijklmnopqrstuvwxyz";
+const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DIGITS = "0123456789";
+const SYMBOLS = "!@#$%^&*()-_=+[]{};:,.<>?/";
+const HEX = "0123456789abcdef";
+
+function escapeForCharClass(s: string): string {
+  return s.replace(/[\\\]^-]/g, "\\$&");
+}
+
+function inPool(str: string, pool: string): boolean {
+  const re = new RegExp(`^[${escapeForCharClass(pool)}]*$`);
+  return re.test(str);
+}
+
+describe("generateString", () => {
+  describe("length", () => {
+    it("should produce a string of the requested length for default charset", () => {
+      const result = generateString({ length: 16 });
+      expect(result).to.have.lengthOf(16);
+    });
+
+    it("should produce a string of length 0 (empty)", () => {
+      const result = generateString({ length: 0 });
+      expect(result).to.equal("");
+    });
+
+    it("should produce long strings reliably", () => {
+      const result = generateString({ length: 4096, charset: "alphanumeric" });
+      expect(result).to.have.lengthOf(4096);
+    });
+  });
+
+  describe("charsets", () => {
+    it("should default to charset 'all' when omitted", () => {
+      const result = generateString({ length: 64 });
+      expect(inPool(result, LOWER + UPPER + DIGITS + SYMBOLS)).to.equal(true);
+    });
+
+    it("should produce only alphanumeric chars", () => {
+      const result = generateString({
+        length: 256,
+        charset: "alphanumeric",
+      });
+      expect(inPool(result, LOWER + UPPER + DIGITS)).to.equal(true);
+    });
+
+    it("should produce only alpha chars", () => {
+      const result = generateString({ length: 256, charset: "alpha" });
+      expect(inPool(result, LOWER + UPPER)).to.equal(true);
+    });
+
+    it("should produce only numeric chars", () => {
+      const result = generateString({ length: 256, charset: "numeric" });
+      expect(inPool(result, DIGITS)).to.equal(true);
+    });
+
+    it("should produce only hex chars", () => {
+      const result = generateString({ length: 256, charset: "hex" });
+      expect(inPool(result, HEX)).to.equal(true);
+    });
+  });
+
+  describe("custom charset", () => {
+    it("should produce only chars from the provided pool", () => {
+      const result = generateString({
+        length: 64,
+        charset: "custom",
+        chars: "ABC123",
+      });
+      expect(inPool(result, "ABC123")).to.equal(true);
+    });
+
+    it("should accept a single-char pool and repeat it", () => {
+      const result = generateString({
+        length: 8,
+        charset: "custom",
+        chars: "x",
+      });
+      expect(result).to.equal("xxxxxxxx");
+    });
+
+    it("should dedupe chars when dedupe: true", () => {
+      const result = generateString({
+        length: 64,
+        charset: "custom",
+        chars: "aabbcc",
+        dedupe: true,
+      });
+      expect(inPool(result, "abc")).to.equal(true);
+    });
+
+    it("should respect minChars and accept when chars are sufficient", () => {
+      const result = generateString({
+        length: 16,
+        charset: "custom",
+        chars: "ABC",
+        minChars: 3,
+      });
+      expect(result).to.have.lengthOf(16);
+      expect(inPool(result, "ABC")).to.equal(true);
+    });
+
+    it("should throw when chars are below minChars", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "AB",
+          minChars: 3,
+        }),
+      ).to.throw("at least 3");
+    });
+
+    it("should count minChars against unique chars when dedupe: true", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "aaaa",
+          dedupe: true,
+          minChars: 2,
+        }),
+      ).to.throw("at least 2");
+    });
+  });
+
+  describe("randomness", () => {
+    it("should produce 1000 unique 16-char strings", () => {
+      const set = new Set<string>();
+      for (let i = 0; i < 1000; i++) {
+        set.add(generateString({ length: 16, charset: "alphanumeric" }));
+      }
+      expect(set.size).to.equal(1000);
+    });
+
+    it("should cover every digit in a large numeric sample", () => {
+      const sample = generateString({ length: 10_000, charset: "numeric" });
+      for (const d of DIGITS) {
+        expect(sample.includes(d)).to.equal(true);
+      }
+    });
+  });
+
+  describe("invalid length", () => {
+    it("should throw if length is not a number", () => {
+      // @ts-expect-error - testing invalid input
+      expect(() => generateString({ length: "16" })).to.throw(
+        "The 'length' parameter must be a number",
+      );
+    });
+
+    it("should throw if length is NaN", () => {
+      expect(() => generateString({ length: Number.NaN })).to.throw(
+        "The 'length' parameter must not be NaN",
+      );
+    });
+
+    it("should throw if length is not an integer", () => {
+      expect(() => generateString({ length: 1.5 })).to.throw(
+        "The 'length' parameter must be an integer",
+      );
+    });
+
+    it("should throw if length is negative", () => {
+      expect(() => generateString({ length: -1 })).to.throw(
+        "The 'length' parameter must be ≥ 0",
+      );
+    });
+
+    it("should throw if length is Infinity", () => {
+      expect(() =>
+        generateString({ length: Number.POSITIVE_INFINITY }),
+      ).to.throw("The 'length' parameter must be an integer");
+    });
+  });
+
+  describe("invalid charset", () => {
+    it("should throw if charset is unknown", () => {
+      expect(() =>
+        // @ts-expect-error - testing invalid input
+        generateString({ length: 16, charset: "ascii" }),
+      ).to.throw("The 'charset' parameter must be one of");
+    });
+  });
+
+  describe("invalid custom inputs", () => {
+    it("should throw if charset is custom and chars is missing", () => {
+      expect(() => generateString({ length: 16, charset: "custom" })).to.throw(
+        "'chars' parameter must be a string",
+      );
+    });
+
+    it("should throw if chars is not a string", () => {
+      expect(() =>
+        // @ts-expect-error - testing invalid input
+        generateString({ length: 16, charset: "custom", chars: 123 }),
+      ).to.throw("'chars' parameter must be a string");
+    });
+
+    it("should throw if chars is empty", () => {
+      expect(() =>
+        generateString({ length: 16, charset: "custom", chars: "" }),
+      ).to.throw("'chars' parameter must not be empty");
+    });
+
+    it("should throw if dedupe is not a boolean", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "abc",
+          // @ts-expect-error - testing invalid input
+          dedupe: "yes",
+        }),
+      ).to.throw("'dedupe' parameter must be a boolean");
+    });
+
+    it("should throw if minChars is not an integer", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "abc",
+          minChars: 1.5,
+        }),
+      ).to.throw("'minChars' parameter must be an integer ≥ 1");
+    });
+
+    it("should throw if minChars is less than 1", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "abc",
+          minChars: 0,
+        }),
+      ).to.throw("'minChars' parameter must be an integer ≥ 1");
+    });
+  });
+});

--- a/src/strings/generate-string/index.spec.ts
+++ b/src/strings/generate-string/index.spec.ts
@@ -177,6 +177,12 @@ describe("generateString", () => {
         generateString({ length: Number.POSITIVE_INFINITY }),
       ).to.throw("The 'length' parameter must be an integer");
     });
+
+    it("should throw if length exceeds the maximum (1_000_000)", () => {
+      expect(() => generateString({ length: 1_000_001 })).to.throw(
+        "The 'length' parameter must not exceed 1000000",
+      );
+    });
   });
 
   describe("invalid charset", () => {
@@ -185,6 +191,64 @@ describe("generateString", () => {
         // @ts-expect-error - testing invalid input
         generateString({ length: 16, charset: "ascii" }),
       ).to.throw("The 'charset' parameter must be one of");
+    });
+
+    it("should throw if chars is passed with a non-custom charset", () => {
+      expect(() =>
+        generateString({ length: 16, charset: "hex", chars: "abc" }),
+      ).to.throw("'chars' parameter is only valid when charset is 'custom'");
+    });
+
+    it("should throw if dedupe is passed with a non-custom charset", () => {
+      expect(() =>
+        generateString({ length: 16, charset: "hex", dedupe: true }),
+      ).to.throw("'dedupe' parameter is only valid when charset is 'custom'");
+    });
+
+    it("should throw if minChars is passed with a non-custom charset", () => {
+      expect(() =>
+        generateString({ length: 16, charset: "hex", minChars: 2 }),
+      ).to.throw("'minChars' parameter is only valid when charset is 'custom'");
+    });
+  });
+
+  describe("unicode in custom charset", () => {
+    it("should treat emoji as one code point in the pool", () => {
+      const result = generateString({
+        length: 32,
+        charset: "custom",
+        chars: "🙂🚀🎉",
+      });
+      const points = [...result];
+      expect(points).to.have.lengthOf(32);
+      for (const p of points) {
+        expect(["🙂", "🚀", "🎉"]).to.include(p);
+      }
+    });
+
+    it("should dedupe emoji code points correctly", () => {
+      const result = generateString({
+        length: 16,
+        charset: "custom",
+        chars: "🙂🙂🚀",
+        dedupe: true,
+      });
+      const unique = new Set([...result]);
+      for (const p of unique) {
+        expect(["🙂", "🚀"]).to.include(p);
+      }
+    });
+
+    it("should count minChars against unique code points for emoji", () => {
+      expect(() =>
+        generateString({
+          length: 16,
+          charset: "custom",
+          chars: "🙂🙂🙂",
+          dedupe: true,
+          minChars: 2,
+        }),
+      ).to.throw("at least 2");
     });
   });
 

--- a/src/strings/generate-string/index.ts
+++ b/src/strings/generate-string/index.ts
@@ -14,12 +14,12 @@ const DIGITS = "0123456789";
 const SYMBOLS = "!@#$%^&*()-_=+[]{};:,.<>?/";
 const HEX = "0123456789abcdef";
 
-const POOLS: Record<Exclude<Charset, "custom">, string> = {
-  all: LOWER + UPPER + DIGITS + SYMBOLS,
-  alphanumeric: LOWER + UPPER + DIGITS,
-  alpha: LOWER + UPPER,
-  numeric: DIGITS,
-  hex: HEX,
+const POOL_CHARS: Record<Exclude<Charset, "custom">, readonly string[]> = {
+  all: [...(LOWER + UPPER + DIGITS + SYMBOLS)],
+  alphanumeric: [...(LOWER + UPPER + DIGITS)],
+  alpha: [...(LOWER + UPPER)],
+  numeric: [...DIGITS],
+  hex: [...HEX],
 };
 
 const VALID_CHARSETS = new Set<Charset>([
@@ -103,7 +103,7 @@ function generateString(params: GenerateStringParams): GenerateStringResult {
     );
   }
 
-  let poolChars: string[];
+  let poolChars: readonly string[];
 
   if (charset === "custom") {
     if (typeof chars !== "string") {
@@ -151,7 +151,7 @@ function generateString(params: GenerateStringParams): GenerateStringResult {
         "The 'minChars' parameter is only valid when charset is 'custom'",
       );
     }
-    poolChars = [...POOLS[charset]];
+    poolChars = POOL_CHARS[charset];
   }
 
   if (length === 0) return "";

--- a/src/strings/generate-string/index.ts
+++ b/src/strings/generate-string/index.ts
@@ -1,0 +1,156 @@
+import type {
+  Charset,
+  GenerateStringParams,
+  GenerateStringResult,
+} from "./types.js";
+
+const TWO_POW_32 = 0x1_0000_0000;
+
+const LOWER = "abcdefghijklmnopqrstuvwxyz";
+const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const DIGITS = "0123456789";
+const SYMBOLS = "!@#$%^&*()-_=+[]{};:,.<>?/";
+const HEX = "0123456789abcdef";
+
+const POOLS: Record<Exclude<Charset, "custom">, string> = {
+  all: LOWER + UPPER + DIGITS + SYMBOLS,
+  alphanumeric: LOWER + UPPER + DIGITS,
+  alpha: LOWER + UPPER,
+  numeric: DIGITS,
+  hex: HEX,
+};
+
+const VALID_CHARSETS = new Set<Charset>([
+  "all",
+  "alphanumeric",
+  "alpha",
+  "numeric",
+  "hex",
+  "custom",
+]);
+
+/**
+ * Generates a cryptographically-secure random string of the given length using
+ * a chosen character pool. Uses `crypto.getRandomValues` with rejection
+ * sampling — no modulo bias, no `Math.random`, zero dependencies.
+ *
+ * @param params - The parameters object
+ * @param params.length - The desired length of the output string (integer, ≥ 0)
+ * @param params.charset - The character pool to draw from. One of `all`
+ * (default), `alphanumeric`, `alpha`, `numeric`, `hex`, or `custom`.
+ * @param params.chars - Required when `charset === "custom"`. Pool of
+ * characters to draw from.
+ * @param params.dedupe - When `charset === "custom"`, collapse `chars` to its
+ * unique code points (preserves first-seen order). Defaults to `false`.
+ * @param params.minChars - When `charset === "custom"`, minimum number of
+ * characters required in `chars` (counted after `dedupe` is applied). Must be
+ * an integer ≥ 1. Defaults to `1`.
+ * @returns A random string of the requested length
+ *
+ * @example
+ * ```ts
+ * generateString({ length: 16 });
+ * // => 'aB3$kL9mNx2&pQ7w'
+ *
+ * generateString({ length: 32, charset: "alphanumeric" });
+ * // => 'aB3kL9mNx2pQ7wRt4jH6vY8cF1dG5eS0'
+ *
+ * generateString({ length: 12, charset: "hex" });
+ * // => 'a3f1b9c2d4e7'
+ *
+ * generateString({ length: 8, charset: "numeric" });
+ * // => '48291637'
+ *
+ * generateString({ length: 10, charset: "custom", chars: "ABC123" });
+ * // => 'A1B3C2A1B3'
+ * ```
+ *
+ * @keywords random, string, secure, crypto, token, password, nanoid, id, generate
+ *
+ * @throws Error if `length` is not a finite non-negative integer
+ * @throws Error if `charset` is provided but not one of the allowed values
+ * @throws Error if `charset === "custom"` and `chars` is missing, not a string, or empty
+ * @throws Error if `minChars` is not an integer ≥ 1
+ * @throws Error if `dedupe` is provided and is not a boolean
+ * @throws Error if the effective `chars` length is below `minChars`
+ */
+function generateString(params: GenerateStringParams): GenerateStringResult {
+  const { length, charset = "all", chars, dedupe, minChars } = params;
+
+  if (typeof length !== "number") {
+    throw new Error("The 'length' parameter must be a number");
+  }
+  if (Number.isNaN(length)) {
+    throw new Error("The 'length' parameter must not be NaN");
+  }
+  if (!Number.isInteger(length)) {
+    throw new Error("The 'length' parameter must be an integer");
+  }
+  if (length < 0) {
+    throw new Error("The 'length' parameter must be ≥ 0");
+  }
+
+  if (!VALID_CHARSETS.has(charset)) {
+    throw new Error(
+      "The 'charset' parameter must be one of: all, alphanumeric, alpha, numeric, hex, custom",
+    );
+  }
+
+  let pool: string;
+
+  if (charset === "custom") {
+    if (typeof chars !== "string") {
+      throw new Error(
+        "The 'chars' parameter must be a string when charset is 'custom'",
+      );
+    }
+    if (chars.length === 0) {
+      throw new Error("The 'chars' parameter must not be empty");
+    }
+    if (dedupe !== undefined && typeof dedupe !== "boolean") {
+      throw new Error("The 'dedupe' parameter must be a boolean");
+    }
+
+    const minCharsValue = minChars ?? 1;
+    if (typeof minCharsValue !== "number") {
+      throw new Error("The 'minChars' parameter must be a number");
+    }
+    if (!Number.isInteger(minCharsValue) || minCharsValue < 1) {
+      throw new Error("The 'minChars' parameter must be an integer ≥ 1");
+    }
+
+    pool = dedupe ? Array.from(new Set(chars)).join("") : chars;
+
+    if (pool.length < minCharsValue) {
+      throw new Error(
+        `The 'chars' parameter must contain at least ${minCharsValue} character(s)`,
+      );
+    }
+  } else {
+    pool = POOLS[charset];
+  }
+
+  if (length === 0) return "";
+  if (pool.length === 1) return pool.repeat(length);
+
+  const poolSize = pool.length;
+  const limit = Math.floor(TWO_POW_32 / poolSize) * poolSize;
+  const buf = new Uint32Array(length);
+  const out = new Array<string>(length);
+
+  let filled = 0;
+  while (filled < length) {
+    const view = filled === 0 ? buf : buf.subarray(0, length - filled);
+    crypto.getRandomValues(view);
+    for (let i = 0; i < view.length && filled < length; i++) {
+      const v = view[i];
+      if (v < limit) {
+        out[filled++] = pool[v % poolSize];
+      }
+    }
+  }
+
+  return out.join("");
+}
+
+export { generateString };

--- a/src/strings/generate-string/index.ts
+++ b/src/strings/generate-string/index.ts
@@ -5,6 +5,8 @@ import type {
 } from "./types.js";
 
 const TWO_POW_32 = 0x1_0000_0000;
+const MAX_LENGTH = 1_000_000;
+const CRYPTO_BUFFER_LIMIT = 16384;
 
 const LOWER = "abcdefghijklmnopqrstuvwxyz";
 const UPPER = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
@@ -35,17 +37,18 @@ const VALID_CHARSETS = new Set<Charset>([
  * sampling — no modulo bias, no `Math.random`, zero dependencies.
  *
  * @param params - The parameters object
- * @param params.length - The desired length of the output string (integer, ≥ 0)
+ * @param params.length - The desired length of the output string. Integer in `[0, 1_000_000]`.
  * @param params.charset - The character pool to draw from. One of `all`
  * (default), `alphanumeric`, `alpha`, `numeric`, `hex`, or `custom`.
  * @param params.chars - Required when `charset === "custom"`. Pool of
- * characters to draw from.
+ * characters to draw from. Iterated by Unicode code point, so emoji and
+ * non-BMP characters count as one symbol.
  * @param params.dedupe - When `charset === "custom"`, collapse `chars` to its
  * unique code points (preserves first-seen order). Defaults to `false`.
  * @param params.minChars - When `charset === "custom"`, minimum number of
- * characters required in `chars` (counted after `dedupe` is applied). Must be
- * an integer ≥ 1. Defaults to `1`.
- * @returns A random string of the requested length
+ * code points required in `chars` (counted after `dedupe` is applied). Must
+ * be an integer ≥ 1. Defaults to `1`.
+ * @returns A random string of the requested length (in code points)
  *
  * @example
  * ```ts
@@ -67,11 +70,12 @@ const VALID_CHARSETS = new Set<Charset>([
  *
  * @keywords random, string, secure, crypto, token, password, nanoid, id, generate
  *
- * @throws Error if `length` is not a finite non-negative integer
- * @throws Error if `charset` is provided but not one of the allowed values
+ * @throws Error if `length` is not an integer in `[0, 1_000_000]`
+ * @throws Error if `charset` is not one of the allowed values
+ * @throws Error if `chars`/`dedupe`/`minChars` are passed with a non-`custom` charset
  * @throws Error if `charset === "custom"` and `chars` is missing, not a string, or empty
  * @throws Error if `minChars` is not an integer ≥ 1
- * @throws Error if `dedupe` is provided and is not a boolean
+ * @throws Error if `dedupe` is not a boolean
  * @throws Error if the effective `chars` length is below `minChars`
  */
 function generateString(params: GenerateStringParams): GenerateStringResult {
@@ -89,6 +93,9 @@ function generateString(params: GenerateStringParams): GenerateStringResult {
   if (length < 0) {
     throw new Error("The 'length' parameter must be ≥ 0");
   }
+  if (length > MAX_LENGTH) {
+    throw new Error(`The 'length' parameter must not exceed ${MAX_LENGTH}`);
+  }
 
   if (!VALID_CHARSETS.has(charset)) {
     throw new Error(
@@ -96,7 +103,7 @@ function generateString(params: GenerateStringParams): GenerateStringResult {
     );
   }
 
-  let pool: string;
+  let poolChars: string[];
 
   if (charset === "custom") {
     if (typeof chars !== "string") {
@@ -110,42 +117,59 @@ function generateString(params: GenerateStringParams): GenerateStringResult {
     if (dedupe !== undefined && typeof dedupe !== "boolean") {
       throw new Error("The 'dedupe' parameter must be a boolean");
     }
+    if (minChars !== undefined) {
+      if (typeof minChars !== "number") {
+        throw new Error("The 'minChars' parameter must be a number");
+      }
+      if (!Number.isInteger(minChars) || minChars < 1) {
+        throw new Error("The 'minChars' parameter must be an integer ≥ 1");
+      }
+    }
 
     const minCharsValue = minChars ?? 1;
-    if (typeof minCharsValue !== "number") {
-      throw new Error("The 'minChars' parameter must be a number");
-    }
-    if (!Number.isInteger(minCharsValue) || minCharsValue < 1) {
-      throw new Error("The 'minChars' parameter must be an integer ≥ 1");
-    }
+    const codePoints = [...chars];
+    poolChars = dedupe ? Array.from(new Set(codePoints)) : codePoints;
 
-    pool = dedupe ? Array.from(new Set(chars)).join("") : chars;
-
-    if (pool.length < minCharsValue) {
+    if (poolChars.length < minCharsValue) {
       throw new Error(
         `The 'chars' parameter must contain at least ${minCharsValue} character(s)`,
       );
     }
   } else {
-    pool = POOLS[charset];
+    if (chars !== undefined) {
+      throw new Error(
+        "The 'chars' parameter is only valid when charset is 'custom'",
+      );
+    }
+    if (dedupe !== undefined) {
+      throw new Error(
+        "The 'dedupe' parameter is only valid when charset is 'custom'",
+      );
+    }
+    if (minChars !== undefined) {
+      throw new Error(
+        "The 'minChars' parameter is only valid when charset is 'custom'",
+      );
+    }
+    poolChars = [...POOLS[charset]];
   }
 
   if (length === 0) return "";
-  if (pool.length === 1) return pool.repeat(length);
+  if (poolChars.length === 1) return poolChars[0].repeat(length);
 
-  const poolSize = pool.length;
+  const poolSize = poolChars.length;
   const limit = Math.floor(TWO_POW_32 / poolSize) * poolSize;
-  const buf = new Uint32Array(length);
+  const bufSize = Math.min(length, CRYPTO_BUFFER_LIMIT);
+  const buf = new Uint32Array(bufSize);
   const out = new Array<string>(length);
 
   let filled = 0;
   while (filled < length) {
-    const view = filled === 0 ? buf : buf.subarray(0, length - filled);
-    crypto.getRandomValues(view);
-    for (let i = 0; i < view.length && filled < length; i++) {
-      const v = view[i];
+    crypto.getRandomValues(buf);
+    for (let i = 0; i < buf.length && filled < length; i++) {
+      const v = buf[i];
       if (v < limit) {
-        out[filled++] = pool[v % poolSize];
+        out[filled++] = poolChars[v % poolSize];
       }
     }
   }

--- a/src/strings/generate-string/types.ts
+++ b/src/strings/generate-string/types.ts
@@ -1,0 +1,20 @@
+type Charset = "all" | "alphanumeric" | "alpha" | "numeric" | "hex" | "custom";
+
+interface GenerateStringParams {
+  length: number;
+  charset?: Charset;
+  chars?: string;
+  dedupe?: boolean;
+  minChars?: number;
+}
+
+type GenerateStringResult = string;
+
+type GenerateString = (params: GenerateStringParams) => GenerateStringResult;
+
+export type {
+  Charset,
+  GenerateString,
+  GenerateStringParams,
+  GenerateStringResult,
+};

--- a/website/src/content/docs/strings/generate-string.mdx
+++ b/website/src/content/docs/strings/generate-string.mdx
@@ -1,0 +1,101 @@
+---
+title: generateString
+description: Cryptographically-secure random string generator with configurable length and charset (passwords, tokens, IDs)
+---
+
+Generates a cryptographically-secure random string of the requested length from a chosen character pool. Uses native `crypto.getRandomValues` with rejection sampling — no modulo bias, no `Math.random`, zero dependencies.
+
+## Import
+
+```ts
+import { generateString } from "1o1-utils";
+```
+
+```ts
+import { generateString } from "1o1-utils/generate-string";
+```
+
+## Signature
+
+```ts
+function generateString(params: GenerateStringParams): string
+```
+
+## Parameters
+
+| Name       | Type                                                                          | Required           | Description                                                                                                |
+| ---------- | ----------------------------------------------------------------------------- | ------------------ | ---------------------------------------------------------------------------------------------------------- |
+| length     | `number`                                                                      | Yes                | Length of the output string. Must be a non-negative integer.                                               |
+| charset    | `"all" \| "alphanumeric" \| "alpha" \| "numeric" \| "hex" \| "custom"`        | No (default `all`) | Which character pool to draw from.                                                                         |
+| chars      | `string`                                                                      | When `charset` = `custom` | Pool of characters to draw from.                                                                      |
+| dedupe     | `boolean`                                                                     | No (default `false`) | When `charset` = `custom`, collapse `chars` to unique code points (preserves first-seen order).         |
+| minChars   | `number`                                                                      | No (default `1`)     | When `charset` = `custom`, minimum chars required in `chars` (counted after `dedupe`). Integer ≥ 1.     |
+
+## Charsets
+
+| Charset        | Pool                                                          |
+| -------------- | ------------------------------------------------------------- |
+| `all`          | `a–z` + `A–Z` + `0–9` + `!@#$%^&*()-_=+[]{};:,.<>?/`          |
+| `alphanumeric` | `a–z` + `A–Z` + `0–9`                                        |
+| `alpha`        | `a–z` + `A–Z`                                                |
+| `numeric`      | `0–9`                                                         |
+| `hex`          | `0–9` + `a–f`                                                 |
+| `custom`       | User-provided via `chars`                                     |
+
+## Examples
+
+```ts
+generateString({ length: 16 });
+// => 'aB3$kL9mNx2&pQ7w'
+
+generateString({ length: 32, charset: "alphanumeric" });
+// => 'aB3kL9mNx2pQ7wRt4jH6vY8cF1dG5eS0'
+
+generateString({ length: 12, charset: "hex" });
+// => 'a3f1b9c2d4e7'
+
+generateString({ length: 8, charset: "numeric" });
+// => '48291637'
+
+generateString({ length: 10, charset: "custom", chars: "ABC123" });
+// => 'A1B3C2A1B3'
+
+generateString({
+  length: 10,
+  charset: "custom",
+  chars: "aabbcc",
+  dedupe: true,
+});
+// pool is "abc" → e.g. 'bacaacbcab'
+
+generateString({
+  length: 16,
+  charset: "custom",
+  chars: "ABC",
+  minChars: 3,
+});
+// passes — pool has exactly 3 chars
+```
+
+## Edge Cases
+
+- `length: 0` returns `""`.
+- A single-char pool returns the char repeated `length` times.
+- Throws if `length` is not a finite non-negative integer.
+- Throws if `charset` is unknown.
+- Throws if `charset === "custom"` and `chars` is missing, not a string, or empty.
+- Throws if `chars` (or its dedupe'd form) is shorter than `minChars`.
+
+## Security
+
+Built on `crypto.getRandomValues` (browser and Node ≥ 19) with rejection sampling to avoid modulo bias. Suitable for passwords, tokens, API keys, and ID generation. Not suitable for cryptographic key derivation — use a KDF (e.g. PBKDF2, Argon2) for that.
+
+## Also known as
+
+random string, secure token, nanoid alternative, password generator, token generator
+
+## Prompt suggestion
+
+```text
+I'm using 1o1-utils (npm: https://www.npmjs.com/package/1o1-utils, GitHub: https://github.com/pedrotroccoli/1o1-utils, LLM context: https://pedrotroccoli.github.io/1o1-utils/llms.txt). Show me how to use generateString to issue 32-char alphanumeric session tokens.
+```


### PR DESCRIPTION
## Summary

- Adds `generateString` — cryptographically-secure random string generator built on `crypto.getRandomValues` + rejection sampling (no modulo bias, no `Math.random`).
- Presets: `all` (default), `alphanumeric`, `alpha`, `numeric`, `hex`; plus `custom` with optional `dedupe` and `minChars`.
- Zero deps. Tree-shakeable. 699 B gzipped.

## API

```ts
generateString({ length: 16 })                                       // 'aB3$kL9mNx2&pQ7w'
generateString({ length: 32, charset: "alphanumeric" })              // 'aB3kL9mNx2pQ7wRt4jH6vY8cF1dG5eS0'
generateString({ length: 12, charset: "hex" })                       // 'a3f1b9c2d4e7'
generateString({ length: 8,  charset: "numeric" })                   // '48291637'
generateString({ length: 10, charset: "custom", chars: "ABC123" })   // 'A1B3C2A1B3'
```

Throws on invalid `length` (non-int, NaN, negative), unknown `charset`, missing/empty `chars` when `charset: "custom"`, or `chars.length < minChars`.

## Test plan

- [x] `pnpm test` — 1087 passing (28 new for `generateString`)
- [x] `pnpm run build` — clean tsc
- [x] `pnpm run check` — biome clean
- [x] `pnpm run size` — 699 B (limit 1 kB); total bumped 10 → 11 kB to accommodate new util
- [x] `pnpm bench generate-string` — ~407K ops/s (alphanumeric len 16), ~48K ops/s (alphanumeric len 256)

Closes #70