### PR TITLE
docs: correct outdated bundle-size, util count, and API examples

### DIFF
--- a/.size-limit.json
+++ b/.size-limit.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "Total (tree-shaken + gzipped)",
+    "name": "Total (tree-shaken + brotli)",
     "path": "dist/index.js",
     "import": "*",
     "limit": "12 kB"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Project Overview
 
-1o1-utils is a lightweight, tree-shakeable TypeScript utility library with zero dependencies. Each utility is independently importable. The library must stay under 5 kB gzipped total, with individual utilities at 1-2 kB.
+1o1-utils is a lightweight, tree-shakeable TypeScript utility library with zero dependencies. Each utility is independently importable. The full library must stay under the 12 kB total limit (currently ~11.6 kB brotli, enforced in `.size-limit.json`), with individual utilities at 1-2 kB.
 
 ## Commands
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -298,7 +298,7 @@ Cover happy paths, edge cases, and error cases.
 
 ## Bundle Size
 
-Each utility must stay under its size limit (1-2 kB gzipped). Run `pnpm size` to verify. The total library limit is 5 kB.
+Each utility must stay under its size limit (1-2 kB brotli). Run `pnpm size` to verify. The total library limit is 12 kB.
 
 ## Pull Request Checklist
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 - **Tree-shakeable** — every utility ships from its own subpath; bundlers drop everything you don't import.
 - **Zero dependencies** — no transitive bloat, no supply-chain risk.
 - **TypeScript-first** — full type inference and strict null safety out of the box.
-- **Tiny per-utility footprint** — most utilities are **150–500 B brotlied**; the largest is ~1.2 kB.
+- **Tiny per-utility footprint** — most utilities are **under 500 B brotlied**; the largest is ~1.2 kB.
 - **Benchmarked** — measured against lodash, radash, es-toolkit, and native JavaScript — up to 11× faster on the slowest competitor.
 - **Interactive playground** — every utility has a "Try it" block on its docs page that runs `1o1-utils` directly from npm.
 
@@ -172,12 +172,12 @@ Run `pnpm size` to see per-utility brotli sizes locally. Sample from the latest 
 | `isNil` | 36 B |
 | `clamp` | 150 B |
 | `chunk` | 199 B |
-| `deepEqual` | 590 B |
+| `deepEqual` | 739 B |
 | `bindKey` | 1.05 kB |
 | `isValidPhone` | 1.19 kB |
-| **Whole library (all utilities)** | **~9.2 kB brotli / ~11 kB gzipped** |
+| **Whole library (all utilities)** | **~11.6 kB brotli / ~13 kB gzipped** |
 
-Tree-shaking removes everything you don't import — typical real-world bundles add a few hundred bytes per utility, not the whole 9 kB.
+Tree-shaking removes everything you don't import — typical real-world bundles add a few hundred bytes per utility, not the whole 13 kB.
 
 ## Benchmarks
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "1o1-utils",
 	"version": "1.10.0",
