### PR TITLE
fix(pkg): add main and module entry fields

### DIFF
--- a/.changeset/fix-sandpack-module-resolution.md
+++ b/.changeset/fix-sandpack-module-resolution.md
@@ -1,0 +1,5 @@
+---
+"1o1-utils": patch
+---
+
+Add top-level `main` and `module` fields pointing to `./dist/index.js`. Bundlers without full `exports`-field support (e.g. Sandpack/CodeSandbox, used by the docs Playground) fell back to a missing `main` and threw `ModuleNotFoundError: null`. The `exports` map is unchanged; these fields only re-expose the existing ESM entry via the legacy keys.

--- a/package.json
+++ b/package.json
@@ -149,6 +149,8 @@
 		"url": "https://github.com/pedrotroccoli/1o1-utils/issues"
 	},
 	"type": "module",
+	"main": "./dist/index.js",
+	"module": "./dist/index.js",
 	"types": "dist/index.d.ts",
 	"sideEffects": false,
 	"files": [


### PR DESCRIPTION
## Problem

Docs site interactive Playground (TryIt, Sandpack/CodeSandbox) throws `ModuleNotFoundError: null` on every example. All examples import bare `from "1o1-utils"`; Sandpack loads the package from npm.

Root cause: `package.json` declares an `exports` map (`.` entry has only `import` + `types`) but **no top-level `main` or `module`**. Sandpack's legacy bundler has weak `exports`-field support and falls back to `main`, which is `undefined` → resolves to `null` → `ModuleNotFoundError: null`.

## Fix

Add top-level `main` + `module` pointing to the existing ESM entry `./dist/index.js`. The `exports` map is unchanged; these keys just re-expose the same entry for bundlers that don't fully honor `exports`. Also improves compat with older tooling.

## Release

Patch changeset included → publishes `1.10.1`. The Playground pins its Sandpack dependency to the root `package.json` version, so it picks up the fix automatically after publish.

## Verification

Not testable locally: Sandpack resolves the dependency from the npm tarball (no local-fs, no URL imports), so the fix is only observable once `1.10.1` is on npm. After publish, open a docs Playground (e.g. `diff`, `retry`, and a Browser one like `isMobile`) and confirm the console/preview runs with no `ModuleNotFoundError`.