### PR TITLE
refactor(internal): extract shared helpers into src/_internal

### DIFF
--- a/.changeset/extract-internal-helpers.md
+++ b/.changeset/extract-internal-helpers.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": patch
+---
+
+Extract shared internal helpers (`isPlainObject`, `UNSAFE_KEYS`, `isNumericSegment`/`isNumericSlice`, `safeAssign`) into a new internal module `src/_internal/`. Eliminates duplication across 12 object utilities (`flatten`, `unflatten`, `map-values`, `map-keys`, `defaults`, `defaults-deep`, `deep-merge`, `pick`, `pick-by`, `omit-by`, `compact`, `set`). Internal-only refactor — no public API change. The unified `isPlainObject` is a strict superset of the previous variants (now accepts both `Object.create(null)` and objects whose ancestor proto chain ends at `Object.prototype`), closing a prior inconsistency.

--- a/src/_internal/index.ts
+++ b/src/_internal/index.ts
@@ -1,0 +1,4 @@
+export { isNumericSegment, isNumericSlice } from "./is-numeric-segment.js";
+export { isPlainObject } from "./is-plain-object.js";
+export { safeAssign } from "./safe-assign.js";
+export { isUnsafeKey, UNSAFE_KEYS } from "./unsafe-keys.js";

--- a/src/_internal/is-numeric-segment.ts
+++ b/src/_internal/is-numeric-segment.ts
@@ -1,0 +1,22 @@
+const MAX_NUMERIC_SEGMENT_LEN = 7;
+
+function isNumericSegment(seg: string): boolean {
+  if (seg.length === 0) return false;
+  for (let i = 0; i < seg.length; i++) {
+    const c = seg.charCodeAt(i);
+    if (c < 48 || c > 57) return false;
+  }
+  return true;
+}
+
+function isNumericSlice(str: string, start: number, end: number): boolean {
+  const span = end - start;
+  if (span <= 0 || span > MAX_NUMERIC_SEGMENT_LEN) return false;
+  for (let i = start; i < end; i++) {
+    const c = str.charCodeAt(i);
+    if (c < 48 || c > 57) return false;
+  }
+  return true;
+}
+
+export { isNumericSegment, isNumericSlice };

--- a/src/_internal/is-plain-object.ts
+++ b/src/_internal/is-plain-object.ts
@@ -1,0 +1,8 @@
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null) return false;
+  const proto = Object.getPrototypeOf(value);
+  if (proto === null || proto === Object.prototype) return true;
+  return (value as { constructor?: unknown }).constructor === Object;
+}
+
+export { isPlainObject };

--- a/src/_internal/safe-assign.ts
+++ b/src/_internal/safe-assign.ts
@@ -1,0 +1,14 @@
+function safeAssign(
+  tgt: Record<string, unknown>,
+  key: string,
+  value: unknown,
+): void {
+  Object.defineProperty(tgt, key, {
+    value,
+    writable: true,
+    enumerable: true,
+    configurable: true,
+  });
+}
+
+export { safeAssign };

--- a/src/_internal/unsafe-keys.ts
+++ b/src/_internal/unsafe-keys.ts
@@ -1,0 +1,7 @@
+const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function isUnsafeKey(key: string): boolean {
+  return UNSAFE_KEYS.has(key);
+}
+
+export { isUnsafeKey, UNSAFE_KEYS };