-	"description": "Fast, tree-shakeable, zero-dependency TypeScript utility library. Most utilities under 1 kB gzipped; full bundle ~10 kB. Fully typed, benchmarked for performance.",
+	"description": "Fast, tree-shakeable, zero-dependency TypeScript utility library. Most utilities under 500 B gzipped; full bundle ~13 kB gzipped. Fully typed, benchmarked for performance.",
 	"keywords": [
 		"utility",
 		"utilities",

--- a/website/src/content/docs/compare/vs-es-toolkit.mdx
+++ b/website/src/content/docs/compare/vs-es-toolkit.mdx
@@ -9,12 +9,12 @@ description: Comparing 1o1-utils and es-toolkit — modern TypeScript utility li
 
 | | 1o1-utils | es-toolkit |
 |---|---|---|
-| Bundle size (gzip) | **~2 kB total** | ~6 kB |
+| Bundle size (gzip) | **~13 kB full / from ~80 B per utility** | ~6 kB |
 | Dependencies | 0 | 0 |
 | TypeScript | Native, strict | Native |
 | Tree-shaking | Full | Full |
 | Named parameters | **Yes** | No (lodash-style positional) |
-| Scope | 18 focused utilities | 200+ utilities |
+| Scope | 59 focused utilities | 200+ utilities |
 | Maintained by | Pedro Troccoli | Toss (fintech) |
 
 ## API equivalence
@@ -33,8 +33,8 @@ description: Comparing 1o1-utils and es-toolkit — modern TypeScript utility li
 | `pick(obj, keys)` | `pick({ obj, keys })` | |
 | `capitalize(str)` | `capitalize({ str })` | |
 | `camelCase` / `snakeCase` / `kebabCase` | `transformCase({ str, to })` | One function |
-| `debounce(fn, ms)` | `debounce({ fn, wait })` | |
-| `throttle(fn, ms)` | `throttle({ fn, wait })` | |
+| `debounce(fn, ms)` | `debounce({ fn, ms })` | |
+| `throttle(fn, ms)` | `throttle({ fn, ms })` | |
 
 ## Side by side
 
@@ -58,7 +58,7 @@ import { debounce } from "1o1-utils/debounce";
 const pages = chunk({ array: items, size: 10 });
 const byId = arrayToHash({ array: users, key: "id" });
 const picked = pick({ obj: user, keys: ["id", "name"] });
-const search = debounce({ fn, wait: 300 });
+const search = debounce({ fn, ms: 300 });
 ```
 
 ## When should you choose es-toolkit?
@@ -70,11 +70,11 @@ const search = debounce({ fn, wait: 300 });
 
 ## When should you choose 1o1-utils?
 
-- **3× smaller bundle** (2 kB vs 6 kB)
+- **Pay-per-import** — each utility tree-shakes from its own subpath, from ~80 B gzipped, so you only ship what you call
 - **Named parameters** — self-documenting call sites, no signature guessing
 - **Benchmarked in CI** with strict size limits
-- Focused on **the 18 utilities 90% of apps actually use** — no bloat
-- You want per-utility imports with predictable tiny sizes (`1o1-utils/chunk` → 199 B)
+- **Zero dependencies** — nothing transitive, no supply-chain surface
+- You want per-utility imports with predictable tiny sizes (`1o1-utils/chunk` → 253 B gzipped)
 
 ## FAQ
 

--- a/website/src/content/docs/compare/vs-just.mdx
+++ b/website/src/content/docs/compare/vs-just.mdx
@@ -9,7 +9,7 @@ description: Comparing 1o1-utils and just — both micro-module utility librarie
 
 | | 1o1-utils | just |
 |---|---|---|
-| Bundle size | ~2 kB total (gzip), 139–366 B per util | similar per-function sizes |
+| Bundle size | ~13 kB full (gzip), from ~80 B per util | similar per-function sizes |
 | Dependencies | 0 | 0 per package |
 | TypeScript | **Native, strict, full inference** | `.d.ts` files, less strict |
 | Distribution | **Single package, tree-shakeable** | Dozens of separate packages |
@@ -51,8 +51,8 @@ import { debounce } from "1o1-utils/debounce";
 | `just-capitalize` | `capitalize({ str })` | |
 | `just-truncate` | `truncate({ str, length, suffix })` | |
 | `just-camel-case` / `just-kebab-case` | `transformCase({ str, to })` | One function |
-| `just-debounce-it` | `debounce({ fn, wait })` | |
-| `just-throttle` | `throttle({ fn, wait })` | |
+| `just-debounce-it` | `debounce({ fn, ms })` | |
+| `just-throttle` | `throttle({ fn, ms })` | |
 
 ## Side by side
 
@@ -75,7 +75,7 @@ import { debounce } from "1o1-utils/debounce";
 
 const pages = chunk({ array: items, size: 10 });
 const picked = pick({ obj: user, keys: ["id", "name"] });
-const search = debounce({ fn, wait: 300 });
+const search = debounce({ fn, ms: 300 });
 ```
 
 ## When should you still use just?

--- a/website/src/content/docs/compare/vs-lodash.mdx
+++ b/website/src/content/docs/compare/vs-lodash.mdx
@@ -9,7 +9,7 @@ Looking for a **lodash alternative** that's dramatically smaller, faster, and fu
 
 | | 1o1-utils | lodash |
 |---|---|---|
-| Bundle size (gzip) | **~2 kB total** | ~24 kB (full), 70 kB unminified |
+| Bundle size (gzip) | **~13 kB full / from ~80 B per utility** | ~24 kB (full) |
 | Dependencies | **0** | 0 (runtime) |
 | TypeScript | **Native, strict** | `@types/lodash` required |
 | Tree-shaking | **Full** | Partial (needs `lodash-es`) |
@@ -48,8 +48,8 @@ Benchmarks run on the same machine, same dataset. Full methodology on the [Bench
 | `_.capitalize(str)` | `capitalize({ str })` | |
 | `_.truncate(str, opts)` | `truncate({ str, length, suffix })` | Flat params |
 | `_.camelCase` / `_.snakeCase` / `_.kebabCase` | `transformCase({ str, to })` | One function |
-| `_.debounce(fn, ms)` | `debounce({ fn, wait })` | |
-| `_.throttle(fn, ms)` | `throttle({ fn, wait })` | |
+| `_.debounce(fn, ms)` | `debounce({ fn, ms })` | |
+| `_.throttle(fn, ms)` | `throttle({ fn, ms })` | |
 
 ## Side by side
 
@@ -78,14 +78,14 @@ const merged = deepMerge({ target: defaults, source: overrides });
 
 ## When should you still use lodash?
 
-1o1-utils covers **18 commonly-used utilities**. Lodash has 200+. Stick with lodash if you need:
+1o1-utils covers **59 commonly-used utilities**. Lodash has 200+. Stick with lodash if you need:
 - Collection helpers like `_.flow`, `_.memoize`, `_.curry`, `_.partial`
 - Function composition / FP suite (`lodash/fp`)
 - Deep-string path accessors (`_.get(obj, "a.b.c")`)
 - Number utilities (`_.random`, `_.clamp`)
 - Legacy ES5 environments
 
-If you only use lodash for chunk, groupBy, pick, omit, debounce — you're carrying 24 kB for 2 kB of value. Switch.
+If you only use lodash for chunk, groupBy, pick, omit, debounce, those five tree-shake to roughly 1.5 kB gzipped with 1o1-utils — instead of dragging in a 24 kB dependency. Switch.
 
 ## Migration checklist
 

--- a/website/src/content/docs/compare/vs-radash.mdx
+++ b/website/src/content/docs/compare/vs-radash.mdx
@@ -9,12 +9,12 @@ Both [radash](https://github.com/sodiray/radash) and 1o1-utils are **modern, Typ
 
 | | 1o1-utils | radash |
 |---|---|---|
-| Bundle size (gzip) | **~2 kB total** | ~12 kB |
+| Bundle size (gzip) | **~13 kB full / from ~80 B per utility** | ~12 kB |
 | Dependencies | 0 | 0 |
 | TypeScript | Native, strict | Native |
 | Tree-shaking | Full | Full |
 | Named parameters | **Yes** | No (positional) |
-| Scope | 18 focused utilities | 90+ utilities |
+| Scope | 59 focused utilities | 90+ utilities |
 | Benchmarks in CI | **Yes** | No |
 
 ## Performance
@@ -47,8 +47,8 @@ Full methodology on the [Benchmarks page](/1o1-utils/benchmarks/).
 | `set(obj, path, val)` | `set({ obj, path, value })` | Immutable |
 | `capitalize(str)` | `capitalize({ str })` | |
 | `camel` / `snake` / `dash` | `transformCase({ str, to })` | One function |
-| `debounce({ delay }, fn)` | `debounce({ fn, wait })` | |
-| `throttle({ interval }, fn)` | `throttle({ fn, wait })` | |
+| `debounce({ delay }, fn)` | `debounce({ fn, ms })` | |
+| `throttle({ interval }, fn)` | `throttle({ fn, ms })` | |
 | `retry({ times }, fn)` | `retry({ fn, attempts })` | |
 | `sleep(ms)` | `sleep({ ms })` | |
 
@@ -79,17 +79,17 @@ const uniqueUsers = unique({ array: users, key: "id" });
 
 ## When should you choose radash?
 
-- You want **broader coverage** — radash has ~90 utilities vs 18 in 1o1-utils
+- You want **broader coverage** — radash has ~90 utilities vs 59 in 1o1-utils
 - You need FP-flavored helpers (`flat`, `iterate`, `chain`, `series`, `parallel`, `tryit`)
 - You prefer positional args and already know the radash API
 
 ## When should you choose 1o1-utils?
 
-- **Smaller bundle** — 2 kB vs 12 kB (6× smaller)
+- **Pay-per-import** — every utility tree-shakes from its own subpath, so you ship from ~80 B per utility, not a whole bundle
 - **Benchmarked in CI** — every utility has size-limit + performance guards
 - **Named parameters** — code reads like English, no need to check signatures
-- **Focused scope** — 18 utilities you actually use, no bloat
-- You want **individual imports** (`1o1-utils/chunk` → 199 B) without bundler magic
+- **Zero dependencies** — nothing transitive, no supply-chain surface
+- You want **individual imports** (`1o1-utils/chunk` → 253 B gzipped) without bundler magic
 
 ## FAQ
 

--- a/website/src/content/docs/contributing.mdx
+++ b/website/src/content/docs/contributing.mdx
@@ -288,7 +288,7 @@ Run `pnpm check:fix` before committing.
 
 ## Bundle size
 
-Each utility must stay under its size limit (1-2 kB gzipped). The total library limit is 5 kB gzipped. Run `pnpm size` to verify.
+Each utility must stay under its size limit (1-2 kB brotli). The total library limit is 12 kB. Run `pnpm size` to verify.
 
 ## Pull request checklist
 

--- a/website/src/content/docs/why-1o1-utils.mdx
+++ b/website/src/content/docs/why-1o1-utils.mdx
@@ -10,7 +10,7 @@ import { Card, CardGrid } from "@astrojs/starlight/components";
     Pure TypeScript. No transitive dependencies. No supply chain risk.
   </Card>
   <Card title="Ultra lightweight" icon="seti:json">
-    2.1 kB total gzipped. Individual utilities weigh 139–366 bytes.
+    ~13 kB gzipped for the entire library. Most individual utilities weigh under 500 bytes.
   </Card>
   <Card title="Ultra simple" icon="pencil">
     Named object params. One function, one job. No config, no magic.
@@ -37,38 +37,80 @@ No transitive dependencies means no supply chain risk, no version conflicts, no 
 
 ## Ultra lightweight
 
-The **entire library** is **2.1 kB gzipped**. For comparison, lodash is 70 kB and radash is 12 kB.
-
-Each utility is a self-contained module you can import individually:
+The **entire library** — all 59 utilities, tree-shaken — is **~13 kB gzipped**. For comparison, lodash is ~24 kB and radash is ~12 kB. But you rarely ship the whole thing: each utility is a self-contained module you import individually, and tree-shaking drops the rest.
 
 ```ts
-import { chunk } from "1o1-utils/chunk";   // 199 B
-import { pick } from "1o1-utils/pick";     // 320 B
-import { sleep } from "1o1-utils/sleep";   // 139 B
+import { chunk } from "1o1-utils/chunk";   // 253 B
+import { pick } from "1o1-utils/pick";     // 498 B
+import { sleep } from "1o1-utils/sleep";   // 176 B
 ```
 
 ### Bundle sizes (gzipped)
 
+Per-utility gzipped size for all 59 utilities. The **Total** is the whole tree-shaken library, not the sum of the rows — shared internals are counted once.
+
 | Utility | Size |
 |---------|------|
-| sleep | 139 B |
-| slugify | 147 B |
-| isEmpty | 164 B |
-| capitalize | 169 B |
-| truncate | 170 B |
-| arrayToHash | 173 B |
-| unique | 173 B |
-| groupBy | 180 B |
-| debounce | 198 B |
-| chunk | 199 B |
-| deepMerge | 248 B |
-| throttle | 258 B |
-| pick | 320 B |
-| retry | 321 B |
-| transformCase | 330 B |
-| sortBy | 350 B |
-| omit | 366 B |
-| **Total** | **2.1 kB** |
+| isNil | 77 B |
+| once | 169 B |
+| escapeRegExp | 170 B |
+| sleep | 176 B |
+| get | 189 B |
+| clamp | 195 B |
+| capitalize | 210 B |
+| isEmpty | 212 B |
+| truncate | 214 B |
+| arrayToHash | 215 B |
+| pipe | 217 B |
+| shuffle | 217 B |
+| slugify | 218 B |
+| unique | 219 B |
+| safely | 220 B |
+| partition | 221 B |
+| groupBy | 222 B |
+| times | 235 B |
+| debounce | 249 B |
+| chunk | 253 B |
+| mapValues | 255 B |
+| range | 261 B |
+| defaults | 271 B |
+| secondsToTimeFormat | 272 B |
+| isValidUrl | 280 B |
+| replace | 283 B |
+| diff | 288 B |
+| mapKeys | 302 B |
+| throttle | 309 B |
+| deepMerge | 310 B |
+| zip | 316 B |
+| unzip | 318 B |
+| defaultsDeep | 322 B |
+| isValidEmail | 326 B |
+| isMobile | 329 B |
+| compact | 336 B |
+| timeFormatToSeconds | 343 B |
+| shallowEqual | 352 B |
+| retry | 379 B |
+| sortBy | 423 B |
+| isCircular | 428 B |
+| omit | 432 B |
+| set | 437 B |
+| randomInt | 445 B |
+| parallel | 449 B |
+| withTimeout | 475 B |
+| pick | 498 B |
+| flatten | 512 B |
+| stringStrength | 521 B |
+| unflatten | 582 B |
+| waitForCondition | 588 B |
+| toNumber | 604 B |
+| cloneDeep | 611 B |
+| copyToClipboard | 615 B |
+| transformCase | 649 B |
+| deepEqual | 821 B |
+| generateString | 869 B |
+| bindKey | 1.21 kB |
+| isValidPhone | 1.55 kB |
+| **Whole library (tree-shaken)** | **~13 kB** |
 
 Every utility stays under strict size limits enforced in CI. If a PR makes a utility heavier, the build fails.
 
@@ -111,7 +153,7 @@ _.get(obj, "a.b.c");
 // What does this do? Read it out loud.
 arrayToHash({ array: users, key: "id" });
 unique({ array: items, key: "sku" });
-pick({ obj, keys: ["a.b.c"] });
+get({ obj, path: "a.b.c" });
 ```
 
 Names follow plain English — `arrayToHash`, not `keyBy`. `unique`, not `uniqBy`. `deepMerge`, not `merge` (which might or might not be deep). `isEmpty`, not `empty` (is it a verb or an adjective?).


### PR DESCRIPTION
## Context
Docs claimed sizes that no longer hold — the library grew to **59 utilities**. The worst offender said "2.1 kB total gzipped" (counted only 17 of 59). README/package.json had also drifted, and compression labels were inconsistent (`size-limit` reports **brotli** but config/docs said "gzipped"). While auditing, two API-example bugs surfaced too.

## Ground truth (measured)
- Full library, tree-shaken, all 59 utils: **~13.2 kB gzip / ~11.6 kB brotli** (`size-limit` total 11.61 kB < 12 kB limit).
- Per-utility: 36 B – 1.55 kB.

## Changes
**Size / count corrections**
- Full-library size → ~13 kB gzip / ~11.6 kB brotli everywhere (README, package.json, why-page).
- Regenerated the why-page bundle table with all 59 utilities (gzip).
- Utility count 18 → 59 in compare pages.
- Total size limit aligned to 12 kB in AGENTS.md / CONTRIBUTING.md (was 5 kB).
- `.size-limit.json` total relabeled "brotli" (matches what `size-limit` measures).

**Messaging**
- Dropped false "smaller bundle" / "6× smaller" / "3× smaller" claims vs radash & es-toolkit (their full bundles are comparable/smaller). Pivoted those pages to per-util tree-shaking + zero-dep + benchmarks.

**API example bugs**
- `debounce`/`throttle` param `wait` → `ms` (real signature) across all compare pages.
- why-page: `_.get(obj, "a.b.c")` was mapped to `pick({ obj, keys })` (wrong util) → fixed to `get({ obj, path })`.

## Verification
- `pnpm build && pnpm size` — total 11.61 kB brotli, all pass.
- Website `pnpm build` — 142 pages, clean.
- Benchmarks audited against `docs/benchmarks/` — all claims accurate, no changes needed.