--- a/src/objects/compact/index.ts
+++ b/src/objects/compact/index.ts
@@ -1,6 +1,5 @@
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { CompactParams } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 /**
  * Creates a new object with all falsy values removed.

--- a/src/objects/deep-merge/index.ts
+++ b/src/objects/deep-merge/index.ts
@@ -1,10 +1,5 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
 import type { DeepMergeParams, DeepMergeResult } from "./types.js";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && value.constructor === Object
-  );
-}
 
 /**
  * Recursively merges a source object into a target object.

--- a/src/objects/defaults-deep/index.ts
+++ b/src/objects/defaults-deep/index.ts
@@ -1,10 +1,5 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
 import type { DefaultsDeepParams, DefaultsDeepResult } from "./types.js";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && value.constructor === Object
-  );
-}
 
 /**
  * Recursively assigns default values from `source` to `target`. For each

--- a/src/objects/defaults/index.ts
+++ b/src/objects/defaults/index.ts
@@ -1,10 +1,5 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
 import type { DefaultsParams, DefaultsResult } from "./types.js";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && value.constructor === Object
-  );
-}
 
 /**
  * Assigns default values from `source` to `target` for properties that are

--- a/src/objects/flatten/index.ts
+++ b/src/objects/flatten/index.ts
@@ -1,16 +1,10 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type {
   FlattenArrayParams,
   FlattenObjectParams,
   FlattenParams,
 } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === null || proto === Object.prototype;
-}
 
 function flattenObject(obj: Record<string, unknown>): Record<string, unknown> {
   const result: Record<string, unknown> = {};

--- a/src/objects/map-keys/index.ts
+++ b/src/objects/map-keys/index.ts
@@ -1,12 +1,6 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { MapKeysParams, MapKeysResult } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && value.constructor === Object
-  );
-}
 
 /**
  * Creates a new object with the same values as `obj`, but with each key

--- a/src/objects/map-values/index.ts
+++ b/src/objects/map-values/index.ts
@@ -1,10 +1,5 @@
+import { isPlainObject } from "../../_internal/is-plain-object.js";
 import type { MapValuesParams, MapValuesResult } from "./types.js";
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  return (
-    typeof value === "object" && value !== null && value.constructor === Object
-  );
-}
 
 /**
  * Creates a new object with the same keys as `obj`, but with each value

--- a/src/objects/omit-by/index.ts
+++ b/src/objects/omit-by/index.ts
@@ -1,6 +1,5 @@
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { OmitByParams } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 /**
  * Creates an object excluding entries for which the predicate returns truthy.

--- a/src/objects/pick-by/index.ts
+++ b/src/objects/pick-by/index.ts
@@ -1,6 +1,5 @@
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { PickByParams } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
 
 /**
  * Creates an object with only the entries for which the predicate returns truthy.

--- a/src/objects/pick/index.ts
+++ b/src/objects/pick/index.ts
@@ -1,19 +1,6 @@
+import { safeAssign } from "../../_internal/safe-assign.js";
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { PickParams } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-
-function safeAssign(
-  tgt: Record<string, unknown>,
-  key: string,
-  value: unknown,
-): void {
-  Object.defineProperty(tgt, key, {
-    value,
-    writable: true,
-    enumerable: true,
-    configurable: true,
-  });
-}
 
 function pickNested(
   source: Record<string, unknown>,

--- a/src/objects/set/index.ts
+++ b/src/objects/set/index.ts
@@ -1,13 +1,5 @@
+import { isNumericSegment } from "../../_internal/is-numeric-segment.js";
 import type { SetParams } from "./types.js";
-
-function isNumericSegment(seg: string): boolean {
-  if (seg.length === 0) return false;
-  for (let i = 0; i < seg.length; i++) {
-    const c = seg.charCodeAt(i);
-    if (c < 48 || c > 57) return false;
-  }
-  return true;
-}
 
 /**
  * Sets a nested value on an object using dot-notation path.

--- a/src/objects/unflatten/index.ts
+++ b/src/objects/unflatten/index.ts
@@ -1,23 +1,7 @@
+import { isNumericSlice } from "../../_internal/is-numeric-segment.js";
+import { isPlainObject } from "../../_internal/is-plain-object.js";
+import { UNSAFE_KEYS } from "../../_internal/unsafe-keys.js";
 import type { UnflattenParams } from "./types.js";
-
-const UNSAFE_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-const MAX_NUMERIC_SEGMENT_LEN = 7;
-
-function isPlainObject(value: unknown): value is Record<string, unknown> {
-  if (typeof value !== "object" || value === null) return false;
-  const proto = Object.getPrototypeOf(value);
-  return proto === null || proto === Object.prototype;
-}
-
-function isSafeNumericSlice(str: string, start: number, end: number): boolean {
-  const span = end - start;
-  if (span <= 0 || span > MAX_NUMERIC_SEGMENT_LEN) return false;
-  for (let i = start; i < end; i++) {
-    const c = str.charCodeAt(i);
-    if (c < 48 || c > 57) return false;
-  }
-  return true;
-}
 
 /**
  * Builds a nested object from a flat record of dot-notation keys. Inverse of
@@ -104,7 +88,7 @@ function unflatten({
         current[seg] = container;
       } else {
         container = (
-          arrays && isSafeNumericSlice(fullKey, nextStart, nextEnd) ? [] : {}
+          arrays && isNumericSlice(fullKey, nextStart, nextEnd) ? [] : {}
         ) as Record<string, unknown>;
         internal.add(container);
         current[seg] = container;


### PR DESCRIPTION
## Summary

Closes #162.

Consolidates duplicated helpers (`isPlainObject`, `UNSAFE_KEYS`, `safeAssign`, `isNumericSegment`/`isNumericSlice`) into a new internal-only module `src/_internal/`. 12 object utilities updated to import from there instead of carrying private copies.

- `_internal/is-plain-object.ts` — unified check accepts both `Object.create(null)` AND objects whose prototype chain ultimately resolves to `Object.prototype`. Strict superset of the previous per-file variants, closes the inconsistency the issue called out.
- `_internal/unsafe-keys.ts` — `UNSAFE_KEYS` Set + `isUnsafeKey(key)`.
- `_internal/is-numeric-segment.ts` — `isNumericSegment(seg)` (used by `set`) + `isNumericSlice(str, start, end)` with the 7-digit cap for DoS protection (used by `unflatten`).
- `_internal/safe-assign.ts` — `Object.defineProperty` wrapper (currently only used by `pick`; kept exported for future use).
- `_internal/index.ts` — barrel for internal use.

`_internal` is intentionally **not** added to `package.json` `exports`.

## Migrated files

`flatten`, `unflatten`, `map-values`, `map-keys`, `defaults`, `defaults-deep`, `deep-merge`, `pick`, `pick-by`, `omit-by`, `compact`, `set`.

## Verification

- `pnpm check` — green (2 pre-existing `noNonNullAssertion` warnings, unrelated).
- `pnpm test` — 1162 passing.
- `pnpm build` — green.
- `pnpm size` — every per-utility budget still passes. Tight ones: `flatten` 444 B / 1 kB, `unflatten` 542 B / 1 kB. Total bundle 11.12 kB / 12 kB.
- Public API surface unchanged.

## Notes

- Benchmarks not regenerated — refactor is pure code motion; algorithms unchanged. If the regen is required, run `pnpm bench --md`.
- Changeset added as `patch` (internal refactor, no public API change).

## Test plan

- [x] `pnpm check`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] `pnpm size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)